### PR TITLE
Implement PipelineRunner Phase 2 typed steps

### DIFF
--- a/docs-generation/PipelineRunner.Tests/Fixtures/TestDoubles.cs
+++ b/docs-generation/PipelineRunner.Tests/Fixtures/TestDoubles.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 
@@ -15,10 +14,33 @@ internal sealed class RecordingProcessRunner : IProcessRunner
     }
 
     public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken cancellationToken)
-        => RunAsync(new ProcessSpec("dotnet", ["build", solutionPath], Path.GetDirectoryName(solutionPath) ?? Environment.CurrentDirectory), cancellationToken);
+        => RunAsync(
+            new ProcessSpec(
+                "dotnet",
+                ["build", solutionPath, "--configuration", "Release", "--verbosity", "quiet"],
+                Path.GetDirectoryName(solutionPath) ?? Environment.CurrentDirectory),
+            cancellationToken);
 
     public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken cancellationToken)
-        => RunAsync(new ProcessSpec("dotnet", ["run", projectPath, .. arguments], workingDirectory), cancellationToken);
+    {
+        var invocation = new List<string>
+        {
+            "run",
+            "--project",
+            projectPath,
+            "--configuration",
+            "Release",
+        };
+
+        if (noBuild)
+        {
+            invocation.Add("--no-build");
+        }
+
+        invocation.Add("--");
+        invocation.AddRange(arguments);
+        return RunAsync(new ProcessSpec("dotnet", invocation, workingDirectory), cancellationToken);
+    }
 
     public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
         => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);

