### PR TITLE
fix(#147): stop filtering resource-group and subscription as common params

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,8 +100,9 @@ Other configs:
 **Critical**: The parameter count shown in console output and `generation-summary.md` reflects only **non-common parameters** that appear in the documentation parameter tables.
 
 - **Common parameters** are defined in `docs-generation/common-parameters.json`:
-  - `--tenant`, `--subscription`, `--auth-method`, `--resource-group`
+  - `--tenant`, `--auth-method` (infrastructure params)
   - `--retry-delay`, `--retry-max-delay`, `--retry-max-retries`, `--retry-mode`, `--retry-network-timeout`
+  - Note: `--resource-group` and `--subscription` are **scoping params** — NOT in common-parameters.json because they are tool-specific and change behavior when present
 - **Exception**: Common parameters that are **required** for a specific tool are kept in the table
 - The count matches what users see in the parameter tables in the generated `.md` files
 - **Filtering occurs in**:
@@ -567,7 +568,7 @@ pwsh -File "$SCRIPT_DIR/MyScript.ps1" -ToolFamily "$TOOL_FAMILY" -Steps "$STEPS"
 - **Every bug fix MUST include tests**: When fixing a bug or error, add one or more unit tests that reproduce the bug and verify the fix. Tests must be placed in a `.Tests` project that is part of `docs-generation.sln` so that CI (`dotnet test docs-generation.sln`) runs them automatically. If no `.Tests` project exists for the affected project, create one (xunit, CPM, added to the solution). If the code under test has `private` methods that need testing, change them to `internal` and add `<InternalsVisibleTo Include="ProjectName.Tests" />` to the source project's `.csproj`.
 - **For new generators**: Place in `Generators/` directory, follow existing patterns
   - Use dependency injection for shared functions (brand mapping, filename cleaning)
-  - Filter common parameters using `ExtractCommonParameters` unless they're required
+  - Filter infrastructure parameters (tenant, auth-method, retry-*) using `common-parameters.json` — scoping params like resource-group and subscription are NOT filtered
   - Document in separate README.md file within the generator directory
 - **For Azure OpenAI integration**:
   - Always implement retry logic with exponential backoff (see `GenerativeAIClient.cs`)

--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
@@ -119,4 +119,79 @@ public class ParameterGeneratorTests
         Assert.True(parameter.IsConditionalRequired);
         Assert.Equal("Provide vault name.", parameter.Description);
     }
+
+    // ── Common Parameter Filtering (#147) ──────────────────────────
+
+    [Fact]
+    public void CommonParameters_DoNotIncludeResourceGroup()
+    {
+        // resource-group is a scoping parameter used by only ~35 tools,
+        // NOT a universal infrastructure param. It must NOT be in common-parameters.json.
+        var commonParamsPath = Path.Combine(
+            FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
+        var json = File.ReadAllText(commonParamsPath);
+        var commonParams = System.Text.Json.JsonSerializer.Deserialize<List<CommonParam>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(commonParams);
+        Assert.DoesNotContain(commonParams, p => p.Name == "--resource-group");
+    }
+
+    [Fact]
+    public void CommonParameters_DoNotIncludeSubscription()
+    {
+        // subscription is also a scoping parameter — tools that declare it
+        // need it shown in their parameter table for user clarity.
+        var commonParamsPath = Path.Combine(
+            FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
+        var json = File.ReadAllText(commonParamsPath);
+        var commonParams = System.Text.Json.JsonSerializer.Deserialize<List<CommonParam>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(commonParams);
+        Assert.DoesNotContain(commonParams, p => p.Name == "--subscription");
+    }
+
+    [Fact]
+    public void CommonParameters_OnlyContainInfrastructureParams()
+    {
+        // Only retry-*, auth-method, and tenant are true infrastructure params
+        // that appear on ALL tools and add no tool-specific information.
+        var commonParamsPath = Path.Combine(
+            FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
+        var json = File.ReadAllText(commonParamsPath);
+        var commonParams = System.Text.Json.JsonSerializer.Deserialize<List<CommonParam>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(commonParams);
+        var allowedPrefixes = new[] { "--retry-", "--auth-method", "--tenant" };
+        foreach (var param in commonParams)
+        {
+            Assert.True(
+                allowedPrefixes.Any(p => param.Name!.StartsWith(p, StringComparison.OrdinalIgnoreCase)),
+                $"Unexpected common parameter '{param.Name}' — scoping params like resource-group and subscription should not be common");
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static string FindProjectRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "docs-generation.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find project root (docs-generation.sln)");
+    }
+
+    private sealed class CommonParam
+    {
+        public string? Name { get; set; }
+        public string? Type { get; set; }
+        public string? Description { get; set; }
+        public bool IsRequired { get; set; }
+    }
 }

--- a/docs-generation/data/common-parameters.json
+++ b/docs-generation/data/common-parameters.json
@@ -6,21 +6,9 @@
     "isRequired": false
   },
   {
-    "name": "--subscription",
-    "type": "string",
-    "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-    "isRequired": false
-  },
-  {
     "name": "--auth-method",
     "type": "string",
     "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-    "isRequired": false
-  },
-  {
-    "name": "--resource-group",
-    "type": "string",
-    "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
     "isRequired": false
   },
   {


### PR DESCRIPTION
## Summary
Removes \--resource-group\ and \--subscription\ from \common-parameters.json\. These are **scoping parameters** that change tool behavior when present, not universal infrastructure params.

### Root Cause
\ParameterGenerator.cs\ filters out any parameter in \common-parameters.json\ that isn't required. Since \esource-group\ was listed as common and is optional for \webapp get\, it was silently dropped from the parameter table.

### Impact
- **35 tools** will now correctly show \esource-group\ in their parameter tables
- All tools declaring \subscription\ will now show it too
- Common params now limited to true infrastructure: \--tenant\, \--auth-method\, \--retry-*\

### Changes
- \data/common-parameters.json\ — removed resource-group and subscription entries
- \ParameterGeneratorTests.cs\ — 3 guard tests (red→green per AD-010)
- \.github/copilot-instructions.md\ — updated common param documentation

### Testing
- 3 new tests, full suite passes

Closes #147