### PR TITLE
feat: wire parameter table artifact to example prompt generator

### DIFF
--- a/docs-generation/CSharpGenerator.Tests/ParameterGeneratorTests.cs
+++ b/docs-generation/CSharpGenerator.Tests/ParameterGeneratorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using CSharpGenerator.Generators;
+using CSharpGenerator.Models;
 using Xunit;
 
 namespace CSharpGenerator.Tests;
@@ -92,5 +93,30 @@ public class ParameterGeneratorTests
             false, "--account-name", conditionals);
 
         Assert.Equal("Optional", result);
+    }
+
+    [Fact]
+    public void BuildParameterManifest_AppliesPromptTableTransforms()
+    {
+        var options = new List<Option>
+        {
+            new()
+            {
+                Name = "--vault-name",
+                Required = false,
+                Description = "Provide vault name"
+            }
+        };
+        var conditionals = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "--vault-name" };
+
+        var manifest = ParameterGenerator.BuildParameterManifest(options, conditionals);
+
+        var parameter = Assert.Single(manifest);
+        Assert.Equal("--vault-name", parameter.Name);
+        Assert.Equal("Vault name", parameter.DisplayName);
+        Assert.False(parameter.Required);
+        Assert.Equal("Optional*", parameter.RequiredText);
+        Assert.True(parameter.IsConditionalRequired);
+        Assert.Equal("Provide vault name.", parameter.Description);
     }
 }

--- a/docs-generation/CSharpGenerator/Generators/ParameterGenerator.cs
+++ b/docs-generation/CSharpGenerator/Generators/ParameterGenerator.cs
@@ -46,7 +46,10 @@ public class ParameterGenerator
                 // Use shared deterministic filename builder
                 var fileName = ToolFileNameBuilder.BuildParameterFileName(
                     tool.Command, nameContext);
+                var manifestFileName = ToolFileNameBuilder.BuildParameterManifestFileName(
+                    tool.Command, nameContext);
                 var outputFile = Path.Combine(outputDir, fileName);
+                var manifestOutputFile = Path.Combine(outputDir, manifestFileName);
 
                 // Filter out common parameters unless they are required for this specific tool
                 var allOptions = tool.Option ?? new List<Option>();
@@ -58,17 +61,20 @@ public class ParameterGenerator
 
                 var filteredOptions = allOptions
                     .Where(opt => !string.IsNullOrEmpty(opt.Name) && 
-                                  (!commonParameterNames.Contains(opt.Name) || opt.Required == true));
+                                  (!commonParameterNames.Contains(opt.Name) || opt.Required == true))
+                    .ToList();
+
+                var parameterManifest = BuildParameterManifest(filteredOptions, conditionalParameters);
 
                 var transformedOptions = filteredOptions
-                    .Select(opt => new
+                    .Zip(parameterManifest, (opt, manifest) => new
                     {
-                        name = opt.Name,
-                        NL_Name = TextCleanup.NormalizeParameter(opt.Name ?? ""),
+                        name = manifest.Name,
+                        NL_Name = manifest.DisplayName,
                         type = opt.Type,
-                        required = opt.Required,
-                        RequiredText = BuildRequiredText(opt.Required, opt.Name ?? "", conditionalParameters),
-                        description = TextCleanup.EnsureEndsPeriod(TextCleanup.ReplaceStaticText(opt.Description ?? ""))
+                        required = manifest.Required,
+                        RequiredText = manifest.RequiredText,
+                        description = manifest.Description
                     })
                     .ToList();
 
@@ -92,6 +98,13 @@ public class ParameterGenerator
                     fileName);
                 var result = frontmatter + templateResult;
                 await File.WriteAllTextAsync(outputFile, result);
+                await File.WriteAllTextAsync(
+                    manifestOutputFile,
+                    JsonSerializer.Serialize(parameterManifest, new JsonSerializerOptions
+                    {
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                        WriteIndented = true
+                    }));
                 tool.HasParameters = true;
             }
             
