### PR TITLE
fix: expand MCP acronym on first use in tool-family articles (#142)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/McpAcronymExpansionTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/McpAcronymExpansionTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for PostProcessor.ExpandMcpAcronym to ensure the first body mention
+/// of "Azure MCP Server" is expanded to "Azure Model Context Protocol (MCP) Server".
+/// Fixes: #142 — MCP acronym not defined on first use.
+/// </summary>
+public class McpAcronymExpansionTests
+{
+    // ── Core expansion behavior ─────────────────────────────────────
+
+    [Fact]
+    public void ExpandMcpAcronym_ExpandsFirstBodyMention()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Azure Storage
+description: Use Azure MCP Server tools to manage storage.
+ms.topic: concept-article
+---
+
+# Azure MCP Server tools for Azure Storage
+
+The Azure MCP Server lets you manage Azure Storage resources.
+
+## List storage accounts
+
+Use Azure MCP Server to list accounts.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // First body mention (intro paragraph) should be expanded
+        Assert.Contains("Azure Model Context Protocol (MCP) Server lets you manage", result);
+        // Title and H1 should NOT be expanded
+        Assert.Contains("title: Azure MCP Server tools", result);
+        Assert.Contains("# Azure MCP Server tools for Azure Storage", result);
+        // Second body mention should remain unchanged
+        Assert.Contains("Use Azure MCP Server to list", result);
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_OnlyExpandsFirstBodyOccurrence()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Azure Cosmos DB
+---
+
+# Azure MCP Server tools for Azure Cosmos DB
+
+The Azure MCP Server lets you manage databases.
+
+You must be authenticated to the Azure MCP Server.
+
+The Azure MCP Server supports multiple regions.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // Count occurrences of expanded form — should be exactly 1
+        var expandedCount = CountOccurrences(result, "Model Context Protocol (MCP)");
+        Assert.Equal(1, expandedCount);
+
+        // Count remaining "Azure MCP Server" (unexpanded) — should be multiple
+        var unexpandedCount = CountOccurrences(result, "Azure MCP Server");
+        Assert.True(unexpandedCount >= 2, $"Expected at least 2 unexpanded mentions, got {unexpandedCount}");
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_PreservesFrontmatter()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Key Vault
+description: Use Azure MCP Server tools to manage secrets.
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Key Vault
+
+The Azure MCP Server lets you manage Key Vault secrets.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // Frontmatter should be completely untouched
+        Assert.Contains("title: Azure MCP Server tools for Key Vault", result);
+        Assert.Contains("description: Use Azure MCP Server tools to manage secrets.", result);
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_PreservesH1Heading()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Monitor
+---
+
+# Azure MCP Server tools for Monitor
+
+The Azure MCP Server provides monitoring tools.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // H1 should not be modified
+        Assert.Contains("# Azure MCP Server tools for Monitor", result);
+        // Body should be expanded
+        Assert.Contains("Azure Model Context Protocol (MCP) Server provides monitoring", result);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ExpandMcpAcronym_NoFrontmatter_ExpandsFirstAfterH1()
+    {
+        var markdown = @"# Azure MCP Server tools for Storage
+
+The Azure MCP Server lets you manage storage.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // H1 preserved
+        Assert.Contains("# Azure MCP Server tools for Storage", result);
+        // Body expanded
+        Assert.Contains("Azure Model Context Protocol (MCP) Server lets you manage", result);
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_NoMcpMention_ReturnsUnchanged()
+    {
+        var markdown = @"---
+title: Some other article
+---
+
+# Some article
+
+This article has no MCP mentions.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        Assert.Equal(markdown, result);
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_NullOrEmpty_ReturnsInput()
+    {
+        Assert.Equal("", PostProcessor.ExpandMcpAcronym(""));
+        Assert.Null(PostProcessor.ExpandMcpAcronym(null!));
+    }
+
+    [Fact]
+    public void ExpandMcpAcronym_AlreadyExpanded_NoDoubleExpansion()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for SQL
+---
+
+# Azure MCP Server tools for SQL
+
+The Azure Model Context Protocol (MCP) Server lets you manage databases.";
+
+        var result = PostProcessor.ExpandMcpAcronym(markdown);
+
+        // Should not create "Azure Model Context Protocol (MCP) Model Context Protocol (MCP) Server"
+        var expandedCount = CountOccurrences(result, "Model Context Protocol (MCP)");
+        Assert.Equal(1, expandedCount);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -37,7 +37,11 @@ public class FamilyFileStitcher
         // 3. Related content section
         sb.AppendLine(familyContent.RelatedContent);
 
-        return sb.ToString().TrimEnd();
+        // 4. Post-processing: expand MCP acronym on first body mention (#142)
+        var markdown = sb.ToString().TrimEnd();
+        markdown = PostProcessor.ExpandMcpAcronym(markdown);
+
+        return markdown;
     }
 
     /// <summary>

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/PostProcessor.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/PostProcessor.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Deterministic post-processing transformations applied after AI generation
+/// and file stitching. These are reliable, testable fixes that don't depend
+/// on AI behavior.
+/// </summary>
+public static class PostProcessor
+{
+    private const string McpShort = "Azure MCP Server";
+    private const string McpExpanded = "Azure Model Context Protocol (MCP) Server";
+
+    /// <summary>
+    /// Expands the first body occurrence of "Azure MCP Server" to
+    /// "Azure Model Context Protocol (MCP) Server" per Acrolinx rule:
+    /// "Clarity > Did you define the acronym in your content?"
+    /// 
+    /// Preserves frontmatter and H1 heading — only expands in body text.
+    /// Skips if already expanded.
+    /// </summary>
+    public static string ExpandMcpAcronym(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return markdown;
+        }
+
+        // If already expanded, don't double-expand
+        if (markdown.Contains("Model Context Protocol (MCP)", StringComparison.Ordinal))
+        {
+            return markdown;
+        }
+
+        // Find the body start: after frontmatter (if present) and H1 heading
+        int bodyStart = FindBodyStart(markdown);
+        if (bodyStart < 0 || bodyStart >= markdown.Length)
+        {
+            return markdown;
+        }
+
+        // Find first "Azure MCP Server" in the body
+        int firstMention = markdown.IndexOf(McpShort, bodyStart, StringComparison.Ordinal);
+        if (firstMention < 0)
+        {
+            return markdown;
+        }
+
+        // Replace only the first body occurrence
+        return string.Concat(
+            markdown.AsSpan(0, firstMention),
+            McpExpanded,
+            markdown.AsSpan(firstMention + McpShort.Length));
+    }
+
+    /// <summary>
+    /// Finds the start of body content (after frontmatter and H1 heading).
+    /// Returns the character index where body text begins.
+    /// </summary>
+    private static int FindBodyStart(string markdown)
+    {
+        int pos = 0;
+
+        // Skip frontmatter if present (between --- markers)
+        if (markdown.StartsWith("---"))
+        {
+            int endFrontmatter = markdown.IndexOf("\n---", 3, StringComparison.Ordinal);
+            if (endFrontmatter > 0)
+            {
+                // Move past the closing --- line
+                pos = markdown.IndexOf('\n', endFrontmatter + 4);
+                if (pos < 0) return -1;
+                pos++;
+            }
+        }
+
+        // Skip the H1 heading line (starts with "# ")
+        while (pos < markdown.Length)
+        {
+            // Skip blank lines
+            if (markdown[pos] == '\n' || markdown[pos] == '\r')
+            {
+                pos++;
+                continue;
+            }
+
+            // Check if this line is an H1 heading
+            if (pos + 1 < markdown.Length && markdown[pos] == '#' && markdown[pos + 1] == ' ')
+            {
+                // Skip to end of H1 line
+                int endOfLine = markdown.IndexOf('\n', pos);
+                if (endOfLine < 0) return -1;
+                pos = endOfLine + 1;
+                break;
+            }
+
+            // Not a heading — we're already in the body
+            break;
+        }
+
+        return pos;
+    }
+}


### PR DESCRIPTION
## Summary
Adds deterministic post-processing to expand 'MCP' on first use in tool-family articles. The first body occurrence of 'Azure MCP Server' is replaced with 'Azure Model Context Protocol (MCP) Server' per Acrolinx rule: *Clarity > Did you define the acronym in your content?*

## Changes
- **\PostProcessor.cs\** (new) — Static \ExpandMcpAcronym()\ method: finds first body mention after frontmatter/H1, replaces with expanded form. Idempotent (skips if already expanded).
- **\FamilyFileStitcher.cs\** — Wired \PostProcessor.ExpandMcpAcronym()\ as step 4 in \Stitch()\
- **\McpAcronymExpansionTests.cs\** — 8 tests: expansion, frontmatter preservation, H1 preservation, idempotency, edge cases

## Testing
- 8 new tests (TDD: written first, then implementation)
- Full test suite: 800+ tests pass, 0 failures
- Validated: tool-family articles will now expand 'Azure MCP Server' → 'Azure Model Context Protocol (MCP) Server' on first body mention

Closes #142