### PR TITLE
fix(#143,#145,#146): Acrolinx compliance prompt rules + contraction post-processor

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/AcrolinxPromptRuleTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/AcrolinxPromptRuleTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests that the tool-family-cleanup system prompt contains required
+/// Acrolinx compliance rules for issues #143, #145, and #146.
+/// These tests would FAIL if the prompt rules were reverted.
+/// </summary>
+public class AcrolinxPromptRuleTests
+{
+    private readonly string _promptContent;
+
+    public AcrolinxPromptRuleTests()
+    {
+        // Load the actual system prompt file
+        var promptPath = Path.Combine(
+            FindProjectRoot(),
+            "docs-generation",
+            "DocGeneration.Steps.ToolFamilyCleanup",
+            "prompts",
+            "tool-family-cleanup-system-prompt.txt");
+
+        _promptContent = File.ReadAllText(promptPath);
+    }
+
+    // ── #143: Split complex overview sentence ───────────────────────
+
+    [Fact]
+    public void Prompt_ContainsOverviewSplitRule()
+    {
+        // The prompt must instruct AI to split the overview into two sentences
+        Assert.Contains("two sentences", _promptContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Prompt_ContainsOverviewPurposeThenCapabilities()
+    {
+        // The prompt must describe: first sentence = purpose, second = capabilities
+        Assert.Contains("purpose", _promptContent, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("capabilities", _promptContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── #145: Present tense and contractions ────────────────────────
+
+    [Fact]
+    public void Prompt_ContainsContractionRule()
+    {
+        // The prompt must instruct use of contractions
+        Assert.Contains("contraction", _promptContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Prompt_ContainsPresentTenseRule()
+    {
+        // The prompt must explicitly mention avoiding future tense "will be"
+        Assert.Contains("will be", _promptContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── #146: Commas after introductory phrases ─────────────────────
+
+    [Fact]
+    public void Prompt_ContainsIntroductoryPhraseCommaRule()
+    {
+        // The prompt must instruct comma usage after introductory phrases
+        Assert.Contains("introductory phrase", _promptContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Prompt_ContainsIntroductoryExamples()
+    {
+        // The prompt must give examples of introductory phrases
+        Assert.Contains("For each", _promptContent);
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────
+
+    private static string FindProjectRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "docs-generation.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find project root (docs-generation.sln)");
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ContractionFixerTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ContractionFixerTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for ContractionFixer — deterministic post-processor that
+/// converts formal non-contracted forms to contractions per Microsoft
+/// style guide. Fixes: #145 (Acrolinx "Could you use contractions?")
+/// </summary>
+public class ContractionFixerTests
+{
+    // ── Core contractions ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("It does not support", "It doesn't support")]
+    [InlineData("This does not apply", "This doesn't apply")]
+    [InlineData("It do not require", "It don't require")]
+    [InlineData("You do not need", "You don't need")]
+    [InlineData("It is not available", "It isn't available")]
+    [InlineData("This is not required", "This isn't required")]
+    [InlineData("It will not work", "It won't work")]
+    [InlineData("It can not be used", "It can't be used")]
+    [InlineData("It cannot be used", "It can't be used")]
+    public void Fix_NonContracted_ReplacedWithContraction(string input, string expected)
+    {
+        var result = ContractionFixer.Fix(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ── Already contracted — idempotent ─────────────────────────────
+
+    [Theory]
+    [InlineData("It doesn't support")]
+    [InlineData("You don't need")]
+    [InlineData("It isn't available")]
+    [InlineData("It won't work")]
+    [InlineData("It can't be used")]
+    public void Fix_AlreadyContracted_NoChange(string input)
+    {
+        var result = ContractionFixer.Fix(input);
+        Assert.Equal(input, result);
+    }
+
+    // ── Should NOT replace inside code/backticks ────────────────────
+
+    [Fact]
+    public void Fix_InsideBackticks_NotReplaced()
+    {
+        var input = "Use `does not` as a parameter value.";
+        var result = ContractionFixer.Fix(input);
+        Assert.Contains("`does not`", result);
+    }
+
+    // ── Multiple replacements in one string ─────────────────────────
+
+    [Fact]
+    public void Fix_MultipleOccurrences_AllReplaced()
+    {
+        var input = "It does not support X and it is not available in Y.";
+        var result = ContractionFixer.Fix(input);
+        Assert.Contains("doesn't", result);
+        Assert.Contains("isn't", result);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Fix_NullOrEmpty_ReturnsInput()
+    {
+        Assert.Equal("", ContractionFixer.Fix(""));
+        Assert.Equal("", ContractionFixer.Fix(null!));
+    }
+
+    [Fact]
+    public void Fix_NoMatchingPatterns_ReturnsUnchanged()
+    {
+        var input = "This is a normal sentence about Azure resources.";
+        var result = ContractionFixer.Fix(input);
+        Assert.Equal(input, result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ContractionFixer.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ContractionFixer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Converts formal non-contracted forms to contractions per Microsoft
+/// style guide (Acrolinx: "Tone > Could you use contractions to make
+/// it less formal?"). Fixes: #145
+/// 
+/// Only operates on prose text — skips content inside backticks.
+/// Idempotent — already-contracted text passes through unchanged.
+/// </summary>
+public static partial class ContractionFixer
+{
+    // Patterns: match the non-contracted form, capture case-preserving prefix
+    private static readonly (Regex Pattern, string Replacement)[] Rules =
+    [
+        (BuildRule("does not"), "doesn't"),
+        (BuildRule("do not"), "don't"),
+        (BuildRule("is not"), "isn't"),
+        (BuildRule("are not"), "aren't"),
+        (BuildRule("will not"), "won't"),
+        (BuildRule("cannot"), "can't"),
+        (BuildRule("can not"), "can't"),
+    ];
+
+    /// <summary>
+    /// Replaces non-contracted negative forms with contractions.
+    /// Skips text inside backticks to avoid breaking code references.
+    /// </summary>
+    public static string Fix(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+            return "";
+
+        var result = markdown;
+        foreach (var (pattern, replacement) in Rules)
+        {
+            result = pattern.Replace(result, replacement);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a regex that matches the phrase outside of backtick-delimited spans.
+    /// Uses a negative lookbehind/lookahead for backtick context.
+    /// </summary>
+    private static Regex BuildRule(string phrase)
+    {
+        // Match the phrase only when NOT inside backticks
+        // Simple heuristic: not preceded by ` without a closing `
+        return new Regex(
+            $@"(?<!`[^`]*)(?<!\w){Regex.Escape(phrase)}(?!\w)(?![^`]*`)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -50,6 +50,9 @@ public class FamilyFileStitcher
         // 7. Post-processing: ensure blank line between annotation link and values (#151)
         markdown = AnnotationSpaceFixer.Fix(markdown);
 
+        // 8. Post-processing: apply contractions per Microsoft style guide (#145)
+        markdown = ContractionFixer.Fix(markdown);
+
         return markdown;
     }
 

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt
@@ -162,6 +162,40 @@ Include relevant links to Azure MCP documentation and first-party Microsoft docu
 - Avoid unexplained jargon and acronyms
 - Use consistent terminology
 
+### Acrolinx Compliance Rules
+
+#### Overview Sentence Structure (#143)
+The overview paragraph immediately after H1 must be split into **two sentences**:
+1. **First sentence**: States the purpose — what the tool family lets you do
+2. **Second sentence**: Lists the capabilities — what specific resources or actions are available
+
+**Bad** (single complex sentence):
+> The Azure MCP Server lets you manage Azure Storage resources, including storage accounts, containers, tables, and blobs with natural language prompts.
+
+**Good** (two clear sentences):
+> The Azure MCP Server lets you manage Azure Storage resources with natural language prompts. You can work with storage accounts, containers, tables, and blobs.
+
+#### Present Tense and Contractions (#145)
+- **Use present tense** — describe what the tool does NOW, not what it "will" do
+  - Replace "will be generated" with "is generated"
+  - Replace "will return" with "returns"
+  - Replace "will be created" with "is created"
+- **Use contractions** per Microsoft style guide to keep a conversational tone:
+  - "does not" → "doesn't"
+  - "do not" → "don't"  
+  - "is not" → "isn't"
+  - "will not" → "won't"
+  - "cannot" / "can not" → "can't"
+
+#### Commas After Introductory Phrases (#146)
+Always add a comma after an introductory phrase at the start of a sentence:
+- "For each detector**,** it returns..."
+- "If not specified**,** the default value is used."
+- "When using this tool**,** you must provide..."
+- "After the operation completes**,** the result is returned."
+
+Common introductory phrases: For each, If not, When using, After, Before, In addition, By default, For example, In this case, To use.
+
 ### Technical Accuracy
 - Verify technical descriptions are accurate
 - Ensure command syntax is properly formatted


### PR DESCRIPTION
## Summary
Batch fix for 3 Acrolinx compliance issues. Adds prompt rules to the Step 4 system prompt AND a deterministic ContractionFixer post-processor.

### Prompt Rules Added
- **#143**: Overview must be two sentences — first states purpose, second lists capabilities
- **#145**: Use present tense (not future), use contractions per MS style guide
- **#146**: Add commas after introductory phrases (For each, If not, When using, etc.)

### Deterministic Post-Processor
**ContractionFixer** (step 7 in FamilyFileStitcher):
- Converts \does not\→\doesn't\, \is not\→\isn't\, \cannot\→\can't\, etc.
- Skips text inside backticks to avoid breaking code references
- Idempotent

## Changes
- \prompts/tool-family-cleanup-system-prompt.txt\ — new Acrolinx section
- \Services/ContractionFixer.cs\ — new post-processor
- \Services/FamilyFileStitcher.cs\ — wired ContractionFixer as step 7
- \AcrolinxPromptRuleTests.cs\ — 6 prompt content tests
- \ContractionFixerTests.cs\ — 18 behavioral tests

## Testing
- 24 new tests, all pass (red→green per AD-010)
- Full suite passes (800+ tests)

Closes #143, #145, #146