### PR TITLE
feat: port PipelineRunner Step 5 to typed C#

### DIFF
--- a/docs-generation/PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
@@ -35,14 +35,16 @@ public class DryRunIntegrationTests
                 StepRegistry.CreateDefault(Path.Combine(repoRoot, "docs-generation", "scripts")),
                 contextFactory);
 
-            var request = new PipelineRequest("compute", new[] { 1, 2, 3, 4 }, ".\\generated-compute", false, false, true);
+            var request = new PipelineRequest("compute", new[] { 1, 2, 3, 4, 5, 6 }, ".\\generated-compute", false, false, true);
             var exitCode = await runner.RunAsync(request, CancellationToken.None);
 
             Assert.Equal(0, exitCode);
             Assert.Empty(processRunner.Invocations);
             Assert.Contains(reportWriter.Messages, message => message.Contains("Dry run plan", StringComparison.Ordinal));
-            Assert.Contains(reportWriter.Messages, message => message.Contains("Step 1", StringComparison.Ordinal));
+            Assert.Contains(reportWriter.Messages, message => message.Contains("Step 1: Generate annotations, parameters, and raw tools [Namespace, Fatal, Typed]", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("Step 4: Generate tool-family article [Namespace, Fatal, Typed]", StringComparison.Ordinal));
+            Assert.Contains(reportWriter.Messages, message => message.Contains("Step 5: Generate skills relevance [Namespace, Warn, Typed]", StringComparison.Ordinal));
+            Assert.Contains(reportWriter.Messages, message => message.Contains("Step 6: Generate horizontal article [Namespace, Fatal, Typed]", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("Post-validators: ToolFamilyPostAssemblyValidator", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("Dependency check: passed", StringComparison.Ordinal));
         }

--- a/docs-generation/PipelineRunner.Tests/Unit/NamespaceStepTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/NamespaceStepTests.cs
@@ -112,6 +112,61 @@ public class NamespaceStepTests
     }
 
     [Fact]
+    public async Task Step5_SkillsRelevance_UsesExpectedGeneratorArguments()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list", "compute show"]);
+            context.Items["Namespace"] = "compute";
+
+            var skillsOutputDirectory = Path.Combine(context.OutputPath, "skills-relevance");
+            SeedFile(Path.Combine(skillsOutputDirectory, "compute-skills-relevance.md"));
+
+            var step = new SkillsRelevanceStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Single(runner.Invocations);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("SkillsRelevance.csproj", StringComparison.Ordinal));
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "compute");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--output-path");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == skillsOutputDirectory);
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--min-score");
+            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "0.1");
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step5_SkillsRelevance_FailureReturnsWarningsWithoutThrowing()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new FailingProcessRunner(7, "GitHub API rate limited");
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list", "compute show"]);
+            context.Items["Namespace"] = "compute";
+
+            var step = new SkillsRelevanceStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Single(runner.Invocations);
+            Assert.Contains(result.Warnings, warning => warning.Contains("Skills relevance generation failed (exit code 7).", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning => warning.Contains("GitHub API rate limited", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task Step6_HorizontalArticles_UsesExpectedGeneratorArguments()
     {
         var testRoot = CreateTestRoot();
@@ -215,5 +270,57 @@ public class NamespaceStepTests
         {
             Directory.Delete(path, recursive: true);
         }
+    }
+
+    private sealed class FailingProcessRunner : IProcessRunner
+    {
+        private readonly int _exitCode;
+        private readonly string _standardError;
+
+        public FailingProcessRunner(int exitCode, string standardError)
+        {
+            _exitCode = exitCode;
+            _standardError = standardError;
+        }
+
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
+        {
+            Invocations.Add(spec);
+            return ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, _exitCode, string.Empty, _standardError, TimeSpan.Zero));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken cancellationToken)
+            => RunAsync(
+                new ProcessSpec(
+                    "dotnet",
+                    ["build", solutionPath, "--configuration", "Release", "--verbosity", "quiet"],
+                    Path.GetDirectoryName(solutionPath) ?? Environment.CurrentDirectory),
+                cancellationToken);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken cancellationToken)
+        {
+            var invocation = new List<string>
+            {
+                "run",
+                "--project",
+                projectPath,
+                "--configuration",
+                "Release",
+            };
+
+            if (noBuild)
+            {
+                invocation.Add("--no-build");
+            }
+
+            invocation.Add("--");
+            invocation.AddRange(arguments);
+            return RunAsync(new ProcessSpec("dotnet", invocation, workingDirectory), cancellationToken);
+        }
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);
     }
 }