@@ -103,6 +116,27 @@ public class ParameterGenerator
             LogFileHelper.WriteDebug(ex.StackTrace ?? "No stack trace");
             throw;
         }
+    }
+
+    internal static List<ParameterManifestEntry> BuildParameterManifest(
+        IEnumerable<Option> options,
+        HashSet<string> conditionalParameters)
+    {
+        return options
+            .Select(opt =>
+            {
+                var parameterName = opt.Name ?? string.Empty;
+                return new ParameterManifestEntry
+                {
+                    Name = parameterName,
+                    DisplayName = TextCleanup.NormalizeParameter(parameterName),
+                    Required = opt.Required,
+                    RequiredText = BuildRequiredText(opt.Required, parameterName, conditionalParameters),
+                    IsConditionalRequired = conditionalParameters.Contains(parameterName),
+                    Description = TextCleanup.EnsureEndsPeriod(TextCleanup.ReplaceStaticText(opt.Description ?? string.Empty))
+                };
+            })
+            .ToList();
     }
 
     /// <summary>
@@ -130,5 +164,15 @@ public class ParameterGenerator
         }
 
         return baseText;
+    }
+
+    internal sealed class ParameterManifestEntry
+    {
+        public string Name { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public bool Required { get; set; }
+        public string RequiredText { get; set; } = string.Empty;
+        public bool IsConditionalRequired { get; set; }
+        public string Description { get; set; } = string.Empty;
     }
 }

--- a/docs-generation/ExamplePromptGeneratorStandalone.Tests/ModelTests.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone.Tests/ModelTests.cs
@@ -67,6 +67,44 @@ public class ModelTests
     }
 
     // ─────────────────────────────────────────────────
+    // ParameterManifestParameter model
+    // ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParameterManifestParameter_DefaultValues()
+    {
+        var parameter = new ParameterManifestParameter();
+
+        Assert.Null(parameter.Name);
+        Assert.Null(parameter.DisplayName);
+        Assert.False(parameter.Required);
+        Assert.Null(parameter.RequiredText);
+        Assert.False(parameter.IsConditionalRequired);
+        Assert.Null(parameter.Description);
+    }
+
+    [Fact]
+    public void ParameterManifestParameter_SetProperties()
+    {
+        var parameter = new ParameterManifestParameter
+        {
+            Name = "--vault-name",
+            DisplayName = "Vault name",
+            Required = false,
+            RequiredText = "Optional*",
+            IsConditionalRequired = true,
+            Description = "Provide vault name."
+        };
+
+        Assert.Equal("--vault-name", parameter.Name);
+        Assert.Equal("Vault name", parameter.DisplayName);
+        Assert.False(parameter.Required);
+        Assert.Equal("Optional*", parameter.RequiredText);
+        Assert.True(parameter.IsConditionalRequired);
+        Assert.Equal("Provide vault name.", parameter.Description);
+    }
+
+    // ─────────────────────────────────────────────────
     // ExamplePromptsResponse model
     // ─────────────────────────────────────────────────
 

