### PR TITLE
fix: normalize CosmosDB branding to Azure Cosmos DB (#141)

### DIFF
--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/StaticTextReplacementTests.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/StaticTextReplacementTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using NaturalLanguageGenerator;
+using Xunit;
+
+namespace CSharpGenerator.Tests;
+
+/// <summary>
+/// Tests for TextCleanup.ReplaceStaticText to verify branding and text normalization.
+/// Fixes: #141 — CosmosDB branding not normalized.
+/// </summary>
+public class StaticTextReplacementTests : IClassFixture<TextCleanupFixture>
+{
+    private readonly TextCleanupFixture _fixture;
+
+    public StaticTextReplacementTests(TextCleanupFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ── CosmosDB Branding (#141) ────────────────────────────────────
+
+    [Fact]
+    public void ReplaceStaticText_CosmosDB_ReplacedWithAzureCosmosDB()
+    {
+        // Arrange — CLI description containing "CosmosDB" (no space)
+        var input = "Add a CosmosDB database to the web app";
+
+        // Act
+        var result = TextCleanup.ReplaceStaticText(input);
+
+        // Assert — should normalize to "Azure Cosmos DB"
+        Assert.Contains("Azure Cosmos DB", result);
+        Assert.DoesNotContain("CosmosDB", result);
+    }
+
+    [Theory]
+    [InlineData("Connect to CosmosDB", "Connect to Azure Cosmos DB")]
+    [InlineData("The CosmosDB account was created", "The Azure Cosmos DB account was created")]
+    [InlineData("Use CosmosDB for NoSQL data", "Use Azure Cosmos DB for NoSQL data")]
+    public void ReplaceStaticText_CosmosDB_VariousContexts(string input, string expected)
+    {
+        // Act
+        var result = TextCleanup.ReplaceStaticText(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ReplaceStaticText_CosmosDB_NotReplacedInsideWord()
+    {
+        // "CosmosDB" inside a larger token should NOT be replaced
+        // e.g., "MyCosmosDBApp" should not become "MyAzure Cosmos DBApp"
+        var input = "The MyCosmosDBApp is running";
+
+        // Act
+        var result = TextCleanup.ReplaceStaticText(input);
+
+        // Assert — word-boundary matching should prevent partial replacement
+        Assert.Contains("MyCosmosDBApp", result);
+    }
+
+    // ── Existing Replacement Verification ───────────────────────────
+
+    [Theory]
+    [InlineData("e.g.", "for example")]
+    [InlineData("i.e.", "in other words")]
+    public void ReplaceStaticText_ExistingAbbreviations_StillWork(string abbrev, string expanded)
+    {
+        // Arrange
+        var input = $"This is {abbrev} a test";
+
+        // Act
+        var result = TextCleanup.ReplaceStaticText(input);
+
+        // Assert
+        Assert.Contains(expanded, result);
+    }
+
+    [Theory]
+    [InlineData("VMSS", "Virtual machine scale set (VMSS)")]
+    public void ReplaceStaticText_ExistingBrandNames_StillWork(string original, string replacement)
+    {
+        // Arrange — VMSS as standalone word
+        var input = $"Deploy to {original} instances";
+
+        // Act
+        var result = TextCleanup.ReplaceStaticText(input);
+
+        // Assert
+        Assert.Contains(replacement, result);
+    }
+}

--- a/docs-generation/data/static-text-replacement.json
+++ b/docs-generation/data/static-text-replacement.json
@@ -30,6 +30,10 @@
     {
         "Parameter": "VMSS",
         "NaturalLanguage": "Virtual machine scale set (VMSS)"
+    },
+    {
+        "Parameter": "CosmosDB",
+        "NaturalLanguage": "Azure Cosmos DB"
     }
 
 ]


### PR DESCRIPTION
## Summary
Adds 'CosmosDB' → 'Azure Cosmos DB' entry to \static-text-replacement.json\ so CLI descriptions containing 'CosmosDB' (without space) are automatically normalized to the correct 'Azure Cosmos DB' branding.

## Changes
- **\data/static-text-replacement.json\** — Added CosmosDB → Azure Cosmos DB mapping
- **\StaticTextReplacementTests.cs\** — 8 new tests: branding replacement, word boundary safety, regression checks

## Testing
- 8 new tests (TDD: written first, failed, then passed after fix)
- Full test suite: 800+ tests pass, 0 failures
- Word boundary regex prevents false positives (e.g., 'MyCosmosDBApp' not replaced)

## Validation
Validated against known-good \generated-validated-appservice/\ output — the CosmosDB string in appservice database-add descriptions will now be corrected on next pipeline run.

Closes #141