### PR TITLE
Fix tool family grouping: merge annotation + prefix matches

### DIFF
--- a/docs-generation/PipelineRunner.Tests/Unit/ToolFamilyCleanupStepTests.cs
+++ b/docs-generation/PipelineRunner.Tests/Unit/ToolFamilyCleanupStepTests.cs
@@ -92,6 +92,100 @@ public class ToolFamilyCleanupStepTests
         }
     }
 
+    [Fact]
+    public async Task Step4_MergesAnnotationAndPrefixMatches_WhenToolsHaveMixedAnnotations()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var processRunner = new CallbackProcessRunner();
+            var context = CreateCosmosContext(testRoot, processRunner);
+
+            // Create tools with MIXED annotations:
+            // 1. Tool WITH @mcpcli annotation → should match by content
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "azure-cosmos-db-list.md"), "cosmos list");
+            
+            // 2. Tool WITHOUT @mcpcli annotation → should match by prefix (via brand-to-server-mapping.json)
+            var pathNoAnnotation = Path.Combine(context.OutputPath, "tools", "azure-cosmos-db-database-container-item-query.md");
+            Directory.CreateDirectory(Path.GetDirectoryName(pathNoAnnotation)!);
+            File.WriteAllText(pathNoAnnotation, "---\n---\n# Database Container Item Query\n\nNo annotation here\n");
+            
+            SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+
+            int toolFileCount = 0;
+            processRunner.OnRun = spec =>
+            {
+                // Count tool files that were copied to the isolated workspace
+                var tempToolsDir = Path.Combine(Path.GetDirectoryName(spec.WorkingDirectory!)!, "generated", "tools");
+                if (Directory.Exists(tempToolsDir))
+                {
+                    toolFileCount = Directory.GetFiles(tempToolsDir, "*.md").Length;
+                }
+
+                var isolatedGeneratedRoot = Path.GetFullPath(Path.Combine(spec.WorkingDirectory, "..", "generated"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family-metadata"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family-related"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family"));
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family-metadata", "cosmos-metadata.md"), "metadata");
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family-related", "cosmos-related.md"), "related");
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family", "cosmos.md"), "final article");
+
+                return CallbackProcessRunner.Success(spec);
+            };
+
+            var step = new ToolFamilyCleanupStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            
+            // CRITICAL ASSERTION: Both tools should be included (1 via annotation match, 1 via prefix match)
+            Assert.Equal(2, toolFileCount);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static PipelineContext CreateCosmosContext(string testRoot, IProcessRunner processRunner)
+    {
+        var docsGenerationRoot = Path.Combine(testRoot, "docs-generation");
+        var outputPath = Path.Combine(testRoot, "generated-cosmos");
+        Directory.CreateDirectory(Path.Combine(docsGenerationRoot, "data"));
+        Directory.CreateDirectory(outputPath);
+        
+        // Seed brand mappings with cosmos entry for testing
+        var brandMappings = System.Text.Json.JsonSerializer.Serialize(new[]
+        {
+            new { brandName = "Azure Cosmos DB", mcpServerName = "cosmos", shortName = "Cosmos DB", fileName = "azure-cosmos-db" }
+        });
+        File.WriteAllText(Path.Combine(docsGenerationRoot, "data", "brand-to-server-mapping.json"), brandMappings);
+
+        var context = new PipelineContext
+        {
+            Request = new PipelineRequest("cosmos", [4], outputPath, SkipBuild: true, SkipValidation: false, DryRun: false),
+            RepoRoot = testRoot,
+            DocsGenerationRoot = docsGenerationRoot,
+            OutputPath = outputPath,
+            ProcessRunner = processRunner,
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new StubFilteredCliWriter(),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            CliOutput = CreateSnapshot(["cosmos list", "cosmos database container item query"]),
+            SelectedNamespaces = ["cosmos"],
+        };
+        
+        // Set the namespace in the Items dictionary (required by NamespaceStepBase)
+        context.Items["Namespace"] = "cosmos";
+        
+        return context;
+    }
+
     private static PipelineContext CreateContext(string testRoot, IProcessRunner processRunner)
     {
         var docsGenerationRoot = Path.Combine(testRoot, "docs-generation");

--- a/docs-generation/PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/docs-generation/PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -159,7 +159,8 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        var contentMatches = new List<string>();
+        // Step 1: Try content matching (annotation-based) on ALL files
+        var contentMatches = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var filePath in toolFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -170,20 +171,22 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             }
         }
 
-        if (contentMatches.Count > 0)
-        {
-            return contentMatches;
-        }
-
+        // Step 2: For files NOT matched by content, try prefix matching
         var prefixes = await GetPrefixesAsync(familyName, cancellationToken);
-        return toolFiles
+        var prefixMatches = toolFiles
+            .Where(path => !contentMatches.Contains(path)) // Only match files not already matched by content
             .Where(path => prefixes.Any(prefix =>
             {
                 var fileName = Path.GetFileNameWithoutExtension(path);
                 return string.Equals(fileName, prefix, StringComparison.OrdinalIgnoreCase)
                     || fileName.StartsWith($"{prefix}-", StringComparison.OrdinalIgnoreCase);
             }))
+            .ToArray();
+
+        // Step 3: Return union of both strategies (deduplicated)
+        return contentMatches.Concat(prefixMatches)
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
 

--- a/docs-generation/ToolFamilyCleanup/Services/ToolReader.cs
+++ b/docs-generation/ToolFamilyCleanup/Services/ToolReader.cs
@@ -136,19 +136,36 @@ public class ToolReader
     }
 
     /// <summary>