--- a/docs-generation/ExamplePromptGeneratorStandalone.Tests/ParameterManifestLoadingTests.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone.Tests/ParameterManifestLoadingTests.cs
@@ -1,0 +1,52 @@
+using ExamplePromptGeneratorStandalone.Models;
+using Shared;
+using Xunit;
+
+namespace ExamplePromptGeneratorStandalone.Tests;
+
+public class ParameterManifestLoadingTests
+{
+    [Fact]
+    public async Task LoadParameterManifestAsync_LoadsManifestForToolCommand()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"param-manifest-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var context = new FileNameContext(new Dictionary<string, BrandMapping>(), new Dictionary<string, string>(), new HashSet<string>());
+            var manifestFileName = ToolFileNameBuilder.BuildParameterManifestFileName("storage account list", context);
+            var manifestPath = Path.Combine(tempDir, manifestFileName);
+            await File.WriteAllTextAsync(manifestPath, "[{\"name\":\"--subscription\",\"displayName\":\"Subscription\",\"required\":true,\"requiredText\":\"Required\",\"isConditionalRequired\":false,\"description\":\"Subscription ID.\"}]");
+
+            var manifest = await Program.LoadParameterManifestAsync("storage account list", tempDir, context);
+
+            var parameter = Assert.Single(manifest!);
+            Assert.Equal("Subscription", parameter.DisplayName);
+            Assert.Equal("Required", parameter.RequiredText);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadParameterManifestAsync_ReturnsNullWhenFileMissing()
+    {
+        var context = new FileNameContext(new Dictionary<string, BrandMapping>(), new Dictionary<string, string>(), new HashSet<string>());
+        var tempDir = Path.Combine(Path.GetTempPath(), $"param-manifest-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var manifest = await Program.LoadParameterManifestAsync("storage account list", tempDir, context);
+
+            Assert.Null(manifest);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/docs-generation/ExamplePromptGeneratorStandalone.Tests/PromptParameterSelectionTests.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone.Tests/PromptParameterSelectionTests.cs
@@ -1,0 +1,117 @@
+using ExamplePromptGeneratorStandalone.Generators;
+using ExamplePromptGeneratorStandalone.Models;
+using Xunit;
+
+namespace ExamplePromptGeneratorStandalone.Tests;
+
+public class PromptParameterSelectionTests
+{
+    [Fact]
+    public void GetPromptParameters_UsesManifestDisplayNamesAndRequiredMarkers()
+    {
+        var tool = new Tool
+        {
+            Command = "keyvault secret get",
+            Option =
+            [
+                new Option { Name = "--vault-name", Required = false, Description = "Raw fallback description" }
+            ]
+        };
+        var manifest = new List<ParameterManifestParameter>
+        {
+            new()
+            {
+                Name = "--vault-name",
+                DisplayName = "Vault name",
+                Required = false,
+                RequiredText = "Required*",
+                Description = "Provide vault name."
+            },
+            new()
+            {
+                Name = "--secret-name",
+                DisplayName = "Secret name",
+                Required = false,
+                RequiredText = "Optional*",
+                Description = "Provide secret name."
+            }
+        };
+
+        var parameters = ExamplePromptGenerator.GetPromptParameters(tool, manifest);
+
+        Assert.Collection(parameters,
+            required =>
+            {
+                Assert.Equal("Vault name", required.Name);
+                Assert.Equal("Required*", required.RequirementText);
+                Assert.Equal("Provide vault name.", required.Description);
+                Assert.True(required.IsRequired);
+            },
+            optional =>
+            {
+                Assert.Equal("Secret name", optional.Name);
+                Assert.Equal("Optional*", optional.RequirementText);
+                Assert.False(optional.IsRequired);
+            });
+    }
+
+    [Fact]
+    public void GetPromptParameters_FallsBackToCliOptions_WhenManifestMissing()
+    {
+        var tool = new Tool
+        {
+            Option =
+            [
+                new Option { Name = "--vault-name", Required = true, Description = "Vault description" },
+                new Option { Name = "--subscription", Required = false, Description = "Subscription description" }
+            ]
+        };
+
+        var parameters = ExamplePromptGenerator.GetPromptParameters(tool, null);
+
+        Assert.Collection(parameters,
+            required =>
+            {
+                Assert.Equal("--vault-name", required.Name);
+                Assert.Equal("Required", required.RequirementText);
+                Assert.True(required.IsRequired);
+            },
+            optional =>
+            {
+                Assert.Equal("--subscription", optional.Name);
+                Assert.Equal("Optional", optional.RequirementText);
+                Assert.False(optional.IsRequired);
+            });
+    }
+
+    [Fact]
+    public void GetPromptParameters_UsesEmptyManifestInsteadOfFallingBackToCliOptions()
+    {
+        var tool = new Tool
+        {
+            Option =
+            [
+                new Option { Name = "--vault-name", Required = true, Description = "Vault description" }
+            ]
+        };
+
+        var parameters = ExamplePromptGenerator.GetPromptParameters(tool, new List<ParameterManifestParameter>());
+
+        Assert.Empty(parameters);
+    }
+
+    [Fact]
+    public void BuildParametersSection_PreservesManifestRequirementText()
+    {
+        var parameters = new List<(string Name, string RequirementText, string Description, bool IsRequired)>
+        {
+            ("Vault name", "Required*", "Provide vault name.", true),
+            ("Secret name", "Optional*", "Provide secret name.", false)
+        };
+
+        var section = ExamplePromptGenerator.BuildParametersSection(parameters);
+
+        Assert.Contains("- Vault name (Required*): Provide vault name.", section);
+        Assert.Contains("- Secret name (Optional*): Provide secret name.", section);
+    }
+}

--- a/docs-generation/ExamplePromptGeneratorStandalone/Generators/ExamplePromptGenerator.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone/Generators/ExamplePromptGenerator.cs
@@ -58,7 +58,9 @@ public sealed class ExamplePromptGenerator
     /// and the prompt count matches the e2e count (the tool authority's intent).
     /// </summary>
     public async Task<(string userPrompt, ExamplePromptsResponse? response, string rawResponse)?> GenerateAsync(
-        Tool tool, List<string>? referencePrompts = null)
+        Tool tool,
+        List<string>? referencePrompts = null,
+        IReadOnlyList<ParameterManifestParameter>? parameterManifest = null)
     {
         if (!IsInitialized || tool == null)
             return null;
@@ -75,18 +77,8 @@ public sealed class ExamplePromptGenerator
             var promptCount = referencePrompts?.Count ?? 5;
 
             // Build parameters section
-            var parametersBuilder = new StringBuilder();
-            var requiredParams = tool.Option?.Where(o => o.Required).ToList() ?? new List<Option>();
-            var optionalParams = tool.Option?.Where(o => !o.Required).ToList() ?? new List<Option>();
-
-            foreach (var param in requiredParams)
-            {
-                parametersBuilder.AppendLine($"- {param.Name} (Required): {param.Description ?? "No description"}");
-            }
-            foreach (var param in optionalParams)
-            {
-                parametersBuilder.AppendLine($"- {param.Name} (Optional): {param.Description ?? "No description"}");
-            }
+            var promptParameters = GetPromptParameters(tool, parameterManifest);
+            var parametersBuilder = new StringBuilder(BuildParametersSection(promptParameters));
 
             // Fill user prompt template - use regex to replace handlebars block
             var userPrompt = _userPromptTemplate
@@ -176,6 +168,53 @@ public sealed class ExamplePromptGenerator
             Console.WriteLine($"  ❌ Generation failed for '{tool.Command}': {ex.Message}");
             return null;
         }
+    }
+
+    internal static List<(string Name, string RequirementText, string Description, bool IsRequired)> GetPromptParameters(
+        Tool tool,
+        IReadOnlyList<ParameterManifestParameter>? parameterManifest = null)
+    {
+        if (parameterManifest != null)
+        {
+            return parameterManifest
+                .Where(p => !string.IsNullOrWhiteSpace(p.Name) || !string.IsNullOrWhiteSpace(p.DisplayName))
+                .Select(p =>
+                {
+                    var requirementText = string.IsNullOrWhiteSpace(p.RequiredText)
+                        ? (p.Required ? "Required" : "Optional")
+                        : p.RequiredText!;
+
+                    return (
+                        Name: string.IsNullOrWhiteSpace(p.DisplayName) ? p.Name ?? "Unknown" : p.DisplayName!,
+                        RequirementText: requirementText,
+                        Description: string.IsNullOrWhiteSpace(p.Description) ? "No description" : p.Description!,
+                        IsRequired: requirementText.StartsWith("Required", StringComparison.OrdinalIgnoreCase));
+                })
+                .OrderByDescending(p => p.IsRequired)
+                .ToList();
+        }
+
+        return (tool.Option ?? new List<Option>())
+            .Where(o => !string.IsNullOrWhiteSpace(o.Name))
+            .Select(o => (
+                Name: o.Name!,
+                RequirementText: o.Required ? "Required" : "Optional",
+                Description: string.IsNullOrWhiteSpace(o.Description) ? "No description" : o.Description!,
+                IsRequired: o.Required))
+            .OrderByDescending(p => p.IsRequired)
+            .ToList();
+    }
+
+    internal static string BuildParametersSection(
+        IEnumerable<(string Name, string RequirementText, string Description, bool IsRequired)> parameters)
+    {
+        var parametersBuilder = new StringBuilder();
+        foreach (var parameter in parameters)
+        {
+            parametersBuilder.AppendLine($"- {parameter.Name} ({parameter.RequirementText}): {parameter.Description}");
+        }
+
+        return parametersBuilder.ToString().TrimEnd();
     }
 
     /// <summary>

--- a/docs-generation/ExamplePromptGeneratorStandalone/Models/ParameterManifestParameter.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone/Models/ParameterManifestParameter.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace ExamplePromptGeneratorStandalone.Models;
+
+public sealed class ParameterManifestParameter
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("required")]
+    public bool Required { get; set; }
+
+    [JsonPropertyName("requiredText")]
+    public string? RequiredText { get; set; }
+
+    [JsonPropertyName("isConditionalRequired")]
+    public bool IsConditionalRequired { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}

