### PR TITLE
feat: add Container Apps brand mapping + beta.31 content generation

### DIFF
--- a/docs-generation/data/brand-to-server-mapping.json
+++ b/docs-generation/data/brand-to-server-mapping.json
@@ -1,5 +1,11 @@
 [
   {
+    "brandName": "Azure Container Apps",
+    "mcpServerName": "containerapps",
+    "shortName": "Container Apps",
+    "fileName": "azure-container-apps"
+  },
+  {
     "brandName": "Azure Container Registry",
     "mcpServerName": "acr",
     "shortName": "ACR",


### PR DESCRIPTION
## Beta.31 Tool Changes

| Change | Namespace | Tool | Status |
|--------|-----------|------|--------|
| NEW namespace | containerapps | list | PASS |
| NEW tool | group | resource list | PASS |
| NEW tool | monitor | send-enhancement-select | PASS |
| RENAMED | monitor | get-learning-resource | PASS |
| RENAMED | monitor | orchestrator-next | PASS |
| RENAMED | monitor | orchestrator-start | PASS |
| RENAMED | monitor | send-brownfield-analysis | PASS |

## What changed
- Added brand-to-server-mapping entry for containerapps (Azure Container Apps)
- All 3 impacted namespaces pass full pipeline (Steps 1-6)

## Notes
- monitor Step 2 had retries on webtests/createorupdate (pre-existing, not beta.31 related)
- group Step 4 needed 1 retry (AI non-determinism, succeeded on retry)
- containerapps passed cleanly first try
- Parallel namespace execution confirmed safe after preflight