### PR TITLE
fix: update generation prompts to prevent SEO cannibalization

### DIFF
--- a/docs-generation/HorizontalArticleGenerator/prompts/horizontal-article-system-prompt.txt
+++ b/docs-generation/HorizontalArticleGenerator/prompts/horizontal-article-system-prompt.txt
@@ -52,6 +52,16 @@ Generate a JSON object with the following structure. All fields prefixed with "g
 }
 ```
 
+## SEO Differentiation Rules (CRITICAL)
+
+These articles document Azure MCP Server tools for working with Azure services, NOT the Azure services themselves. The content must complement official Azure service documentation, never compete with it in search results.
+
+- **Article framing**: The template title uses "Azure MCP Server tools for {ServiceBrandName}" — all generated content must align with this MCP-first positioning
+- **genai-serviceShortDescription**: Must describe what MCP tools let you manage (concrete nouns), not what the Azure service is. This is about MCP tool capabilities, not Azure service marketing
+- **genai-serviceOverview**: Describe the Azure service briefly for context, but do NOT write content that would replace or duplicate the official Azure service overview page
+- **genai-capabilities**: Frame as "what you can do with Azure MCP Server tools" — not "what the Azure service can do"
+- **Keywords in generated content**: Focus on MCP-specific terms and tool operations. Do NOT optimize for generic Azure service search queries (e.g., avoid framing content around "cognitive search", "NoSQL database", "serverless compute" as primary topics — those belong to official Azure service docs)
+
 ## Content Generation Guidelines
 
 **IMPORTANT**: Search for and use published Azure documentation as your primary authoritative source. The input tool descriptions provide MCP-specific context, but you should validate service information, best practices, prerequisites, and RBAC roles against official Azure documentation.
@@ -310,3 +320,5 @@ Before generating content, carefully analyze each tool to determine if it operat
 - [ ] Uses "might" instead of "may" throughout
 - [ ] Uses Oxford commas in lists of three or more items
 - [ ] genai-aiSpecificScenarios, genai-authenticationNotes, and genai-commonIssues are NOT included in the output
+- [ ] SEO: genai-serviceShortDescription does NOT contain generic Azure service marketing terms — it describes MCP tool operations only
+- [ ] SEO: No generated content positions the article as a replacement for official Azure service documentation

--- a/docs-generation/HorizontalArticleGenerator/prompts/horizontal-article-user-prompt.txt
+++ b/docs-generation/HorizontalArticleGenerator/prompts/horizontal-article-user-prompt.txt
@@ -62,6 +62,7 @@ Characteristics:
 
 ## Key Constraints
 
+- **SEO Differentiation**: These are MCP Server tool articles, not Azure service documentation. Content must complement official Azure docs, not compete with them. Do NOT generate content that positions the article as a primary resource for the Azure service itself — it is a reference for using MCP tools with that service
 - **Universality**: This prompt runs for ALL 52 Azure MCP namespaces. Every field you generate must be grounded to the specific tools and service provided above — do not assume any particular Azure service. Apply all rules generically regardless of service
 - **Authentication**: Azure MCP Server uses `DefaultAzureCredential` (Microsoft Entra ID). Do not mention API keys anywhere
 - **Naming**: Use "Microsoft Entra ID" instead of "Azure Active Directory" (renamed in 2023)

--- a/docs-generation/HorizontalArticleGenerator/templates/horizontal-article-template.hbs
+++ b/docs-generation/HorizontalArticleGenerator/templates/horizontal-article-template.hbs
@@ -1,6 +1,6 @@
 ---
-title: Manage {{serviceBrandName}} with Azure MCP Server
-description: Learn how to use the Azure MCP Server to manage {{genai-serviceShortDescription}} through AI-powered natural language interactions.
+title: Azure MCP Server tools for {{serviceBrandName}}
+description: Use Azure MCP Server tools to manage {{genai-serviceShortDescription}} through AI-powered natural language interactions.
 author: diberry
 ms.author: diberry
 ms.service: azure-mcp-server
@@ -15,7 +15,7 @@ ms.custom: build-2025
 
 ---
 
-# Manage {{serviceBrandName}} with Azure MCP Server
+# Azure MCP Server tools for {{serviceBrandName}}
 
 Manage {{genai-serviceShortDescription}} using natural language conversations with AI assistants through the Azure MCP Server.
 

--- a/docs-generation/ToolFamilyCleanup/prompts/family-metadata-system-prompt.txt
+++ b/docs-generation/ToolFamilyCleanup/prompts/family-metadata-system-prompt.txt
@@ -8,16 +8,16 @@ Generate EXACTLY this structure:
 
 ```markdown
 ---
