### PR TITLE
feat: add OpenAI Service and Well-Architected Framework to brand mapping

### DIFF
--- a/docs-generation/data/brand-to-server-mapping.json
+++ b/docs-generation/data/brand-to-server-mapping.json
@@ -310,5 +310,17 @@
     "mcpServerName": "pricing",
     "shortName": "Pricing",
     "fileName": "azure-pricing"
+  },
+  {
+    "brandName": "Azure OpenAI Service",
+    "mcpServerName": "foundryextensions",
+    "shortName": "OpenAI",
+    "fileName": "azure-openai-service"
+  },
+  {
+    "brandName": "Azure Well-Architected Framework",
+    "mcpServerName": "wellarchitectedframework",
+    "shortName": "Well-Architected Framework",
+    "fileName": "azure-well-architected-framework"
   }
 ]


### PR DESCRIPTION
Adds two new MCP server entries to `brand-to-server-mapping.json`:

- **Azure OpenAI Service** — `foundryextensions` MCP server, maps to `azure-openai-service` filename
- **Azure Well-Architected Framework** — `wellarchitectedframework` MCP server, maps to `azure-well-architected-framework` filename

These entries enable the content generation system to produce documentation for these servers.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>