--- a/docs-generation/ExamplePromptGeneratorStandalone/Program.cs
+++ b/docs-generation/ExamplePromptGeneratorStandalone/Program.cs
@@ -19,11 +19,12 @@ internal static class Program
         // Parse arguments
         if (args.Length < 2)
         {
-            Console.WriteLine("Usage: ExamplePromptGeneratorStandalone <cliOutputFile> <outputDir> [version] [--e2e-prompts <path>]");
-            Console.WriteLine("  cliOutputFile    - Path to cli-output.json");
-            Console.WriteLine("  outputDir        - Output directory for generated files");
-            Console.WriteLine("  version          - (Optional) CLI version string. If not provided, reads from cli-version.json");
-            Console.WriteLine("  --e2e-prompts    - (Optional) Path to parsed.json from E2eTestPromptParser");
+            Console.WriteLine("Usage: ExamplePromptGeneratorStandalone <cliOutputFile> <outputDir> [version] [--e2e-prompts <path>] [--param-manifests <dir>]");
+            Console.WriteLine("  cliOutputFile      - Path to cli-output.json");
+            Console.WriteLine("  outputDir          - Output directory for generated files");
+            Console.WriteLine("  version            - (Optional) CLI version string. If not provided, reads from cli-version.json");
+            Console.WriteLine("  --e2e-prompts      - (Optional) Path to parsed.json from E2eTestPromptParser");
+            Console.WriteLine("  --param-manifests  - (Optional) Directory containing per-tool parameter manifest JSON files");
             Console.WriteLine("\nNote: Templates and prompts are embedded in the package.");
             return 1;
         }