--- a/docs-generation/PipelineRunner.Tests/Unit/NamespaceStepTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/NamespaceStepTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Services;
+using PipelineRunner.Steps;
+using PipelineRunner.Tests.Fixtures;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class NamespaceStepTests
+{
+    [Fact]
+    public async Task Step1_AnnotationsParametersRaw_UsesExpectedGeneratorArguments()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list", "compute show"]);
+            context.Items["Namespace"] = "compute";
+
+            SeedFile(Path.Combine(context.OutputPath, "annotations", "compute-list-annotations.md"));
+            SeedFile(Path.Combine(context.OutputPath, "parameters", "compute-list-parameters.md"));
+            SeedFile(Path.Combine(context.OutputPath, "tools-raw", "compute-list.md"));
+
+            var step = new AnnotationsParametersRawStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(3, runner.Invocations.Count);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "generate-docs");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--annotations");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--no-build");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("cli-output-single-tool.json", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument == "--parameters");
+            Assert.Contains(runner.Invocations[2].Arguments, argument => argument.EndsWith("ToolGeneration_Raw.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[2].Arguments, argument => argument == Path.Combine(context.OutputPath, "tools-raw"));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step2_ExamplePrompts_UsesGeneratorAndValidatorArguments()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list"]);
+            context.Items["Namespace"] = "compute list";
+
+            SeedFile(Path.Combine(context.OutputPath, "example-prompts", "compute-list-example-prompts.md"));
+            SeedFile(Path.Combine(context.OutputPath, "example-prompts-prompts", "compute-list-input-prompt.md"));
+            SeedFile(Path.Combine(context.OutputPath, "example-prompts-raw-output", "compute-list-raw-output.txt"));
+            SeedFile(Path.Combine(context.OutputPath, "e2e-test-prompts", "parsed.json"), "{}");
+            Directory.CreateDirectory(Path.Combine(context.OutputPath, "parameters"));
+
+            var step = new ExamplePromptsStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(2, runner.Invocations.Count);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("ExamplePromptGeneratorStandalone.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--e2e-prompts");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--param-manifests");
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument.EndsWith("ExamplePromptValidator.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument == "--tool-command");
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument == "compute list");
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step3_ToolGeneration_UsesExpectedGeneratorArguments()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list", "compute show"]);
+            context.Items["Namespace"] = "compute";
+
+            SeedFile(Path.Combine(context.OutputPath, "tools-raw", "compute-list.md"));
+            SeedFile(Path.Combine(context.OutputPath, "annotations", "compute-list-annotations.md"));
+            SeedFile(Path.Combine(context.OutputPath, "parameters", "compute-list-parameters.md"));
+            SeedFile(Path.Combine(context.OutputPath, "example-prompts", "compute-list-example-prompts.md"));
+            SeedFile(Path.Combine(context.OutputPath, "tools-composed", "compute-list.md"));
+            SeedFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"));
+
+            var step = new ToolGenerationStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(2, runner.Invocations.Count);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("ToolGeneration_Composed.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == Path.Combine(context.OutputPath, "tools-raw"));
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == Path.Combine(context.OutputPath, "example-prompts"));
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument.EndsWith("ToolGeneration_Improved.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[1].Arguments, argument => argument == "8000");
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step6_HorizontalArticles_UsesExpectedGeneratorArguments()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list", "compute show"]);
+            context.Items["Namespace"] = "compute";
+
+            SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-compute.md"));
+
+            var step = new HorizontalArticlesStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Single(runner.Invocations);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("HorizontalArticleGenerator.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--single-service");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "compute");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--output-path");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == context.OutputPath);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--transform");
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static PipelineContext CreateContext(string testRoot, IProcessRunner processRunner, bool skipValidation, IReadOnlyList<string> toolCommands)
+    {
+        var docsGenerationRoot = Path.Combine(testRoot, "docs-generation");
+        var outputPath = Path.Combine(testRoot, "generated-compute");
+        Directory.CreateDirectory(docsGenerationRoot);
+        Directory.CreateDirectory(outputPath);
+
+        return new PipelineContext
+        {
+            Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
+            RepoRoot = testRoot,
+            DocsGenerationRoot = docsGenerationRoot,
+            OutputPath = outputPath,
+            ProcessRunner = processRunner,
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new FilteredCliWriter(new WorkspaceManager()),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            CliOutput = CreateSnapshot(toolCommands),
+            SelectedNamespaces = ["compute"],
+        };
+    }
+
+    private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            version = "1.2.3",
+            results = toolCommands.Select(command => new
+            {
+                command,
+                name = command,
+                description = $"Description for {command}",
+            }),
+        });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+        var tools = root.GetProperty("results")
+            .EnumerateArray()
+            .Select(tool => new CliTool(
+                tool.GetProperty("command").GetString() ?? string.Empty,
+                tool.GetProperty("name").GetString() ?? string.Empty,
+                tool.GetProperty("description").GetString(),
+                tool.Clone()))
+            .ToArray();
+
+        return new CliMetadataSnapshot(Path.Combine(Path.GetTempPath(), $"cli-output-{Guid.NewGuid():N}.json"), root, tools);
+    }
+
+    private static string CreateTestRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"pipeline-runner-step-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void SeedFile(string path, string content = "content")
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static void DeleteTestRoot(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
@@ -1,6 +1,7 @@
 using PipelineRunner.Contracts;
 using PipelineRunner.Context;
 using PipelineRunner.Registry;
+using PipelineRunner.Steps;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -40,6 +41,29 @@ public class StepRegistryTests
         var step = registry.GetStep(2);
 
         Assert.Equal("second", step.Name);
+    }
+
+    [Fact]
+    public void CreateDefault_RegistersTypedPhaseTwoSteps()
+    {
+        var scriptsRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-scripts-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(scriptsRoot);
+
+        try
+        {
+            var registry = StepRegistry.CreateDefault(scriptsRoot);
+
+            Assert.IsType<AnnotationsParametersRawStep>(registry.GetStep(1));
+            Assert.IsType<ExamplePromptsStep>(registry.GetStep(2));
+            Assert.IsType<ToolGenerationStep>(registry.GetStep(3));
+            Assert.IsType<ShimStep>(registry.GetStep(4));
+            Assert.IsType<ShimStep>(registry.GetStep(5));
+            Assert.IsType<HorizontalArticlesStep>(registry.GetStep(6));
+        }
+        finally
+        {
+            Directory.Delete(scriptsRoot, recursive: true);
+        }
     }
 
     private sealed class FakeStep : IPipelineStep

