### PR TITLE
Fix tool-count reliability: deterministic count + validation retry

### DIFF
--- a/docs-generation/PipelineRunner.Tests/Integration/ToolFamilyValidatorIntegrationTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Integration/ToolFamilyValidatorIntegrationTests.cs
@@ -71,6 +71,7 @@ public class ToolFamilyValidatorIntegrationTests
         public global::PipelineRunner.Contracts.FailurePolicy FailurePolicy => global::PipelineRunner.Contracts.FailurePolicy.Fatal;
         public IReadOnlyList<int> DependsOn => Array.Empty<int>();
         public IReadOnlyList<global::PipelineRunner.Contracts.IPostValidator> PostValidators => Array.Empty<global::PipelineRunner.Contracts.IPostValidator>();
+        public int MaxRetries => 0;
         public ValueTask<global::PipelineRunner.Contracts.StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
             => ValueTask.FromResult(global::PipelineRunner.Contracts.StepResult.DryRun(Array.Empty<string>()));
     }

--- a/docs-generation/PipelineRunner.Tests/PipelineRunner.Tests.csproj
+++ b/docs-generation/PipelineRunner.Tests/PipelineRunner.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PipelineRunner\PipelineRunner.csproj" />
+    <ProjectReference Include="..\ToolFamilyCleanup\ToolFamilyCleanup.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs-generation/PipelineRunner.Tests/Unit/FamilyMetadataGeneratorTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/FamilyMetadataGeneratorTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class FamilyMetadataGeneratorTests
+{
+    [Fact]
+    public void EnsureCorrectToolCount_FixesIncorrectLlmCount()
+    {
+        // Arrange
+        var metadata = @"---
+title: Azure Compute Operations
+description: Manage Azure Virtual Machines and compute resources
+ms.service: azure
+ms.topic: reference
+tool_count: 8
+---
+
+# Azure Compute Operations
+
+Manage and monitor Azure Virtual Machines, scale sets, and compute resources.";
+
+        var actualToolCount = 9;
+
+        // Act
+        var result = InvokeEnsureCorrectToolCount(metadata, actualToolCount);
+
+        // Assert
+        Assert.Contains("tool_count: 9", result);
+        Assert.DoesNotContain("tool_count: 8", result);
+    }
+
+    [Fact]
+    public void EnsureCorrectToolCount_HandlesVariousWhitespace()
+    {
+        // Arrange
+        var metadata = @"---
+title: Test
+tool_count:    15
+---";
+
+        var actualToolCount = 20;
+
+        // Act
+        var result = InvokeEnsureCorrectToolCount(metadata, actualToolCount);
+
+        // Assert
+        Assert.Contains("tool_count: 20", result);
+        Assert.DoesNotContain("tool_count:    15", result);
+    }
+
+    [Fact]
+    public void EnsureCorrectToolCount_PreservesOtherFrontmatter()
+    {
+        // Arrange
+        var metadata = @"---
+title: Azure SQL Operations
+description: Manage Azure SQL databases and servers
+ms.service: azure-sql
+ms.topic: reference
+tool_count: 12
+author: Test Author
+---
+
+# Azure SQL Operations
+
+Content here.";
+
+        var actualToolCount = 15;
+
+        // Act
+        var result = InvokeEnsureCorrectToolCount(metadata, actualToolCount);
+
+        // Assert
+        Assert.Contains("title: Azure SQL Operations", result);
+        Assert.Contains("description: Manage Azure SQL databases and servers", result);
+        Assert.Contains("ms.service: azure-sql", result);
+        Assert.Contains("ms.topic: reference", result);
+        Assert.Contains("tool_count: 15", result);
+        Assert.Contains("author: Test Author", result);
+        Assert.Contains("# Azure SQL Operations", result);
+    }
+
+    [Fact]
+    public void EnsureCorrectToolCount_HandlesNoToolCountInMetadata()
+    {
+        // Arrange
+        var metadata = @"---
+title: Test
+---
+
+# Content";
+
+        var actualToolCount = 10;
+
+        // Act
+        var result = InvokeEnsureCorrectToolCount(metadata, actualToolCount);
+
+        // Assert - Should not crash, just return original
+        Assert.Equal(metadata, result);
+    }
+
+    [Fact]
+    public void EnsureCorrectToolCount_HandlesEmptyString()
+    {
+        // Arrange
+        var metadata = "";
+        var actualToolCount = 5;
+
+        // Act
+        var result = InvokeEnsureCorrectToolCount(metadata, actualToolCount);
+
+        // Assert
+        Assert.Equal("", result);
+    }
+
+    /// <summary>
+    /// Uses reflection to invoke the private static EnsureCorrectToolCount method.
+    /// This is necessary because the method is private in FamilyMetadataGenerator.
+    /// </summary>
+    private static string InvokeEnsureCorrectToolCount(string metadata, int actualToolCount)
+    {
+        var generatorType = Type.GetType("ToolFamilyCleanup.Services.FamilyMetadataGenerator, ToolFamilyCleanup");
+        if (generatorType == null)
+        {
+            throw new InvalidOperationException("Could not load FamilyMetadataGenerator type");
+        }
+
+        var method = generatorType.GetMethod(
+            "EnsureCorrectToolCount",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            null,
+            new[] { typeof(string), typeof(int) },
+            null);
+
+        if (method == null)
+        {
+            throw new InvalidOperationException("Could not find EnsureCorrectToolCount method");
+        }
+
+        var result = method.Invoke(null, new object[] { metadata, actualToolCount });
+        return result?.ToString() ?? string.Empty;
+    }
+}

