### PR TITLE
fix: wrap .cmd/.bat files in cmd.exe for Windows process execution

### DIFF
--- a/docs-generation/PipelineRunner/Services/ProcessRunner.cs
+++ b/docs-generation/PipelineRunner/Services/ProcessRunner.cs
@@ -53,9 +53,22 @@ public sealed class ProcessRunner : IProcessRunner
 
     public async ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
     {
+        // On Windows, .cmd/.bat files need cmd.exe to execute correctly
+        // because UseShellExecute=false bypasses shell interpretation
+        var fileName = spec.FileName;
+        var arguments = spec.Arguments;
+        if (OperatingSystem.IsWindows() &&
+            (fileName.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase) ||
+             fileName.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)))
+        {
+            arguments = new List<string>(arguments.Count + 2) { "/c", fileName };
+            ((List<string>)arguments).AddRange(spec.Arguments);
+            fileName = "cmd.exe";
+        }
+
         var startInfo = new ProcessStartInfo
         {
-            FileName = spec.FileName,
+            FileName = fileName,
             WorkingDirectory = spec.WorkingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -64,7 +77,7 @@ public sealed class ProcessRunner : IProcessRunner
             CreateNoWindow = true,
         };
 
-        foreach (var argument in spec.Arguments)
+        foreach (var argument in arguments)
         {
             startInfo.ArgumentList.Add(argument);
         }


### PR DESCRIPTION
## Problem
\ProcessRunner.RunAsync()\ uses \UseShellExecute=false\, which bypasses shell interpretation. On Windows, \.cmd\/\.bat\ files (like \
pm.cmd\) need \cmd.exe\ to execute correctly — without it, npm can't resolve its own \
ode_modules/npm/bin/npm-prefix.js\.

## Fix
Auto-detect \.cmd\/\.bat\ files on Windows and wrap them in \cmd.exe /c\. Generic fix that handles any future batch file invocations.

## Validation
- 49/49 PipelineRunner tests pass
- Full compute pipeline run: exit code 0, all 7 steps complete
- BootstrapStep npm.cmd invocation now works correctly

## Related
- Fixes the Windows npm bug identified during LKG validation of PR #124 and #125