--- a/docs-generation/PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
@@ -33,14 +33,19 @@ public class PipelineRunnerPostValidatorTests
                 reportWriter,
                 repoRoot);
 
-            var runner = new global::PipelineRunner.PipelineRunner(
-                new StepRegistry([new FakeStep(new FixedValidator(success: false, warnings: ["validator failed"]))]),
-                contextFactory);
+            var step = new RecordingStep(
+                id: 4,
+                name: "Generate tool-family article",
+                failurePolicy: FailurePolicy.Fatal,
+                success: true,
+                postValidators: [new FixedValidator(success: false, warnings: ["validator failed"])]);
+            var runner = new global::PipelineRunner.PipelineRunner(new StepRegistry([step]), contextFactory);
 
             var request = new PipelineRequest("compute", [4], ".\\generated-compute", SkipBuild: true, SkipValidation: false, DryRun: false);
             var exitCode = await runner.RunAsync(request, CancellationToken.None);
 
             Assert.Equal(global::PipelineRunner.PipelineRunner.FatalExitCode, exitCode);
+            Assert.Equal(1, step.Executions);
             Assert.Contains(reportWriter.Messages, message => message.Contains("Validator: FixedValidator", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("validator failed", StringComparison.Ordinal));
         }
@@ -50,15 +55,81 @@ public class PipelineRunnerPostValidatorTests
         }
     }
 