--- a/docs-generation/PipelineRunner/Registry/StepRegistry.cs
+++ b/docs-generation/PipelineRunner/Registry/StepRegistry.cs
@@ -26,12 +26,12 @@ public sealed class StepRegistry
 
     public static StepRegistry CreateDefault(string scriptsRoot)
         => new([
-            new ShimStep(1, "Generate annotations, parameters, and raw tools", FailurePolicy.Fatal, Path.Combine(scriptsRoot, "1-Generate-AnnotationsParametersRaw-One.ps1"), "ToolCommand", expectedOutputs: ["annotations", "parameters", "tools-raw"]),
-            new ShimStep(2, "Generate example prompts", FailurePolicy.Fatal, Path.Combine(scriptsRoot, "2-Generate-ExamplePrompts-One.ps1"), "ToolCommand", dependsOn: [1], requiresAiConfiguration: true, expectedOutputs: ["example-prompts", "example-prompts-prompts", "example-prompts-raw-output"]),
-            new ShimStep(3, "Compose and improve tool files", FailurePolicy.Fatal, Path.Combine(scriptsRoot, "3-Generate-ToolGenerationAndAIImprovements-One.ps1"), "ToolCommand", dependsOn: [1, 2], requiresAiConfiguration: true, expectedOutputs: ["tools-composed", "tools"]),
+            new AnnotationsParametersRawStep(),
+            new ExamplePromptsStep(),
+            new ToolGenerationStep(),
             new ShimStep(4, "Generate tool-family article", FailurePolicy.Fatal, Path.Combine(scriptsRoot, "4-Generate-ToolFamilyCleanup-One.ps1"), "ToolCommand", dependsOn: [3], requiresAiConfiguration: true, usesIsolatedWorkspace: true, expectedOutputs: ["tool-family-metadata", "tool-family-related", "tool-family", "reports"]),
             new ShimStep(5, "Generate skills relevance", FailurePolicy.Warn, Path.Combine(scriptsRoot, "5-Generate-SkillsRelevance-One.ps1"), "ServiceArea", expectedOutputs: ["skills-relevance"]),
-            new ShimStep(6, "Generate horizontal article", FailurePolicy.Fatal, Path.Combine(scriptsRoot, "6-Generate-HorizontalArticles-One.ps1"), "ServiceArea", requiresAiConfiguration: true, expectedOutputs: ["horizontal-articles"]),
+            new HorizontalArticlesStep(),
         ]);
 
     public IReadOnlyList<IPipelineStep> GetAllSteps()

