### PR TITLE
fix: Add ETag to TextCleanup acronym preservation

### DIFF
--- a/docs-generation/CSharpGenerator.Tests/NormalizeParameterTests.cs
+++ b/docs-generation/CSharpGenerator.Tests/NormalizeParameterTests.cs
@@ -143,6 +143,7 @@ public class NormalizeParameterTests : IClassFixture<TextCleanupFixture>
     [InlineData("sql-server-name", "SQL server name")]
     [InlineData("dns-name", "DNS name")]
     [InlineData("sku-name", "SKU name")]
+    [InlineData("etag-value", "ETag value")]
     public void NormalizeParameter_WithAcronyms_PreservesAcronymsAndQualifiers(string input, string expected)
     {
         // Act
@@ -282,6 +283,7 @@ public class NormalizeParameterTests : IClassFixture<TextCleanupFixture>
     [InlineData("id", "ID")]
     [InlineData("uri", "URI")]
     [InlineData("url", "URL")]
+    [InlineData("etag", "ETag")]
     [InlineData("type", "Type")]
     [InlineData("status", "Status")]
     public void NormalizeParameter_SingleWordQualifiers_FormattedCorrectly(string input, string expected)

--- a/docs-generation/NaturalLanguageGenerator/TextCleanup.cs
+++ b/docs-generation/NaturalLanguageGenerator/TextCleanup.cs
@@ -204,6 +204,7 @@ public static class TextCleanup
             "xml" => "XML",
             "yaml" => "YAML",
             "oauth" => "OAuth",
+            "etag" => "ETag",
             "cdn" => "CDN",
             "rg" => "Resource group",
             _ => word
@@ -271,7 +272,7 @@ public static class TextCleanup
     // Helper method to check if a word is a known acronym that should remain uppercase
     private static bool IsAcronym(string word)
     {
-        string[] knownAcronyms = { "ID", "IDs", "URI", "URL", "URLs", "AI", "API", "APIs", "CPU", "GPU", "IP", "SQL", "VM", "VMs", "DNS", "SKU", "SKUs", "TLS", "SSL", "HTTP", "HTTPS", "JSON", "XML", "YAML", "OAuth", "CDN" };
+        string[] knownAcronyms = { "ID", "IDs", "URI", "URL", "URLs", "AI", "API", "APIs", "CPU", "GPU", "IP", "SQL", "VM", "VMs", "DNS", "SKU", "SKUs", "TLS", "SSL", "HTTP", "HTTPS", "JSON", "XML", "YAML", "OAuth", "ETag", "CDN" };
         return knownAcronyms.Contains(word);
     }
     public static string ReplaceStaticText(string text)


### PR DESCRIPTION
Adds ETag to the list of preserved acronyms in TextCleanup.cs so it doesn't get altered during text cleanup.