--- a/docs-generation/PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
@@ -56,6 +56,97 @@ public class PipelineRunnerPostValidatorTests
     }
 
     [Fact]
+    public async Task RunAsync_PostValidatorFailure_RetriesStepWithMaxRetries()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-retry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "docs-generation", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "docs-generation.sln"), string.Empty);
+
+        try
+        {
+            var processRunner = new RecordingProcessRunner();
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                processRunner,
+                new WorkspaceManager(),
+                new StaticCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            // Step with maxRetries=2 and validator that always fails
+            var step = new RecordingStep(
+                id: 4,
+                name: "Generate tool-family article",
+                failurePolicy: FailurePolicy.Fatal,
+                success: true,
+                maxRetries: 2,
+                postValidators: [new FixedValidator(success: false, warnings: ["validator failed"])]);
+            var runner = new global::PipelineRunner.PipelineRunner(new StepRegistry([step]), contextFactory);
+
+            var request = new PipelineRequest("compute", [4], ".\\generated-compute", SkipBuild: true, SkipValidation: false, DryRun: false);
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.FatalExitCode, exitCode);
+            Assert.Equal(3, step.Executions); // 1 initial + 2 retries = 3 total attempts
+            Assert.Contains(reportWriter.Messages, message => message.Contains("Retry attempt", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_PostValidatorFailure_SucceedsOnRetry()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-retry-success-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "docs-generation", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "docs-generation.sln"), string.Empty);
+
+        try
+        {
+            var processRunner = new RecordingProcessRunner();
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                processRunner,
+                new WorkspaceManager(),
+                new StaticCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            // Validator that fails first time but succeeds on second attempt
+            var validator = new CountingValidator(failUntilAttempt: 2);
+            var step = new RecordingStep(
+                id: 4,
+                name: "Generate tool-family article",
+                failurePolicy: FailurePolicy.Fatal,
+                success: true,
+                maxRetries: 2,
+                postValidators: [validator]);
+            var runner = new global::PipelineRunner.PipelineRunner(new StepRegistry([step]), contextFactory);
+
+            var request = new PipelineRequest("compute", [4], ".\\generated-compute", SkipBuild: true, SkipValidation: false, DryRun: false);
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(2, step.Executions); // Initial attempt + 1 retry
+            Assert.Equal(2, validator.Attempts);
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RunAsync_WarnFailureContinuesToLaterSteps()
     {
         var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-warn-hook-{Guid.NewGuid():N}");
@@ -116,8 +207,9 @@ public class PipelineRunnerPostValidatorTests
             FailurePolicy failurePolicy,
             bool success,
             IReadOnlyList<string>? warnings = null,
-            IReadOnlyList<IPostValidator>? postValidators = null)
-            : base(id, name, StepScope.Namespace, failurePolicy, postValidators: postValidators)
+            IReadOnlyList<IPostValidator>? postValidators = null,
+            int maxRetries = 0)
+            : base(id, name, StepScope.Namespace, failurePolicy, postValidators: postValidators, maxRetries: maxRetries)
         {
             _success = success;
             _warnings = warnings ?? Array.Empty<string>();
@@ -138,6 +230,28 @@ public class PipelineRunnerPostValidatorTests
 
         public ValueTask<ValidatorResult> ValidateAsync(PipelineContext context, IPipelineStep step, CancellationToken cancellationToken)
             => ValueTask.FromResult(new ValidatorResult(Name, success, warnings));
+    }
+
+    private sealed class CountingValidator : IPostValidator
+    {
+        private readonly int _failUntilAttempt;
+
+        public CountingValidator(int failUntilAttempt)
+        {
+            _failUntilAttempt = failUntilAttempt;
+        }
+
+        public int Attempts { get; private set; }
+
+        public string Name => "CountingValidator";
+
+        public ValueTask<ValidatorResult> ValidateAsync(PipelineContext context, IPipelineStep step, CancellationToken cancellationToken)
+        {
+            Attempts++;
+            var success = Attempts >= _failUntilAttempt;
+            var warnings = success ? Array.Empty<string>() : new[] { "validator failed" };
+            return ValueTask.FromResult(new ValidatorResult(Name, success, warnings));
+        }
     }
 
     private sealed class StaticCliMetadataLoader : ICliMetadataLoader