--- a/docs-generation/PipelineRunner/Steps/Namespace/AnnotationsParametersRawStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/AnnotationsParametersRawStep.cs
@@ -1,0 +1,85 @@
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public sealed class AnnotationsParametersRawStep : NamespaceStepBase
+{
+    public AnnotationsParametersRawStep()
+        : base(
+            1,
+            "Generate annotations, parameters, and raw tools",
+            FailurePolicy.Fatal,
+            createsFilteredCliView: true,
+            expectedOutputs: ["annotations", "parameters", "tools-raw"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+    {
+        var (_, cliOutput, cliVersion, matchingTools) = ResolveTarget(context);
+        var filteredCli = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step1", cancellationToken);
+
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var csharpGeneratorProject = GetProjectPath(context, "CSharpGenerator");
+        var rawGeneratorProject = GetProjectPath(context, "ToolGeneration_Raw");
+        var rawToolsDirectory = Path.Combine(context.OutputPath, "tools-raw");
+
+        var annotationsResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            csharpGeneratorProject,
+            ["generate-docs", filteredCli.FilePath, context.OutputPath, "--annotations", "--version", cliVersion],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(annotationsResult);
+        if (!annotationsResult.Succeeded)
+        {
+            AddProcessIssue(annotationsResult, warnings, "Annotations generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var parametersResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            csharpGeneratorProject,
+            ["generate-docs", filteredCli.FilePath, context.OutputPath, "--parameters", "--version", cliVersion],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(parametersResult);
+        if (!parametersResult.Succeeded)
+        {
+            AddProcessIssue(parametersResult, warnings, "Parameter generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var rawToolsResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            rawGeneratorProject,
+            [filteredCli.FilePath, rawToolsDirectory, cliVersion],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(rawToolsResult);
+        if (!rawToolsResult.Succeeded)
+        {
+            AddProcessIssue(rawToolsResult, warnings, "Raw tool generation reported issues");
+        }
+
+        var validationIssues = new List<string>();
+        if (!context.Request.SkipValidation)
+        {
+            EnsurePathHasContent(Path.Combine(context.OutputPath, "annotations"), "annotations output", validationIssues);
+            EnsurePathHasContent(Path.Combine(context.OutputPath, "parameters"), "parameters output", validationIssues);
+            EnsurePathHasContent(rawToolsDirectory, "raw tool output", validationIssues);
+        }
+
+        warnings.AddRange(validationIssues);
+
+        var success = annotationsResult.Succeeded
+            && parametersResult.Succeeded
+            && (rawToolsResult.Succeeded || context.Request.SkipValidation || PathHasContent(rawToolsDirectory))
+            && validationIssues.Count == 0;
+
+        return BuildResult(context, processResults, success, warnings);
+    }
+}

--- a/docs-generation/PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
@@ -1,0 +1,115 @@
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public sealed class ExamplePromptsStep : NamespaceStepBase
+{
+    public ExamplePromptsStep()
+        : base(
+            2,
+            "Generate example prompts",
+            FailurePolicy.Fatal,
+            dependsOn: [1],
+            requiresAiConfiguration: true,
+            createsFilteredCliView: true,
+            expectedOutputs: ["example-prompts", "example-prompts-prompts", "example-prompts-raw-output"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+    {
+        var (_, cliOutput, cliVersion, matchingTools) = ResolveTarget(context);
+        var filteredCli = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step2", cancellationToken);
+
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var validatorResults = new List<ValidatorResult>();
+        var generatorProject = GetProjectPath(context, "ExamplePromptGeneratorStandalone");
+
+        var generatorArguments = new List<string>
+        {
+            filteredCli.FilePath,
+            context.OutputPath,
+            cliVersion,
+        };
+
+        var e2ePromptsPath = Path.Combine(context.OutputPath, "e2e-test-prompts", "parsed.json");
+        if (File.Exists(e2ePromptsPath))
+        {
+            generatorArguments.Add("--e2e-prompts");
+            generatorArguments.Add(e2ePromptsPath);
+        }
+
+        var parameterManifestDirectory = Path.Combine(context.OutputPath, "parameters");
+        generatorArguments.Add("--param-manifests");
+        generatorArguments.Add(parameterManifestDirectory);
+
+        var generatorResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            generatorProject,
+            generatorArguments,
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(generatorResult);
+        if (!generatorResult.Succeeded)
+        {
+            AddProcessIssue(generatorResult, warnings, "Example prompt generation failed");
+            return BuildResult(context, processResults, false, warnings, validatorResults);
+        }
+
+        if (!context.Request.SkipValidation)
+        {
+            var outputIssues = new List<string>();
+            EnsurePathHasContent(Path.Combine(context.OutputPath, "example-prompts"), "example prompts output", outputIssues);
+            EnsurePathHasContent(Path.Combine(context.OutputPath, "example-prompts-prompts"), "example prompt input output", outputIssues);
+            EnsurePathHasContent(Path.Combine(context.OutputPath, "example-prompts-raw-output"), "example prompt raw output", outputIssues);
+
+            warnings.AddRange(outputIssues);
+            if (outputIssues.Count > 0)
+            {
+                return BuildResult(context, processResults, false, warnings, validatorResults);
+            }
+
+            if (matchingTools.Count == 1)
+            {
+                var validatorProject = GetProjectPath(context, "ExamplePromptValidator");
+                var validatorWarnings = new List<string>();
+                var validatorResult = await context.ProcessRunner.RunDotNetProjectAsync(
+                    validatorProject,
+                    [
+                        "--generated", context.OutputPath,
+                        "--example-prompts-dir", Path.Combine(context.OutputPath, "example-prompts"),
+                        "--tool-command", matchingTools[0].Command,
+                    ],
+                    context.Request.SkipBuild,
+                    context.DocsGenerationRoot,
+                    cancellationToken);
+
+                processResults.Add(validatorResult);
+                if (!validatorResult.Succeeded)
+                {
+                    AddProcessIssue(validatorResult, validatorWarnings, "Example prompt validation completed with issues");
+                    warnings.AddRange(validatorWarnings);
+                }
+
+                validatorResults.Add(new ValidatorResult(
+                    "Validate-ExamplePrompts-RequiredParams",
+                    validatorResult.Succeeded,
+                    validatorWarnings));
+            }
+            else
+            {
+                const string warning = "Skipping example prompt validation for multi-tool namespace runs.";
+                warnings.Add(warning);
+                validatorResults.Add(new ValidatorResult(
+                    "Validate-ExamplePrompts-RequiredParams",
+                    true,
+                    [warning]));
+            }
+        }
+
+        return BuildResult(context, processResults, true, warnings, validatorResults);
+    }
+}

--- a/docs-generation/PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
@@ -1,0 +1,67 @@
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public sealed class HorizontalArticlesStep : NamespaceStepBase
+{
+    public HorizontalArticlesStep()
+        : base(
+            6,
+            "Generate horizontal article",
+            FailurePolicy.Fatal,
+            requiresAiConfiguration: true,
+            createsFilteredCliView: true,
+            expectedOutputs: ["horizontal-articles"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+    {
+        var (currentNamespace, cliOutput, _, matchingTools) = ResolveTarget(context);
+        _ = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step6", cancellationToken);
+
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var cliVersionPath = Path.Combine(context.OutputPath, "cli", "cli-version.json");
+        if (!context.Request.SkipValidation && !File.Exists(cliVersionPath))
+        {
+            warnings.Add($"CLI version file not found at '{cliVersionPath}'.");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var processResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            GetProjectPath(context, "HorizontalArticleGenerator"),
+            ["--single-service", currentNamespace, "--output-path", context.OutputPath, "--transform"],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(processResult);
+        if (!processResult.Succeeded)
+        {
+            AddProcessIssue(processResult, warnings, "Horizontal article generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var articleDirectory = Path.Combine(context.OutputPath, "horizontal-articles");
+        var articlePath = Path.Combine(articleDirectory, $"horizontal-article-{currentNamespace}.md");
+        var errorPath = Path.Combine(articleDirectory, $"error-{currentNamespace}.txt");
+        var aiErrorPath = Path.Combine(articleDirectory, $"error-{currentNamespace}-airesponse.txt");
+
+        var success = true;
+        if (File.Exists(errorPath) || File.Exists(aiErrorPath))
+        {
+            success = false;
+            warnings.Add($"Horizontal article generation produced an error artifact for '{currentNamespace}'.");
+        }
+
+        if (!File.Exists(articlePath))
+        {
+            warnings.Add($"Expected horizontal article output at '{articlePath}'.");
+            success = false;
+        }
+
+        return BuildResult(context, processResults, success, warnings);
+    }
+}

--- a/docs-generation/PipelineRunner/Steps/Namespace/NamespaceStepBase.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/NamespaceStepBase.cs
@@ -1,0 +1,107 @@
+using PipelineRunner.Contracts;
+using PipelineRunner.Context;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public abstract class NamespaceStepBase : StepDefinition
+{
+    protected NamespaceStepBase(
+        int id,
+        string name,
+        FailurePolicy failurePolicy,
+        IReadOnlyList<int>? dependsOn = null,
+        bool requiresAiConfiguration = false,
+        bool createsFilteredCliView = false,
+        bool usesIsolatedWorkspace = false,
+        IReadOnlyList<string>? expectedOutputs = null)
+        : base(
+            id,
+            name,
+            StepScope.Namespace,
+            failurePolicy,
+            dependsOn,
+            requiresAiConfiguration: requiresAiConfiguration,
+            createsFilteredCliView: createsFilteredCliView,
+            usesIsolatedWorkspace: usesIsolatedWorkspace,
+            expectedOutputs: expectedOutputs)
+    {
+    }
+
+    protected (string CurrentNamespace, CliMetadataSnapshot CliOutput, string CliVersion, IReadOnlyList<CliTool> MatchingTools) ResolveTarget(PipelineContext context)
+    {
+        var currentNamespace = GetCurrentNamespace(context);
+        var cliOutput = context.CliOutput ?? throw new InvalidOperationException("CLI metadata must be loaded before executing namespace steps.");
+        var cliVersion = context.CliVersion;
+        if (string.IsNullOrWhiteSpace(cliVersion))
+        {
+            throw new InvalidOperationException("CLI version metadata must be loaded before executing namespace steps.");
+        }
+
+        var matchingTools = context.TargetMatcher.FindMatches(cliOutput.Tools, currentNamespace);
+        return (currentNamespace, cliOutput, cliVersion, matchingTools);
+    }
+
+    protected static string GetCurrentNamespace(PipelineContext context)
+    {
+        if (!context.Items.TryGetValue("Namespace", out var namespaceValue) || namespaceValue is not string currentNamespace)
+        {
+            throw new InvalidOperationException("Namespace-scoped steps require a current namespace in the pipeline context.");
+        }
+
+        return context.TargetMatcher.Normalize(currentNamespace);
+    }
+
+    protected static string GetProjectPath(PipelineContext context, string projectName)
+        => Path.Combine(context.DocsGenerationRoot, projectName, $"{projectName}.csproj");
+
+    protected ValueTask<FilteredCliFileHandle> CreateFilteredCliFileAsync(
+        PipelineContext context,
+        CliMetadataSnapshot cliOutput,
+        IReadOnlyList<CliTool> matchingTools,
+        string tempDirectoryName,
+        CancellationToken cancellationToken)
+        => context.FilteredCliWriter.WriteAsync(cliOutput, matchingTools, tempDirectoryName, cancellationToken);
+
+    protected static bool PathHasContent(string path)
+        => File.Exists(path)
+            || (Directory.Exists(path) && Directory.EnumerateFileSystemEntries(path).Any());
+
+    protected static void EnsurePathHasContent(string path, string description, ICollection<string> issues)
+    {
+        if (!PathHasContent(path))
+        {
+            issues.Add($"Expected {description} at '{path}'.");
+        }
+    }
+
+    protected static void AddProcessIssue(ProcessExecutionResult processResult, ICollection<string> warnings, string summary)
+    {
+        warnings.Add($"{summary} (exit code {processResult.ExitCode}).");
+        if (!string.IsNullOrWhiteSpace(processResult.StandardError))
+        {
+            warnings.Add(processResult.StandardError.Trim());
+        }
+    }
+
+    protected StepResult BuildResult(
+        PipelineContext context,
+        IReadOnlyCollection<ProcessExecutionResult> processResults,
+        bool success,
+        IEnumerable<string>? warnings = null,
+        IEnumerable<ValidatorResult>? validatorResults = null)
+    {
+        var resolvedWarnings = warnings?
+            .Where(static warning => !string.IsNullOrWhiteSpace(warning))
+            .ToArray() ?? Array.Empty<string>();
+        var resolvedValidators = validatorResults?.ToArray() ?? Array.Empty<ValidatorResult>();
+        var outputs = ExpectedOutputs
+            .Select(relativePath => Path.Combine(context.OutputPath, relativePath))
+            .ToArray();
+
+        var duration = TimeSpan.FromTicks(processResults.Sum(result => result.Duration.Ticks));
+        var commands = processResults.Select(result => result.DisplayCommand).ToArray();
+
+        return new StepResult(success, resolvedWarnings, duration, outputs, commands, resolvedValidators);
+    }
+}

--- a/docs-generation/PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
@@ -1,0 +1,99 @@
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public sealed class ToolGenerationStep : NamespaceStepBase
+{
+    private const int DefaultMaxTokens = 8000;
+
+    public ToolGenerationStep()
+        : base(
+            3,
+            "Compose and improve tool files",
+            FailurePolicy.Fatal,
+            dependsOn: [1, 2],
+            requiresAiConfiguration: true,
+            createsFilteredCliView: true,
+            expectedOutputs: ["tools-composed", "tools"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+    {
+        var (_, cliOutput, _, matchingTools) = ResolveTarget(context);
+        _ = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step3", cancellationToken);
+
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var rawToolsDirectory = Path.Combine(context.OutputPath, "tools-raw");
+        var composedToolsDirectory = Path.Combine(context.OutputPath, "tools-composed");
+        var improvedToolsDirectory = Path.Combine(context.OutputPath, "tools");
+        var annotationsDirectory = Path.Combine(context.OutputPath, "annotations");
+        var parametersDirectory = Path.Combine(context.OutputPath, "parameters");
+        var examplePromptsDirectory = Path.Combine(context.OutputPath, "example-prompts");
+
+        var missingPrerequisites = new List<string>();
+        EnsurePathHasContent(rawToolsDirectory, "raw tool prerequisites", missingPrerequisites);
+        EnsurePathHasContent(annotationsDirectory, "annotation prerequisites", missingPrerequisites);
+        EnsurePathHasContent(parametersDirectory, "parameter prerequisites", missingPrerequisites);
+        EnsurePathHasContent(examplePromptsDirectory, "example prompt prerequisites", missingPrerequisites);
+        if (missingPrerequisites.Count > 0)
+        {
+            return BuildResult(context, processResults, false, missingPrerequisites);
+        }
+
+        var composedResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            GetProjectPath(context, "ToolGeneration_Composed"),
+            [
+                rawToolsDirectory,
+                composedToolsDirectory,
+                annotationsDirectory,
+                parametersDirectory,
+                examplePromptsDirectory,
+            ],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(composedResult);
+        if (!composedResult.Succeeded)
+        {
+            AddProcessIssue(composedResult, warnings, "Composed tool generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        if (!PathHasContent(composedToolsDirectory))
+        {
+            warnings.Add($"Expected composed tool output at '{composedToolsDirectory}'.");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var improvedResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            GetProjectPath(context, "ToolGeneration_Improved"),
+            [composedToolsDirectory, improvedToolsDirectory, DefaultMaxTokens.ToString()],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(improvedResult);
+        if (!improvedResult.Succeeded)
+        {
+            AddProcessIssue(improvedResult, warnings, "AI-improved tool generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        if (!context.Request.SkipValidation)
+        {
+            var outputIssues = new List<string>();
+            EnsurePathHasContent(composedToolsDirectory, "composed tool output", outputIssues);
+            EnsurePathHasContent(improvedToolsDirectory, "improved tool output", outputIssues);
+            warnings.AddRange(outputIssues);
+            if (outputIssues.Count > 0)
+            {
+                return BuildResult(context, processResults, false, warnings);
+            }
+        }
+
+        return BuildResult(context, processResults, true, warnings);
+    }
+}


### PR DESCRIPTION
## Summary
- replace ShimStep with typed C# step implementations for PipelineRunner steps 1, 2, 3, and 6
- register the typed steps, add shared namespace-step helpers, and update process-runner test doubles to match real dotnet invocation shapes
- add unit coverage for each typed step plus default registry coverage for the Phase 2 step mix

## Validation
- dotnet build docs-generation.sln --configuration Release --nologo -clp:Summary
- dotnet test docs-generation.sln --configuration Release --no-build --nologo -clp:Summary

## Results
- build succeeded with 0 warnings
- tests passed: 610/610