-title: Azure {ServiceName} tools for the Azure MCP Server overview
-description: Learn about the tools available in Azure {ServiceName} for managing {brief-service-description} as part of the Azure MCP Server.
-keywords: Azure, MCP Server, {service-name}, tools, {relevant-keywords}
+title: Azure MCP Server tools for {ServiceName} overview
+description: Use Azure MCP Server tools to manage {brief-service-description} with natural language prompts from your IDE.
+keywords: azure mcp server, azmcp, mcp tools, {service-name} tools, {1-2 MCP-specific terms}
 ms.service: azure-mcp-server
 ms.topic: concept-article
 tool_count: {NUMBER}
 mcp-cli.version: {CLI_VERSION}
 ---
 
-# Azure {ServiceName} tools for the Azure MCP Server overview
+# Azure MCP Server tools for {ServiceName} overview
 
 The Azure MCP Server lets you manage {service-description}, including {key-capabilities}, with natural language prompts.
 
@@ -26,12 +26,20 @@ The Azure MCP Server lets you manage {service-description}, including {key-capab
 [!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]
 ```
 
+## SEO Differentiation Rules (CRITICAL)
+
+These articles document Azure MCP Server tools, NOT the Azure services themselves. The content must complement official Azure service docs, never compete with them.
+
+- **Title and H1**: MUST lead with "Azure MCP Server" — never lead with the Azure service name (e.g., never "Azure AI Search tools for..." — always "Azure MCP Server tools for Azure AI Search...")
+- **Description**: MUST lead with "Use Azure MCP Server tools" or similar MCP-first phrasing
+- **Keywords**: Must focus on MCP-specific terms (`azure mcp server`, `azmcp`, `mcp tools`). Do NOT include generic service keywords like `cognitive search`, `azure search`, `cosmos database`, `nosql database` that belong to official Azure service documentation
+
 ## Requirements
 
 1. **Frontmatter**:
-   - `title`: Must follow pattern "Azure {ServiceName} tools for the Azure MCP Server overview"
-   - `description`: Brief description mentioning the service and MCP Server
-   - `keywords`: Comma-separated, include Azure, MCP Server, service name, and 2-3 relevant terms
+   - `title`: Must follow pattern "Azure MCP Server tools for {ServiceName} overview"
+   - `description`: Must lead with "Use Azure MCP Server tools to..." — MCP Server product name must appear before the service name
+   - `keywords`: Comma-separated. Must include `azure mcp server, azmcp, mcp tools`. Add 1-2 service-specific MCP terms (e.g., `storage mcp tools`). Do NOT include generic Azure service keywords that would compete with official Azure service documentation
    - `ms.service`: Always "azure-mcp-server"
    - `ms.topic`: Always "concept-article"
    - `tool_count`: Exact number provided in user prompt
@@ -39,7 +47,7 @@ The Azure MCP Server lets you manage {service-description}, including {key-capab
 
 2. **H1 Heading**:
    - Must match the title exactly
-   - Format: "Azure {ServiceName} tools for the Azure MCP Server overview"
+   - Format: "Azure MCP Server tools for {ServiceName} overview"
 
 3. **Introduction Paragraph 1**:
    - Start with "The Azure MCP Server lets you manage..."

--- a/docs-generation/ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
+++ b/docs-generation/ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
@@ -3,22 +3,24 @@ You are an expert technical writer and editor specializing in Microsoft document
 ## Document Structure Requirements
 
 ### 1. Frontmatter (YAML Header)
-- `title` - Must match the H1 heading
-- `description` - Accurate summary of the content
-- `keywords` - Include relevant search terms
+- `title` - Must match the H1 heading. MUST lead with "Azure MCP Server" — never lead with the Azure service name
+- `description` - Must lead with "Use Azure MCP Server" or "Learn how to use Azure MCP Server tools" — the MCP Server product name must appear before the service name
+- `keywords` - Must focus on MCP-specific terms (e.g., `azure mcp server, azmcp, mcp tools`). Do NOT include generic Azure service keywords (e.g., `cognitive search`, `azure search`, `cosmos database`) that would compete with official Azure service documentation in search results
 - `ms.service: azure-mcp-server`
 - `ms.topic: concept-article`
 - `tool_count: X` - Count of tools in the document
 
 ### 2. H1 Title Format
-Format: `# Azure {Service} tools for the Azure MCP Server overview`
+Format: `# Azure MCP Server tools for {Service} overview`
 
-Example: `# Azure Storage tools for the Azure MCP Server overview`
+Example: `# Azure MCP Server tools for Azure Storage overview`
+
+**SEO CRITICAL**: The title and H1 MUST lead with "Azure MCP Server" — never lead with the Azure service name (e.g., never start with "Azure AI Search", "Azure Cosmos DB", "Azure Storage"). The service name should appear AFTER "Azure MCP Server tools for". This prevents our tool reference articles from cannibalizing official Azure service documentation in search results.
 
 ### 3. Overview Section (Required)
 Immediately after H1, include:
-- High-level explanation of what the tool family does
-- Description of the related Azure service with link to first-party documentation
+- High-level explanation of what the tool family does — frame as MCP Server capabilities, not Azure service documentation
+- Description of the related Azure service with link to first-party documentation (position as complementary reference, not replacement)
 - Parameter consideration include:
 
 ```markdown
@@ -196,6 +198,14 @@ Include relevant links to Azure MCP documentation and first-party Microsoft docu
 - Not removing information or tools
 - Do NOT use backticks around parameter names in tables or headings
  - In parameter tables, use bold text only (example: **VM name**, not **`VM name`**)
+
+## SEO Differentiation Rules (CRITICAL)
+
+These articles document Azure MCP Server tools, NOT the Azure services themselves. The content must complement official Azure service documentation, not compete with it in search results.
+
+- **Title and H1**: MUST lead with "Azure MCP Server" — never lead with the Azure service name. Format: "Azure MCP Server tools for {Service} overview"
+- **Description**: MUST lead with "Use Azure MCP Server tools" or similar MCP-first phrasing
+- **Keywords**: Must focus on MCP-specific terms (`azure mcp server`, `azmcp`, `mcp tools`). Do NOT include generic service keywords (e.g., `cognitive search`, `azure search`, `cosmos database`) that would cause our articles to outrank official Azure service documentation
 
 ## Important Notes
 

--- a/docs-generation/prompts/tool-family-cleanup-system-prompt.txt
+++ b/docs-generation/prompts/tool-family-cleanup-system-prompt.txt
@@ -32,6 +32,7 @@ You are an expert technical writer and editor specializing in Microsoft document
    - Ensure examples use natural language that users would actually say to an AI assistant
    - Verify that links and references are properly formatted
    - Ensure metadata (frontmatter) is complete and correct
+   - **SEO Differentiation**: Title and H1 MUST lead with "Azure MCP Server" — never lead with the Azure service name. Format: "Azure MCP Server tools for {Service} overview". Description must use MCP-first phrasing ("Use Azure MCP Server tools to..."). Keywords must focus on MCP-specific terms — do NOT include generic service keywords (e.g., `cognitive search`, `azure search`) that would compete with official Azure service documentation
 
 5. **Markdown Quality**:
    - Ensure proper markdown syntax

--- a/docs-generation/templates/tool-family-page.hbs
+++ b/docs-generation/templates/tool-family-page.hbs
@@ -4,7 +4,7 @@ ms.date: {{formatDate generatedAt}}
 mcp-cli.version: {{version}}
 ---
 
-# {{areaName}} Tools
+# Azure MCP Server tools for {{areaName}}
 
 **Area:** {{areaName}}  
 **Description:** {{areaDescription}}  


### PR DESCRIPTION
## What
Updates AI prompts in the generation pipeline to prevent generated articles from cannibalizing official Azure service documentation in search results.

## Why
Generated tool family and horizontal articles currently use titles/keywords that lead with Azure service names (e.g., 'Azure AI Search Tools') instead of 'Azure MCP Server'. This causes our reference articles to outrank the official Azure service docs.

## Changes
- Tool family cleanup prompts: added SEO differentiation rules for titles, descriptions, keywords
- Horizontal article prompts: same SEO rules
- Horizontal article template: title/H1 changed from 'Manage {Service} with Azure MCP Server' to 'Azure MCP Server tools for {Service}'
- Tool family page template: H1 now leads with 'Azure MCP Server tools for'
- All generated content must lead with 'Azure MCP Server' in titles/H1
- Generic service keywords removed from keyword targeting guidance

## Impact
Next generation run will produce articles with MCP-first titles and descriptions. Existing published articles will need a regeneration pass to pick up the new patterns.