-    /// Extracts family name from filename.
+    /// Extracts family name from filename using brand mapping data.
     /// Pattern: {family}-*.md
     /// Examples:
     ///   advisor-recommendation-list.md → advisor
     ///   storage-account-create.md → storage
     ///   ai-foundry-agents-connect.md → ai-foundry (special case)
+    ///   azure-cosmos-db-list.md → cosmos (mapped via brand-to-server-mapping.json)
     /// </summary>
     private string ExtractFamilyNameFromFileName(string fileName)
     {
         // Remove .md extension
         var nameWithoutExt = fileName.Replace(".md", "");
         
-        // Split by hyphens
+        // Try to match against brand mappings first (best accuracy)
+        var brandMappings = Shared.DataFileLoader.LoadBrandMappingsAsync().GetAwaiter().GetResult();
+        foreach (var mapping in brandMappings.Values)
+        {
+            var prefix = mapping.FileName?.ToLowerInvariant();
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                // Check if filename starts with this prefix
+                if (nameWithoutExt.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                    nameWithoutExt.StartsWith($"{prefix}-", StringComparison.OrdinalIgnoreCase))
+                {
+                    return mapping.McpServerName;
+                }
+            }
+        }
+        
+        // Fallback: split by hyphens and use heuristics
         var parts = nameWithoutExt.Split('-');
         
         if (parts.Length < 1)
@@ -161,6 +178,26 @@ public class ToolReader
         {
             // ai-foundry-... → ai-foundry
             return $"{parts[0]}-{parts[1]}";
+        }
+        
+        // Special case for "azure-*" prefixes - skip "azure" and try to match the service name
+        if (parts[0] == "azure" && parts.Length > 1)
+        {
+            // azure-cosmos-db-... → cosmos (if we can find it in mappings by trying 2+ segments)
+            for (int segmentCount = Math.Min(parts.Length - 1, 4); segmentCount >= 1; segmentCount--)
+            {
+                var candidatePrefix = string.Join("-", parts.Take(1 + segmentCount));
+                foreach (var mapping in brandMappings.Values)
+                {
+                    if (string.Equals(mapping.FileName, candidatePrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return mapping.McpServerName;
+                    }
+                }
+            }
+            
+            // If no mapping found, return second segment as a fallback
+            return parts[1];
         }
         
         // Default: first part is the family name


### PR DESCRIPTION
## Problem

Two related bugs in the tool family grouping system cause Step 4 to fail for namespaces where the LLM doesn't consistently generate `@mcpcli` annotations in tool files.

### Bug 1: `ResolveFamilyToolFilesAsync` short-circuits on partial annotation matches

**File:** `docs-generation/PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs`

When SOME tool files have `@mcpcli` annotations and others don't, only the annotated files are returned. The prefix-based fallback is NEVER reached because `contentMatches.Count > 0`.

**Example (cosmos namespace):**
- `azure-cosmos-db-list.md` has `<!-- @mcpcli cosmos list -->` → content match ✅
- `azure-cosmos-db-database-container-item-query.md` has NO annotation → not matched ❌
- Result: only 1 of 2 tools included

### Bug 2: `ToolReader.ExtractFamilyNameFromFileName` too simplistic

**File:** `docs-generation/ToolFamilyCleanup/Services/ToolReader.cs`

When a tool file lacks `@mcpcli` annotation and falls back to filename parsing, filenames like `azure-cosmos-db-list.md` get family name "azure" instead of the actual namespace.

## Solution

1. **Fixed `ResolveFamilyToolFilesAsync`**: Always try BOTH content matching AND prefix matching, then merge results (deduplicated). The final set is the UNION of both methods.

2. **Fixed `ToolReader.ExtractFamilyNameFromFileName`**: Load brand-to-server-mapping.json to get filename prefix → namespace mappings for intelligent multi-segment extraction.

3. **Added test**: `Step4_MergesAnnotationAndPrefixMatches_WhenToolsHaveMixedAnnotations` verifies both annotated and unannotated tools are included.

## Testing

✅ All 50 tests pass
✅ New test validates the fix

## Impact

- Ensures `EnsureCorrectToolCount` fix (PR #125) gets correct tool counts
- Fixes Step 4 failures for partially annotated namespaces (cosmos, etc.)