@@ -32,6 +33,7 @@ internal static class Program
         var outputDir = args[1];
         LogFileHelper.Initialize("example-prompts");
         string? e2ePromptsPath = null;
+        string? paramManifestsDir = null;
 
         // Scan for named flags first (they can appear anywhere after positional args)
         string? versionArg = null;
@@ -40,6 +42,10 @@ internal static class Program
             if (args[i] == "--e2e-prompts" && i + 1 < args.Length)
             {
                 e2ePromptsPath = args[++i];
+            }
+            else if (args[i] == "--param-manifests" && i + 1 < args.Length)
+            {
+                paramManifestsDir = args[++i];
             }
             else if (versionArg == null && !args[i].StartsWith("--"))
             {
@@ -107,12 +113,19 @@ internal static class Program
             }
         }
 
-        Console.WriteLine($"📂 CLI output:  {Path.GetFullPath(cliOutputFile)}");
-        Console.WriteLine($"📂 Output dir:  {Path.GetFullPath(outputDir)}");
-        Console.WriteLine($"📂 Templates:   {Path.GetFullPath(templatesDir)}");
-        Console.WriteLine($"📂 Prompts:     {Path.GetFullPath(promptsDir)}");
-        Console.WriteLine($"📂 E2e prompts: {(e2ePromptsPath != null ? Path.GetFullPath(e2ePromptsPath) : "(none)")}");
-        Console.WriteLine($"📌 Version:     {version}\n");
+        if (!string.IsNullOrEmpty(paramManifestsDir) && !Directory.Exists(paramManifestsDir))
+        {
+            Console.WriteLine($"⚠️  Parameter manifests directory not found (falling back to CLI JSON): {paramManifestsDir}");
+            paramManifestsDir = null;
+        }
+
+        Console.WriteLine($"📂 CLI output:       {Path.GetFullPath(cliOutputFile)}");
+        Console.WriteLine($"📂 Output dir:       {Path.GetFullPath(outputDir)}");
+        Console.WriteLine($"📂 Templates:        {Path.GetFullPath(templatesDir)}");
+        Console.WriteLine($"📂 Prompts:          {Path.GetFullPath(promptsDir)}");
+        Console.WriteLine($"📂 E2e prompts:      {(e2ePromptsPath != null ? Path.GetFullPath(e2ePromptsPath) : "(none)")}");
+        Console.WriteLine($"📂 Param manifests:  {(paramManifestsDir != null ? Path.GetFullPath(paramManifestsDir) : "(none)")}");
+        Console.WriteLine($"📌 Version:          {version}\n");
 
         // Load CLI output
         Console.WriteLine("Loading CLI tools...");
