### PR TITLE
docs: add parameter optional+conditional directive

### DIFF
--- a/docs-generation/CSharpGenerator/Generators/ParameterGenerator.cs
+++ b/docs-generation/CSharpGenerator/Generators/ParameterGenerator.cs
@@ -105,6 +105,22 @@ public class ParameterGenerator
         }
     }
 
+    /// <summary>
+    /// Builds the "Required or optional" column text for a parameter.
+    /// 
+    /// Parameters can be both optional and conditional. The requirement level is
+    /// a combination of the base level (Required/Optional) and a conditional modifier (*).
+    /// Possible outputs:
+    ///   - "Required"  — always required.
+    ///   - "Optional"  — never required.
+    ///   - "Required*" — required, and part of a conditional group.
+    ///   - "Optional*" — optional by default, but conditionally required depending on
+    ///                    how other parameters in the group are used.
+    /// 
+    /// The asterisk (*) pairs with a footnote in the rendered parameter table that
+    /// explains the conditional relationship (e.g., "At least one of the parameters
+    /// marked with * is required").
+    /// </summary>
     internal static string BuildRequiredText(bool required, string parameterName, HashSet<string> conditionalParameters)
     {
         var baseText = required ? "Required" : "Optional";

--- a/docs-generation/CSharpGenerator/Models/Option.cs
+++ b/docs-generation/CSharpGenerator/Models/Option.cs
@@ -1,5 +1,19 @@
 namespace CSharpGenerator.Models;
 
+/// <summary>
+/// Represents a tool parameter (option) with its requirement level.
+/// 
+/// Parameter requirement levels:
+///   - Required:  Always required for every invocation.
+///   - Optional:  Never required; provides additional context or filtering.
+///   - Required*: Conditionally required — required when certain other parameters are absent.
+///   - Optional*: Conditionally required — optional by default but becomes required depending
+///                on how other parameters are used (e.g., "at least one of X or Y is required").
+///
+/// A parameter can be both optional AND conditional. The <see cref="Required"/> boolean captures
+/// the base level; the asterisk is appended by <c>ParameterGenerator.BuildRequiredText</c> when
+/// the parameter appears in the tool's conditional-required set.
+/// </summary>
 public class Option
 {
     public string? Name { get; set; }

--- a/docs-generation/ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
+++ b/docs-generation/ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
@@ -191,6 +191,7 @@ Include relevant links to Azure MCP documentation and first-party Microsoft docu
 - Every single tool section from the original document
 - Any conditional requirement sentence that starts with "Requires at least one" (keep verbatim)
 - Asterisks in the "Required or optional" column and the footnote explaining the asterisk
+- Parameters can be both optional AND conditional. A parameter marked "Optional*" is optional by default but becomes conditionally required depending on other parameters. Do NOT simplify "Optional*" to "Optional" or "Required*" to "Required" — the asterisk and footnote are semantically meaningful.
 
 **Focus on**:
 - Style, clarity, and correctness improvements

--- a/docs-generation/ToolGeneration_Improved/Prompts/system-prompt.txt
+++ b/docs-generation/ToolGeneration_Improved/Prompts/system-prompt.txt
@@ -62,6 +62,7 @@ Your task is to review and improve tool documentation files for the Azure Model 
 - Do NOT change tool command names
 - Do NOT remove or paraphrase any conditional requirement sentence that starts with "Requires at least one"; keep it verbatim
 - Do NOT remove asterisks in the "Required or optional" column or the footnote explaining the asterisk
+- Parameters can be both optional AND conditional. A parameter marked "Optional*" is optional by default but becomes conditionally required depending on other parameters. Do NOT simplify "Optional*" to "Optional" or "Required*" to "Required" — the asterisk and footnote are semantically meaningful.
 
 ## Output Format
 


### PR DESCRIPTION
Parameters can be both optional AND conditional. This PR adds:

- **ParameterGenerator.cs**: XML doc on `BuildRequiredText` explaining all 4 output values (Required, Optional, Required*, Optional*)
- **Option.cs**: XML doc explaining the requirement level model and how base level + conditional asterisk combine
- **tool-family-cleanup-system-prompt.txt**: Directive preventing AI from simplifying Optional*/Required* to Optional/Required
- **system-prompt.txt**: Same directive for the tool generation prompt

All 106 tests pass. No behavioral changes — documentation and prompt directives only.