--- a/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/StepRegistryTests.cs
@@ -90,6 +90,8 @@ public class StepRegistryTests
 
         public IReadOnlyList<IPostValidator> PostValidators => Array.Empty<IPostValidator>();
 
+        public int MaxRetries => 0;
+
         public ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
             => ValueTask.FromResult(StepResult.DryRun(Array.Empty<string>()));
     }

--- a/docs-generation/PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -222,6 +222,8 @@ public class ToolFamilyPostAssemblyValidatorTests
 
         public IReadOnlyList<IPostValidator> PostValidators => Array.Empty<IPostValidator>();
 
+        public int MaxRetries => 0;
+
         public ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
             => ValueTask.FromResult(StepResult.DryRun(Array.Empty<string>()));
     }

--- a/docs-generation/PipelineRunner/Contracts/IPipelineStep.cs
+++ b/docs-generation/PipelineRunner/Contracts/IPipelineStep.cs
@@ -16,5 +16,7 @@ public interface IPipelineStep
 
     IReadOnlyList<IPostValidator> PostValidators { get; }
 
+    int MaxRetries { get; }
+
     ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken);
 }

--- a/docs-generation/PipelineRunner/Contracts/StepDefinition.cs
+++ b/docs-generation/PipelineRunner/Contracts/StepDefinition.cs
@@ -17,7 +17,8 @@ public abstract class StepDefinition : IPipelineStep
         bool createsFilteredCliView = false,
         bool usesIsolatedWorkspace = false,
         IReadOnlyList<string>? expectedOutputs = null,
-        string implementation = "Typed")
+        string implementation = "Typed",
+        int maxRetries = 0)
     {
         Id = id;
         Name = name;
@@ -32,6 +33,7 @@ public abstract class StepDefinition : IPipelineStep
         UsesIsolatedWorkspace = usesIsolatedWorkspace;
         ExpectedOutputs = expectedOutputs ?? Array.Empty<string>();
         Implementation = implementation;
+        MaxRetries = maxRetries;
     }
 
     public int Id { get; }
@@ -59,6 +61,8 @@ public abstract class StepDefinition : IPipelineStep
     public IReadOnlyList<string> ExpectedOutputs { get; }
 
     public string Implementation { get; }
+
+    public int MaxRetries { get; }
 
     public abstract ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken);
 }

--- a/docs-generation/PipelineRunner/PipelineRunner.cs
+++ b/docs-generation/PipelineRunner/PipelineRunner.cs
@@ -203,10 +203,35 @@ public sealed class PipelineRunner
         CancellationToken cancellationToken)
     {
         context.Reports.Info($"  Step {step.Id}: {step.Name}");
-        var result = await step.ExecuteAsync(context, cancellationToken);
-        if (result.Success && !context.Request.SkipValidation && step.PostValidators.Count > 0)
+        
+        // Determine max attempts (1 + MaxRetries)
+        var maxAttempts = 1 + step.MaxRetries;
+        var hasValidators = !context.Request.SkipValidation && step.PostValidators.Count > 0;
+        
+        StepResult result = null!;
+        
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            result = await RunPostValidatorsAsync(context, step, result, cancellationToken);
+            if (attempt > 1)
+            {
+                context.Reports.Warning($"    Retry attempt {attempt - 1}/{step.MaxRetries} for step {step.Id}");
+            }
+            
+            result = await step.ExecuteAsync(context, cancellationToken);
+            
+            if (result.Success && hasValidators)
+            {
+                result = await RunPostValidatorsAsync(context, step, result, cancellationToken);
+            }
+            
+            // If successful or no retries available, break out
+            if (result.Success || attempt == maxAttempts)
+            {
+                break;
+            }
+            
+            // Validation failed, but we have more retries
+            context.Reports.Warning($"    Step {step.Id} validation failed, retrying ({attempt}/{maxAttempts - 1})");
         }
 
         foreach (var warning in result.Warnings)