@@ -215,7 +228,8 @@ internal static class Program
                 }
             }
 
-            var result = await generator.GenerateAsync(tool, referencePrompts);
+            var parameterManifest = await LoadParameterManifestAsync(tool.Command, paramManifestsDir, nameContext);
+            var result = await generator.GenerateAsync(tool, referencePrompts, parameterManifest);
             if (!result.HasValue)
             {
                 failureCount++;
@@ -259,7 +273,8 @@ internal static class Program
             var promptsList = promptsResponse.Prompts.Select(p => new { prompt = p }).ToList();
 
             // Get required parameters for the template comment
-            var requiredParams = tool.Option?.Where(o => o.Required).ToList() ?? new List<Models.Option>();
+            var promptParameters = ExamplePromptGenerator.GetPromptParameters(tool, parameterManifest);
+            var requiredParams = promptParameters.Where(p => p.IsRequired).ToList();
             var requiredParamNames = string.Join(", ", requiredParams.Select(p => $"'{p.Name}'"));
 
             string exampleContent;
@@ -343,6 +358,38 @@ internal static class Program
         }
 
         return failureCount > 0 ? 1 : 0;
+    }
+
+    internal static async Task<List<ParameterManifestParameter>?> LoadParameterManifestAsync(
+        string? toolCommand,
+        string? paramManifestsDir,
+        FileNameContext nameContext)
+    {
+        if (string.IsNullOrWhiteSpace(toolCommand) || string.IsNullOrWhiteSpace(paramManifestsDir))
+        {
+            return null;
+        }
+
+        var manifestFileName = ToolFileNameBuilder.BuildParameterManifestFileName(toolCommand, nameContext);
+        var manifestPath = Path.Combine(paramManifestsDir, manifestFileName);
+        if (!File.Exists(manifestPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(manifestPath);
+            return JsonSerializer.Deserialize<List<ParameterManifestParameter>>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  ⚠️  Failed to load parameter manifest for '{toolCommand}' (falling back to CLI JSON): {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>

--- a/docs-generation/Shared.Tests/ToolFileNameBuilderTests.cs
+++ b/docs-generation/Shared.Tests/ToolFileNameBuilderTests.cs
@@ -139,6 +139,13 @@ public class ToolFileNameBuilderTests
     }
 
     [Fact]
+    public void BuildParameterManifestFileName_AppendsSuffix()
+    {
+        var result = ToolFileNameBuilder.BuildParameterManifestFileName("aks nodepool get", Ctx);
+        Assert.Equal("azure-kubernetes-service-node-pool-get-params.json", result);
+    }
+
+    [Fact]
     public void BuildExamplePromptsFileName_AppendsSuffix()
     {
         var result = ToolFileNameBuilder.BuildExamplePromptsFileName("aks nodepool get", Ctx);

--- a/docs-generation/Shared/ToolFileNameBuilder.cs
+++ b/docs-generation/Shared/ToolFileNameBuilder.cs
@@ -144,6 +144,10 @@ public static class ToolFileNameBuilder
     public static string BuildParameterFileName(string command, FileNameContext ctx)
         => $"{BuildBaseFileName(command, ctx)}-parameters.md";
 
+    /// <summary>Builds the full filename for a parameter manifest file.</summary>
+    public static string BuildParameterManifestFileName(string command, FileNameContext ctx)
+        => $"{BuildBaseFileName(command, ctx)}-params.json";
+
     /// <summary>Builds the full filename for an example prompts file.</summary>
     public static string BuildExamplePromptsFileName(string command, FileNameContext ctx)
         => $"{BuildBaseFileName(command, ctx)}-example-prompts.md";
@@ -177,6 +181,14 @@ public static class ToolFileNameBuilder
         Dictionary<string, string> compoundWords,
         HashSet<string> stopWords)
         => $"{BuildBaseFileName(command, brandMappings, compoundWords, stopWords)}-parameters.md";
+
+    /// <summary>Builds the full filename for a parameter manifest file.</summary>
+    public static string BuildParameterManifestFileName(
+        string command,
+        Dictionary<string, BrandMapping> brandMappings,
+        Dictionary<string, string> compoundWords,
+        HashSet<string> stopWords)
+        => $"{BuildBaseFileName(command, brandMappings, compoundWords, stopWords)}-params.json";
 
     /// <summary>Builds the full filename for an example prompts file.</summary>
     public static string BuildExamplePromptsFileName(

--- a/docs-generation/scripts/1-Generate-AnnotationsParametersRaw-One.ps1
+++ b/docs-generation/scripts/1-Generate-AnnotationsParametersRaw-One.ps1
@@ -11,7 +11,7 @@
     Steps:
     1. Filters cli-output.json to include only the specified tool
     2. Generates annotations for that tool
-    3. Generates parameters for that tool
+    3. Generates parameters and parameter manifests for that tool
     4. Generates raw tool file for that tool
     5. Shows all output files
 
@@ -188,11 +188,13 @@ try {
         
         $annotationsFile = Join-Path $outputDir "annotations/$baseFileName-annotations.md"
         $parametersFile = Join-Path $outputDir "parameters/$baseFileName-parameters.md"
+        $parameterManifestFile = Join-Path $outputDir "parameters/$baseFileName-params.json"
         $rawToolFile = Join-Path $outputDir "tools-raw/$baseFileName.md"
     } else {
         # Multiple tools in family - show first few
         $annotationsFile = "(multiple files)"
         $parametersFile = "(multiple files)"
+        $parameterManifestFile = "(multiple files)"
         $rawToolFile = "(multiple files)"
     }
     
@@ -216,6 +218,12 @@ try {
         } else {
             Write-Warning "✗ Parameters not found: $parametersFile"
         }
+
+        if (Test-Path $parameterManifestFile) {
+            Write-Success "✓ Parameter manifest: $parameterManifestFile"
+        } else {
+            Write-Warning "✗ Parameter manifest not found: $parameterManifestFile"
+        }
         
         if (Test-Path $rawToolFile) {
             Write-Success "✓ Raw tool: $rawToolFile"
@@ -231,7 +239,8 @@ try {
         $rawToolsDir = Join-Path $outputDir "tools-raw"
         
         $annotationsCount = if (Test-Path $annotationsDir) { (Get-ChildItem $annotationsDir -Filter "*.md" | Measure-Object).Count } else { 0 }
-        $parametersCount = if (Test-Path $parametersDir) { (Get-ChildItem $parametersDir -Filter "*.md" | Measure-Object).Count } else { 0 }
+        $parametersCount = if (Test-Path $parametersDir) { (Get-ChildItem $parametersDir -Filter "*-parameters.md" | Measure-Object).Count } else { 0 }
+        $parameterManifestCount = if (Test-Path $parametersDir) { (Get-ChildItem $parametersDir -Filter "*-params.json" | Measure-Object).Count } else { 0 }
         $rawToolCount = if (Test-Path $rawToolsDir) { (Get-ChildItem $rawToolsDir -Filter "*.md" | Measure-Object).Count } else { 0 }
         
         if ($annotationsCount -gt 0) {
@@ -244,6 +253,12 @@ try {
             Write-Success "✓ Parameters: $parametersCount files in $parametersDir"
         } else {
             Write-Warning "✗ No parameters found"
+        }
+
+        if ($parameterManifestCount -gt 0) {
+            Write-Success "✓ Parameter manifests: $parameterManifestCount files in $parametersDir"
+        } else {
+            Write-Warning "✗ No parameter manifests found"
         }
         
         if ($rawToolCount -gt 0) {
@@ -278,6 +293,13 @@ try {
             } else {
                 Write-Success "✓ Parameters file exists"
             }
+
+            if (-not (Test-Path $parameterManifestFile)) {
+                Write-Warning "✗ Parameter manifest file not found"
+                $allFound = $false
+            } else {
+                Write-Success "✓ Parameter manifest file exists"
+            }
             
             if (-not (Test-Path $rawToolFile)) {
                 Write-Warning "✗ Raw tool file not found"
@@ -293,7 +315,7 @@ try {
             }
         } else {
             # Multiple tools validation
-            Write-Success "✓ Generated $($matchingTools.Count) annotation, parameter, and raw tool files"
+            Write-Success "✓ Generated $($matchingTools.Count) annotation, parameter, parameter manifest, and raw tool files"
             Write-Info "  Verify files in:"
             Write-Info "    - $annotationsDir"
             Write-Info "    - $parametersDir"

--- a/docs-generation/scripts/2-Generate-ExamplePrompts-One.ps1
+++ b/docs-generation/scripts/2-Generate-ExamplePrompts-One.ps1
@@ -101,7 +101,11 @@ try {
         Write-Warning "No e2e reference prompts found at: $e2ePromptsFile (using default prompt count)"
     }
 
-    & dotnet run --project $generatorProject --configuration Release $noBuildArg -- $filteredOutputFile $outputDir $cliVersion @e2eArgs
+    $parameterManifestDir = Join-Path $outputDir "parameters"
+    $paramManifestArgs = @("--param-manifests", $parameterManifestDir)
+    Write-Info "Using parameter manifests directory: $parameterManifestDir"
+
+    & dotnet run --project $generatorProject --configuration Release $noBuildArg -- $filteredOutputFile $outputDir $cliVersion @e2eArgs @paramManifestArgs
     
     if ($LASTEXITCODE -ne 0) {
         throw "Example prompts generation failed"


### PR DESCRIPTION
## Summary
- emit per-tool parameter manifest JSON alongside parameter markdown using the same parameter-table transformations
- load parameter manifests in the standalone example prompt generator with fallback to CLI option data
- pass manifest directories through the step scripts and cover the new behavior with unit tests

## Validation
- dotnet build .\docs-generation.sln -nologo
- dotnet test .\docs-generation.sln -nologo
