### PR TITLE
fix: strip duplicate AI-generated example blocks (#153)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/DuplicateExampleStripperTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/DuplicateExampleStripperTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for DuplicateExampleStripper to ensure non-canonical example blocks
+/// are removed while preserving the "Example prompts include:" canonical format.
+/// Fixes: #153 — AI generates duplicate Examples block.
+/// </summary>
+public class DuplicateExampleStripperTests
+{
+    // ── Core stripping behavior ─────────────────────────────────────
+
+    [Fact]
+    public void Strip_RemovesBlockquoteExampleLine()
+    {
+        var content = @"Description of the tool.
+
+> Example: Get web app 'my-webapp' in resource group 'my-rg'
+
+<!-- Required parameters: 0 -  -->
+
+Example prompts include:
+
+- ""List all web apps.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.DoesNotContain("> Example: Get web app", result);
+        Assert.Contains("Example prompts include:", result);
+        Assert.Contains("\"List all web apps.\"", result);
+    }
+
+    [Fact]
+    public void Strip_RemovesRawExamplesBulletList()
+    {
+        var content = @"Description of the tool.
+
+Examples:
+- Get details for a specific web app: ""Get web app 'my-webapp'""
+- List all web apps: ""List all web apps in the subscription""
+
+<!-- Required parameters: 0 -  -->
+
+Example prompts include:
+
+- ""List all web apps in my subscription.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.DoesNotContain("Examples:", result);
+        Assert.DoesNotContain("Get details for a specific web app", result);
+        Assert.Contains("Example prompts include:", result);
+        Assert.Contains("\"List all web apps in my subscription.\"", result);
+    }
+
+    [Fact]
+    public void Strip_RemovesExamplePromptsWithoutInclude()
+    {
+        var content = @"[Tool annotation hints](index.md#tool-annotations):
+Destructive: no
+
+Example prompts:
+- ""Diagnose web app 'finance-backend'.""
+- ""Diagnose web app 'orders-api'.""
+
+<!-- Required parameters: 2 -->
+
+Example prompts include:
+
+- ""Run diagnostics on web app 'my-app'.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        // "Example prompts:" (without "include") should be removed
+        Assert.DoesNotContain("Example prompts:\n", result);
+        Assert.DoesNotContain("finance-backend", result);
+        // Canonical should remain
+        Assert.Contains("Example prompts include:", result);
+        Assert.Contains("Run diagnostics on web app", result);
+    }
+
+    [Fact]
+    public void Strip_PreservesCanonicalExamplePrompts()
+    {
+        var content = @"Description of the tool.
+
+Example prompts include:
+
+- ""Create a storage account named 'mystorageaccount'.""
+- ""List all storage accounts in resource group 'rg-prod'.""
+
+| Parameter | Required or optional | Description |";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.Contains("Example prompts include:", result);
+        Assert.Contains("Create a storage account", result);
+        Assert.Contains("List all storage accounts", result);
+    }
+
+    [Fact]
+    public void Strip_HandlesMultipleDuplicateFormats()
+    {
+        var content = @"Description.
+
+> Example: add database 'mydb' to app 'my-webapp'
+
+Examples:
+- Add a database: ""Add database 'mydb'""
+- Remove a database: ""Remove database 'mydb'""
+
+Example prompts include:
+
+- ""Add database 'ordersdb' to app 'order-api'.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.DoesNotContain("> Example:", result);
+        Assert.DoesNotContain("Examples:", result);
+        Assert.Contains("Example prompts include:", result);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Strip_NoDuplicates_ReturnsUnchanged()
+    {
+        var content = @"Description.
+
+Example prompts include:
+
+- ""List all accounts.""
+
+| Parameter | Required | Description |";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public void Strip_NullOrEmpty_ReturnsInput()
+    {
+        Assert.Equal("", DuplicateExampleStripper.Strip(""));
+        Assert.Null(DuplicateExampleStripper.Strip(null!));
+    }
+
+    [Fact]
+    public void Strip_PreservesNonExampleBlockquotes()
+    {
+        var content = @"> [!NOTE]
+> This is an important note.
+
+Example prompts include:
+
+- ""List accounts.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        // Non-example blockquotes should be preserved
+        Assert.Contains("> [!NOTE]", result);
+        Assert.Contains("> This is an important note.", result);
+    }
+
+    [Fact]
+    public void Strip_PreservesExamplesHeadingInOtherContexts()
+    {
+        // "## Examples" as a real H2 heading should NOT be removed
+        // (that's handled by phantom H2 stripping, not this)
+        var content = @"## Examples
+
+Some example text.
+
+Example prompts include:
+
+- ""List items.""";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        // H2 headings are not our responsibility
+        Assert.Contains("## Examples", result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Strips non-canonical duplicate example blocks from tool-family articles.
+/// 
+/// The canonical format is "Example prompts include:" followed by bullet items.
+/// AI steps (3 and 4) sometimes inject additional formats:
+///   - "> Example: ..." (blockquote single example)
+///   - "Examples:\n- ..." (raw bullet list)
+///   - "Example prompts:\n- ..." (variant without "include")
+/// 
+/// This post-processor removes those duplicates while preserving the canonical block.
+/// </summary>
+public static class DuplicateExampleStripper
+{
+    // Pattern 1: "> Example: <text>" — blockquote single example line
+    // Matches "> Example:" followed by text, NOT "> Example prompts"
+    private static readonly Regex BlockquoteExamplePattern = new(
+        @"^> Example:(?! prompts).*$",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    // Pattern 2: "Examples:" followed by bullet items (not a heading)
+    // Matches "Examples:" at start of line (not "## Examples") followed by "- " lines
+    private static readonly Regex RawExamplesBlockPattern = new(
+        @"^(?<!#+ )Examples:\s*\n(?:- .+\n?)+",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    // Pattern 3: "Example prompts:" (without "include") followed by bullet items
+    // Must NOT match "Example prompts include:"
+    private static readonly Regex ExamplePromptsNoIncludePattern = new(
+        @"^Example prompts:(?! include)\s*\n(?:- .+\n?)+",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips non-canonical example blocks from the content.
+    /// Preserves "Example prompts include:" canonical blocks.
+    /// </summary>
+    public static string Strip(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return content;
+        }
+
+        var result = content;
+
+        // Remove blockquote examples ("> Example: ...")
+        result = BlockquoteExamplePattern.Replace(result, "");
+
+        // Remove raw "Examples:" bullet lists
+        result = RawExamplesBlockPattern.Replace(result, "");
+
+        // Remove "Example prompts:" (without "include") bullet lists
+        result = ExamplePromptsNoIncludePattern.Replace(result, "");
+
+        // Clean up excessive blank lines left by removals (3+ → 2)
+        result = Regex.Replace(result, @"\n{3,}", "\n\n");
+
+        return result;
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -44,6 +44,9 @@ public class FamilyFileStitcher
         // 5. Post-processing: inject required frontmatter fields (#155)
         markdown = FrontmatterEnricher.Enrich(markdown);
 
+        // 6. Post-processing: strip duplicate example blocks (#153)
+        markdown = DuplicateExampleStripper.Strip(markdown);
+
         return markdown;
     }
 


### PR DESCRIPTION
## Summary
Adds deterministic post-processing to remove non-canonical example blocks that AI steps inject alongside the canonical \Example prompts include:\ section.

## Problem
AI Steps 3 and 4 generate additional example formats:
- \> Example: ...\ (blockquote single example from Step 3)
- \Examples:\n- ...\ (raw bullet list from Step 3)
- \Example prompts:\n- ...\ (variant without 'include' from Step 4)

These appear alongside the canonical \Example prompts include:\ block, creating duplicate content.

## Changes
- **\DuplicateExampleStripper.cs\** (new) — Regex-based stripper for 3 non-canonical patterns. Preserves canonical format and non-example blockquotes.
- **\FamilyFileStitcher.cs\** — Wired \DuplicateExampleStripper.Strip()\ as step 4 in \Stitch()\
- **\DuplicateExampleStripperTests.cs\** — 9 tests: pattern removal, canonical preservation, edge cases

## Testing
- 9 new tests (TDD)
- Full test suite: 800+ tests pass, 0 failures
- Validated against \generated-validated-appservice/tool-family/appservice.md\ which shows the duplicate pattern

Closes #153