--- a/docs-generation/PipelineRunner/Steps/Namespace/NamespaceStepBase.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/NamespaceStepBase.cs
@@ -15,7 +15,8 @@ public abstract class NamespaceStepBase : StepDefinition
         bool requiresAiConfiguration = false,
         bool createsFilteredCliView = false,
         bool usesIsolatedWorkspace = false,
-        IReadOnlyList<string>? expectedOutputs = null)
+        IReadOnlyList<string>? expectedOutputs = null,
+        int maxRetries = 0)
         : base(
             id,
             name,
@@ -26,7 +27,8 @@ public abstract class NamespaceStepBase : StepDefinition
             requiresAiConfiguration: requiresAiConfiguration,
             createsFilteredCliView: createsFilteredCliView,
             usesIsolatedWorkspace: usesIsolatedWorkspace,
-            expectedOutputs: expectedOutputs)
+            expectedOutputs: expectedOutputs,
+            maxRetries: maxRetries)
     {
     }
 

--- a/docs-generation/PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -17,7 +17,8 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             postValidators: [new ToolFamilyPostAssemblyValidator()],
             requiresAiConfiguration: true,
             usesIsolatedWorkspace: true,
-            expectedOutputs: ["tool-family-metadata", "tool-family-related", "tool-family", "reports"])
+            expectedOutputs: ["tool-family-metadata", "tool-family-related", "tool-family", "reports"],
+            maxRetries: 2)
     {
     }
 

--- a/docs-generation/ToolFamilyCleanup/Services/FamilyMetadataGenerator.cs
+++ b/docs-generation/ToolFamilyCleanup/Services/FamilyMetadataGenerator.cs
@@ -75,7 +75,10 @@ public class FamilyMetadataGenerator
         var metadata = await _aiClient.GetChatCompletionAsync(_systemPrompt, userPrompt, maxTokens: MAX_TOKENS);
 
         // Extract markdown if wrapped in code fences
-        return ExtractMarkdown(metadata.Trim());
+        var extractedMetadata = ExtractMarkdown(metadata.Trim());
+        
+        // Fix A: Post-process to replace LLM-generated tool_count with actual count
+        return EnsureCorrectToolCount(extractedMetadata, familyContent.ToolCount);
     }
 
     /// <summary>
@@ -94,5 +97,25 @@ public class FamilyMetadataGenerator
         }
 
         return response.Trim();
+    }
+
+    /// <summary>
+    /// Ensures the tool_count in YAML frontmatter matches the actual count.
+    /// This prevents LLM counting errors from propagating to the output.
+    /// </summary>
+    private static string EnsureCorrectToolCount(string metadata, int actualToolCount)
+    {
+        if (string.IsNullOrWhiteSpace(metadata))
+            return metadata;
+
+        // Pattern to match tool_count in YAML frontmatter (allowing for any whitespace around colon and value)
+        var toolCountPattern = new System.Text.RegularExpressions.Regex(
+            @"(?<=^---\s*\n(?:.*\n)*?)^tool_count\s*:\s*\d+",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        // Replace with actual count
+        var result = toolCountPattern.Replace(metadata, $"tool_count: {actualToolCount}", 1);
+        
+        return result;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the tool-count reliability bug in Step 4 (tool-family article generation) with two complementary fixes:

### Fix A: Deterministic tool_count
Post-processes LLM output to replace the generated tool_count with the actual count from FamilyContent.ToolCount. This prevents LLM counting errors (like dropping vm-create from compute namespace) from propagating to documentation.

**Implementation:** FamilyMetadataGenerator.EnsureCorrectToolCount uses regex to find and replace tool_count in YAML frontmatter.

### Fix B: Validation retry
Adds retry support for steps with post-validators. When a PostAssemblyValidator returns Success=false, the step retries (up to 2 retries, 3 total attempts) before marking as fatal failure.

**Implementation:** 
- Added MaxRetries property to IPipelineStep and StepDefinition
- Updated PipelineRunner.ExecuteStepAsync to implement retry loop
- ToolFamilyCleanupStep configured with maxRetries=2

## Testing
- **New tests:** 7 (5 for tool_count fix, 2 for retry logic)
- **Total tests:** 637 passing (0 failures)
- All existing tests continue to pass

## Related
Requested by: Dina Berry
Agent: Amos (Pipeline Dev)