-    private sealed class FakeStep : StepDefinition
+    [Fact]
+    public async Task RunAsync_WarnFailureContinuesToLaterSteps()
     {
-        public FakeStep(IPostValidator validator)
-            : base(4, "Generate tool-family article", StepScope.Namespace, FailurePolicy.Fatal, postValidators: [validator])
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-warn-hook-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "docs-generation", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "docs-generation.sln"), string.Empty);
+
+        try
         {
+            var processRunner = new RecordingProcessRunner();
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                processRunner,
+                new WorkspaceManager(),
+                new StaticCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            var warnStep = new RecordingStep(
+                id: 5,
+                name: "Generate skills relevance",
+                failurePolicy: FailurePolicy.Warn,
+                success: false,
+                warnings: ["skills relevance generation failed"]);
+            var nextStep = new RecordingStep(
+                id: 6,
+                name: "Generate horizontal article",
+                failurePolicy: FailurePolicy.Fatal,
+                success: true);
+            var runner = new global::PipelineRunner.PipelineRunner(new StepRegistry([warnStep, nextStep]), contextFactory);
+
+            var request = new PipelineRequest("compute", [5, 6], ".\\generated-compute", SkipBuild: true, SkipValidation: false, DryRun: false);
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(1, warnStep.Executions);
+            Assert.Equal(1, nextStep.Executions);
+            Assert.Contains(reportWriter.Messages, message => message.Contains("skills relevance generation failed", StringComparison.Ordinal));
+            Assert.Contains(reportWriter.Messages, message => message.Contains("Pipeline completed with 1 warning(s).", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private sealed class RecordingStep : StepDefinition
+    {
+        private readonly bool _success;
+        private readonly IReadOnlyList<string> _warnings;
+
+        public RecordingStep(
+            int id,
+            string name,
+            FailurePolicy failurePolicy,
+            bool success,
+            IReadOnlyList<string>? warnings = null,
+            IReadOnlyList<IPostValidator>? postValidators = null)
+            : base(id, name, StepScope.Namespace, failurePolicy, postValidators: postValidators)
+        {
+            _success = success;
+            _warnings = warnings ?? Array.Empty<string>();
         }
 
+        public int Executions { get; private set; }
+
         public override ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
-            => ValueTask.FromResult(new StepResult(true, Array.Empty<string>(), TimeSpan.Zero, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<ValidatorResult>()));
+        {
+            Executions++;
+            return ValueTask.FromResult(new StepResult(_success, _warnings, TimeSpan.Zero, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<ValidatorResult>()));
+        }
     }
 
     private sealed class FixedValidator(bool success, IReadOnlyList<string> warnings) : IPostValidator

--- a/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
@@ -44,7 +44,7 @@ public class StepRegistryTests
     }
 
     [Fact]
-    public void CreateDefault_RegistersTypedPhaseThreeSteps()
+    public void CreateDefault_RegistersAllStandardStepsAsTypedImplementations()
     {
         var scriptsRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-scripts-{Guid.NewGuid():N}");
         Directory.CreateDirectory(scriptsRoot);
@@ -57,8 +57,9 @@ public class StepRegistryTests
             Assert.IsType<ExamplePromptsStep>(registry.GetStep(2));
             Assert.IsType<ToolGenerationStep>(registry.GetStep(3));
             Assert.IsType<ToolFamilyCleanupStep>(registry.GetStep(4));
-            Assert.IsType<ShimStep>(registry.GetStep(5));
+            Assert.IsType<SkillsRelevanceStep>(registry.GetStep(5));
             Assert.IsType<HorizontalArticlesStep>(registry.GetStep(6));
+            Assert.DoesNotContain(registry.GetAllSteps(), step => step is ShimStep);
         }
         finally
         {

--- a/docs-generation/PipelineRunner/Registry/StepRegistry.cs
+++ b/docs-generation/PipelineRunner/Registry/StepRegistry.cs
@@ -30,7 +30,7 @@ public sealed class StepRegistry
             new ExamplePromptsStep(),
             new ToolGenerationStep(),
             new ToolFamilyCleanupStep(),
-            new ShimStep(5, "Generate skills relevance", FailurePolicy.Warn, Path.Combine(scriptsRoot, "5-Generate-SkillsRelevance-One.ps1"), "ServiceArea", expectedOutputs: ["skills-relevance"]),
+            new SkillsRelevanceStep(),
             new HorizontalArticlesStep(),
         ]);
 

--- a/docs-generation/PipelineRunner/Steps/Namespace/SkillsRelevanceStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/SkillsRelevanceStep.cs
@@ -1,0 +1,59 @@
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+public sealed class SkillsRelevanceStep : NamespaceStepBase
+{
+    private const string DefaultMinScore = "0.1";
+
+    public SkillsRelevanceStep()
+        : base(
+            5,
+            "Generate skills relevance",
+            FailurePolicy.Warn,
+            expectedOutputs: ["skills-relevance"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+    {
+        var currentNamespace = GetCurrentNamespace(context);
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var skillsOutputDirectory = Path.Combine(context.OutputPath, "skills-relevance");
+
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_TOKEN")))
+        {
+            warnings.Add("GITHUB_TOKEN not set. Unauthenticated GitHub API rate limits (60 req/hr) apply.");
+        }
+
+        var processResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            GetProjectPath(context, "SkillsRelevance"),
+            [
+                currentNamespace,
+                "--output-path", skillsOutputDirectory,
+                "--min-score", DefaultMinScore,
+            ],
+            context.Request.SkipBuild,
+            context.DocsGenerationRoot,
+            cancellationToken);
+        processResults.Add(processResult);
+
+        if (!processResult.Succeeded)
+        {
+            AddProcessIssue(processResult, warnings, "Skills relevance generation failed");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        var reportPath = Path.Combine(skillsOutputDirectory, $"{currentNamespace}-skills-relevance.md");
+        if (!File.Exists(reportPath))
+        {
+            warnings.Add($"Expected skills relevance output at '{reportPath}'.");
+            return BuildResult(context, processResults, false, warnings);
+        }
+
+        return BuildResult(context, processResults, true, warnings);
+    }
+}

--- a/docs-generation/scripts/README.md
+++ b/docs-generation/scripts/README.md
@@ -1,60 +1,113 @@
 # docs-generation/scripts
 
-Scripts for the Azure MCP documentation generation pipeline and related development tooling.
+Scripts and entry points for the Azure MCP documentation generation pipeline.
 
 ## Directory structure
 
 ```
 scripts/
-├── (root)          # Active pipeline scripts called from start.sh
-├── standalone/     # Individual generator scripts for running a single step
+├── (root)          # Thin entry wrappers + manual/fallback step scripts
+├── standalone/     # Individual generator scripts for direct execution
 └── utilities/      # Dev, debug, testing, and CI helpers
 ```
 
-## Active pipeline scripts (root)
+## Standard execution path
 
-These scripts form the current generation flow invoked by the root `start.sh` orchestrator:
+The standard pipeline path is now:
 
 ```
 start.sh
-├── preflight.ps1                                         # One-time setup (build, CLI metadata, env + brand validation)
-│   ├── validate-env.ps1                                  # Validates .env for Azure OpenAI-backed steps
-│   └── 0-Validate-BrandMappings.ps1                      # Validates brand-to-server-mapping.json
-└── start-only.sh                                         # Worker: processes one namespace/family
-    └── Generate-ToolFamily.ps1                           # Per-namespace orchestrator (core Steps 1-4, optional Steps 5-6)
-        ├── Invoke-CliAnalyzer.ps1                        # Runs CliAnalyzer on CLI JSON
-        ├── 1-Generate-AnnotationsParametersRaw-One.ps1   # Step 1: annotations, parameters, raw tools
-        ├── 2-Generate-ExamplePrompts-One.ps1             # Step 2: example prompts + validation
-        ├── 3-Generate-ToolGenerationAndAIImprovements-One.ps1 # Step 3: composed + AI-improved tools
-        ├── 4-Generate-ToolFamilyCleanup-One.ps1          # Step 4: tool family assembly
-        ├── Validate-ToolFamily-PostAssembly.ps1          # Step 4 sub-step: post-assembly validation
-        ├── 5-Generate-SkillsRelevance-One.ps1            # Step 5: skills relevance report
-        └── 6-Generate-HorizontalArticles-One.ps1         # Step 6: horizontal how-to articles
+└── docs-generation/PipelineRunner/PipelineRunner.csproj
+    ├── preflight.ps1                                # bootstrap: env, build, CLI metadata, brand validation
+    └── typed C# namespace steps (Steps 1-6)
+        ├── AnnotationsParametersRawStep             # Step 1
+        ├── ExamplePromptsStep                       # Step 2
+        ├── ToolGenerationStep                       # Step 3
+        ├── ToolFamilyCleanupStep                    # Step 4
+        ├── SkillsRelevanceStep                      # Step 5
+        └── HorizontalArticlesStep                   # Step 6
 ```
 
-### Pipeline step model
+All six standard steps are now typed C# classes under `docs-generation/PipelineRunner/Steps/Namespace/`.
+The numbered `*-One.ps1` scripts remain in the repo as reference, fallback, and ad-hoc/manual execution helpers, but they are no longer in the standard `start.sh` execution path.
 
-- **Core pipeline:** Steps 1-4
-- **Step 4 validation:** `Validate-ToolFamily-PostAssembly.ps1` runs automatically inside Step 4
-- **Supplementary outputs:** Step 5 (skills relevance) and Step 6 (horizontal articles)
+### Typed standard steps
 
-### Script details
+| Step | Typed class | Generator(s) invoked | Failure policy | Primary outputs |
+|---|---|---|---|---|
+| 1 | `AnnotationsParametersRawStep` | `CSharpGenerator`, `ToolGeneration_Raw` | Fatal | `annotations/`, `parameters/`, `tools-raw/` |
+| 2 | `ExamplePromptsStep` | `ExamplePromptGeneratorStandalone`, `ExamplePromptValidator` | Fatal | `example-prompts/`, `example-prompts-prompts/`, `example-prompts-raw-output/` |
+| 3 | `ToolGenerationStep` | `ToolGeneration_Composed`, `ToolGeneration_Improved` | Fatal | `tools-composed/`, `tools/` |
+| 4 | `ToolFamilyCleanupStep` | `ToolFamilyCleanup` + typed post-validator | Fatal | `tool-family-metadata/`, `tool-family-related/`, `tool-family/`, `reports/` |
+| 5 | `SkillsRelevanceStep` | `SkillsRelevance` | Warn | `skills-relevance/` |
+| 6 | `HorizontalArticlesStep` | `HorizontalArticleGenerator` | Fatal | `horizontal-articles/` |
 
-| Script | Purpose |
+Step 5 remains warning-only by design: skills relevance is supplementary and must not halt the main pipeline.
+
+## PipelineRunner CLI
+
+Run the typed runner from the repo root:
+
+```bash
+dotnet run --project docs-generation/PipelineRunner/PipelineRunner.csproj -- --namespace compute --steps 1,2,3,4,5,6 --output ./generated-compute
+```
+
+### Supported options
+
+| Option | Meaning |
 |---|---|
-| `preflight.ps1` | One-time setup: validates environment, builds the .NET solution, generates CLI metadata, and runs brand validation |
-| `validate-env.ps1` | Checks `.env` has the Azure OpenAI credentials required for Steps 2, 3, 4, and 6 |
-| `0-Validate-BrandMappings.ps1` | Validates `brand-to-server-mapping.json` consistency with CLI namespaces before the numbered steps run |
-| `start-only.sh` | Worker script that processes a single namespace/family; called by `start.sh` in a loop |
-| `Generate-ToolFamily.ps1` | Main per-namespace orchestrator running core Steps 1-4, then optional Steps 5-6 |
-| `Invoke-CliAnalyzer.ps1` | Runs the CliAnalyzer .NET project to extract tool metadata from CLI JSON |
-| `1-Generate-AnnotationsParametersRaw-One.ps1` | Step 1: generates annotation, parameter, and raw tool include files for one namespace/family |
-| `2-Generate-ExamplePrompts-One.ps1` | Step 2: generates AI example prompts and validates them for one namespace/family |
-| `3-Generate-ToolGenerationAndAIImprovements-One.ps1` | Step 3: runs ToolGeneration_Composed and ToolGeneration_Improved for one namespace/family |
-| `4-Generate-ToolFamilyCleanup-One.ps1` | Step 4: assembles tool-family files with AI metadata for one namespace/family |
-| `Validate-ToolFamily-PostAssembly.ps1` | Step 4 sub-step: validates the assembled tool-family article and report output |
-| `5-Generate-SkillsRelevance-One.ps1` | Step 5: generates GitHub Copilot skills relevance reports for one namespace/family |
-| `6-Generate-HorizontalArticles-One.ps1` | Step 6: generates horizontal how-to articles using AI for one namespace/family |
+| `--namespace <name>` | Run a single namespace/service area. Omit to process all namespaces discovered from CLI metadata. |
+| `--steps <csv>` | Comma-separated step list. Default: `1,2,3,4,5,6`. |
+| `--output <path>` | Output directory. Defaults to `./generated` or `./generated-<namespace>`. |
+| `--skip-build` | Reuse existing Release outputs and skip build work. |
+| `--skip-validation` | Skip validation behavior that is modeled in the runner/steps. |
+| `--dry-run` | Print the resolved plan, including step names, scopes, failure policies, and implementation type, without running bootstrap or generators. |
+
+### Example commands
+
+```bash
+# Full typed plan for one namespace without running generators
+dotnet run --project docs-generation/PipelineRunner/PipelineRunner.csproj -- --namespace compute --dry-run
+
+# Run only the core documentation pipeline
+dotnet run --project docs-generation/PipelineRunner/PipelineRunner.csproj -- --namespace compute --steps 1,2,3,4
+
+# Run only supplementary outputs after core content already exists
+dotnet run --project docs-generation/PipelineRunner/PipelineRunner.csproj -- --namespace compute --steps 5,6 --skip-build
+```
+
+## `start.sh` backward compatibility
+
+`start.sh` remains the operator-facing shell entry point and preserves the existing positional workflow:
+
+```bash
+./start.sh                # all namespaces, all 6 steps
+./start.sh compute        # one namespace, all 6 steps
+./start.sh compute 1,2,3  # one namespace, selected steps
+./start.sh 1,2,3          # all namespaces, selected steps
+```
+
+Compatibility notes:
+
+- `start.sh` now delegates to `PipelineRunner` instead of `Generate-ToolFamily.ps1`.
+- If the first argument starts with `-`, `start.sh` passes all arguments through directly to `PipelineRunner`.
+- The numbered PowerShell wrappers stay available for manual runs, but the supported day-to-day path is `start.sh` → `PipelineRunner`.
+
+## Root scripts
+
+| Script | Current role |
+|---|---|
+| `preflight.ps1` | Still used by `PipelineRunner` bootstrap for environment checks, build coordination, CLI metadata, and brand validation |
+| `validate-env.ps1` | Validates `.env` for Azure OpenAI-backed steps |
+| `0-Validate-BrandMappings.ps1` | Validates `brand-to-server-mapping.json` consistency with CLI namespaces |
+| `Generate-ToolFamily.ps1` | Legacy/manual PowerShell orchestrator retained for reference and fallback |
+| `1-Generate-AnnotationsParametersRaw-One.ps1` | Legacy/manual Step 1 wrapper retained for reference and fallback |
+| `2-Generate-ExamplePrompts-One.ps1` | Legacy/manual Step 2 wrapper retained for reference and fallback |
+| `3-Generate-ToolGenerationAndAIImprovements-One.ps1` | Legacy/manual Step 3 wrapper retained for reference and fallback |
+| `4-Generate-ToolFamilyCleanup-One.ps1` | Legacy/manual Step 4 wrapper retained for reference and fallback |
+| `5-Generate-SkillsRelevance-One.ps1` | Legacy/manual Step 5 wrapper retained for reference and fallback |
+| `6-Generate-HorizontalArticles-One.ps1` | Legacy/manual Step 6 wrapper retained for reference and fallback |
+| `Invoke-CliAnalyzer.ps1` | Manual helper for CLI analyzer generation |
 
 ## standalone/
 


### PR DESCRIPTION
## Summary
- port PipelineRunner Step 5 to a typed `SkillsRelevanceStep` with `FailurePolicy.Warn`
- register all 6 standard pipeline steps as typed C# classes and keep `ShimStep` only for future custom/ad-hoc use
- update the pipeline scripts README to document the `start.sh` -> `PipelineRunner` architecture, CLI options, and compatibility notes

## Testing
- `dotnet build docs-generation.sln`
- `dotnet test docs-generation.sln` (**620 passed, 0 failed**)
- `dotnet run --project docs-generation/PipelineRunner/PipelineRunner.csproj -- --namespace compute --dry-run`

## Dry-run plan
```text
Dry run plan:
  Output: C:\Users\diberry\repos\project-azure-mcp-server\microsoft-mcp-doc-generation\generated-compute
  Namespaces: compute
  Step 1: Generate annotations, parameters, and raw tools [Namespace, Fatal, Typed]
  Step 2: Generate example prompts [Namespace, Fatal, Typed]
    Depends on: 1
  Step 3: Compose and improve tool files [Namespace, Fatal, Typed]
    Depends on: 1, 2
  Step 4: Generate tool-family article [Namespace, Fatal, Typed]
    Depends on: 3
    Post-validators: ToolFamilyPostAssemblyValidator
  Step 5: Generate skills relevance [Namespace, Warn, Typed]
  Step 6: Generate horizontal article [Namespace, Fatal, Typed]
  Dependency check: passed
```