### PR TITLE
feat(#150): multi-namespace merge config schema + validation (Phase 1-2)

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -203,6 +203,25 @@ Step dependency chain (what each step reads from disk):
 
 Generated content must NEVER use `~/` (DocFX repo-root) paths. Use only: absolute URLs, site-root-relative (`/azure/...`), or file-relative (`../includes/...`) paths.
 
+### AD-011: Multi-Namespace Merge — Post-Assembly Design
+**Date:** 2026-03-22  
+**Author:** Avery (Lead)  
+**Status:** Active
+
+Some Azure services span multiple MCP namespaces but publish as a single article (e.g., `monitor` + `workbooks` → `azure-monitor.md`). Rather than threading multi-namespace awareness through all 6 pipeline steps (high risk), we use a **post-assembly merge** pattern:
+
+1. Each namespace generates independently through Steps 1-6 as before
+2. A merge step runs AFTER all namespaces complete
+3. Grouped namespaces are defined in `brand-to-server-mapping.json` via optional fields:
+   - `mergeGroup`: group identifier (e.g., `"azure-monitor"`)
+   - `mergeOrder`: position within group (1 = primary)
+   - `mergeRole`: `"primary"` (owns frontmatter/overview/related-content) or `"secondary"` (contributes tool H2 sections only)
+4. Namespaces WITHOUT `mergeGroup` are standalone — fully backward compatible
+5. Validation rules:
+   - Each group must have exactly one `"primary"` namespace
+   - `mergeOrder` values must be unique and sequential within a group
+   - `mergeGroup` value should match the primary namespace's `fileName`
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/docs-generation/DocGeneration.Core.Shared/BrandMapping.cs
+++ b/docs-generation/DocGeneration.Core.Shared/BrandMapping.cs
@@ -12,4 +12,24 @@ public class BrandMapping
     public string McpServerName { get; set; } = string.Empty;
     public string ShortName { get; set; } = string.Empty;
     public string FileName { get; set; } = string.Empty;
+
+    // Multi-namespace merge support (AD-011)
+    // All three fields are optional — namespaces without them are standalone.
+
+    /// <summary>
+    /// Group identifier for namespaces that merge into a single article.
+    /// Should match the primary namespace's FileName.
+    /// </summary>
+    public string? MergeGroup { get; set; }
+
+    /// <summary>
+    /// Position within the merge group (1 = first/primary).
+    /// </summary>
+    public int? MergeOrder { get; set; }
+
+    /// <summary>
+    /// Role in the merge group: "primary" (owns frontmatter, overview, related content)
+    /// or "secondary" (contributes only tool H2 sections).
+    /// </summary>
+    public string? MergeRole { get; set; }
 }

--- a/docs-generation/DocGeneration.Core.Shared/MergeGroupValidator.cs
+++ b/docs-generation/DocGeneration.Core.Shared/MergeGroupValidator.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shared;
+
+/// <summary>
+/// Validates merge group configuration in brand-to-server-mapping.json.
+/// Per AD-011: multi-namespace articles use post-assembly merge with
+/// config-driven grouping.
+/// </summary>
+public static class MergeGroupValidator
+{
+    private static readonly HashSet<string> ValidRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "primary", "secondary"
+    };
+
+    /// <summary>
+    /// Validates all merge group configurations. Returns a list of error messages
+    /// (empty = valid).
+    /// </summary>
+    public static List<string> Validate(IReadOnlyList<BrandMapping> mappings)
+    {
+        var errors = new List<string>();
+
+        // Check individual entries for incomplete merge fields
+        foreach (var m in mappings)
+        {
+            if (string.IsNullOrEmpty(m.MergeGroup))
+                continue;
+
+            if (!m.MergeOrder.HasValue)
+                errors.Add($"'{m.McpServerName}': has mergeGroup '{m.MergeGroup}' but missing mergeOrder");
+
+            if (string.IsNullOrEmpty(m.MergeRole))
+                errors.Add($"'{m.McpServerName}': has mergeGroup '{m.MergeGroup}' but missing mergeRole");
+            else if (!ValidRoles.Contains(m.MergeRole))
+                errors.Add($"'{m.McpServerName}': invalid mergeRole '{m.MergeRole}' — must be 'primary' or 'secondary'");
+        }
+
+        // Group-level validation
+        var groups = mappings
+            .Where(m => !string.IsNullOrEmpty(m.MergeGroup))
+            .GroupBy(m => m.MergeGroup!);
+
+        foreach (var group in groups)
+        {
+            var primaries = group.Where(m =>
+                string.Equals(m.MergeRole, "primary", StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (primaries.Count == 0)
+                errors.Add($"Merge group '{group.Key}': no primary namespace defined");
+            else if (primaries.Count > 1)
+                errors.Add($"Merge group '{group.Key}': multiple primary namespaces ({string.Join(", ", primaries.Select(p => p.McpServerName))})");
+
+            // Check for duplicate mergeOrder values
+            var orders = group
+                .Where(m => m.MergeOrder.HasValue)
+                .GroupBy(m => m.MergeOrder!.Value)
+                .Where(g => g.Count() > 1);
+
+            foreach (var dup in orders)
+                errors.Add($"Merge group '{group.Key}': duplicate mergeOrder {dup.Key} ({string.Join(", ", dup.Select(d => d.McpServerName))})");
+        }
+
+        return errors;
+    }
+}

--- a/docs-generation/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/MergeGroupValidatorTests.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/MergeGroupValidatorTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Shared;
+using Xunit;
+
+namespace DocGeneration.Steps.Bootstrap.BrandMappings.Tests;
+
+/// <summary>
+/// Tests for MergeGroupValidator — validates merge group configuration
+/// in brand-to-server-mapping.json per AD-011.
+/// </summary>
+public class MergeGroupValidatorTests
+{
+    // ── Valid configurations ────────────────────────────────────────
+
+    [Fact]
+    public void Validate_NoMergeGroups_ReturnsValid()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "storage", FileName = "azure-storage" },
+            new() { McpServerName = "cosmos", FileName = "azure-cosmos-db" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_ValidMergeGroup_ReturnsValid()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary" },
+            new() { McpServerName = "workbooks", FileName = "azure-workbooks",
+                     MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary" },
+            new() { McpServerName = "storage", FileName = "azure-storage" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Empty(errors);
+    }
+
+    // ── Missing primary ─────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_GroupWithNoPrimary_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "secondary" },
+            new() { McpServerName = "workbooks", FileName = "azure-workbooks",
+                     MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Single(errors);
+        Assert.Contains("primary", errors[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Multiple primaries ──────────────────────────────────────────
+
+    [Fact]
+    public void Validate_GroupWithMultiplePrimaries_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary" },
+            new() { McpServerName = "workbooks", FileName = "azure-workbooks",
+                     MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "primary" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Single(errors);
+        Assert.Contains("multiple", errors[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Incomplete merge fields ─────────────────────────────────────
+
+    [Fact]
+    public void Validate_MergeGroupWithoutOrder_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeRole = "primary" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Single(errors);
+        Assert.Contains("mergeOrder", errors[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_MergeGroupWithoutRole_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1 }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.NotEmpty(errors);
+        Assert.Contains(errors, e => e.Contains("mergeRole", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Duplicate merge order ───────────────────────────────────────
+
+    [Fact]
+    public void Validate_DuplicateMergeOrder_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary" },
+            new() { McpServerName = "workbooks", FileName = "azure-workbooks",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "secondary" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Single(errors);
+        Assert.Contains("duplicate", errors[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Invalid role value ──────────────────────────────────────────
+
+    [Fact]
+    public void Validate_InvalidMergeRole_ReturnsError()
+    {
+        var mappings = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "leader" }
+        };
+
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Contains(errors, e => e.Contains("mergeRole", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Production config test ──────────────────────────────────────
+
+    [Fact]
+    public void Validate_ProductionBrandMapping_IsValid()
+    {
+        // Verify the actual brand-to-server-mapping.json is valid
+        var mappingPath = Path.Combine(
+            FindProjectRoot(), "docs-generation", "data", "brand-to-server-mapping.json");
+        var json = File.ReadAllText(mappingPath);
+        var mappings = System.Text.Json.JsonSerializer.Deserialize<List<BrandMapping>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(mappings);
+        var errors = MergeGroupValidator.Validate(mappings);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_ProductionConfig_HasMonitorWorkbooksGroup()
+    {
+        var mappingPath = Path.Combine(
+            FindProjectRoot(), "docs-generation", "data", "brand-to-server-mapping.json");
+        var json = File.ReadAllText(mappingPath);
+        var mappings = System.Text.Json.JsonSerializer.Deserialize<List<BrandMapping>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(mappings);
+        var monitorGroup = mappings.Where(m => m.MergeGroup == "azure-monitor").ToList();
+        Assert.Equal(2, monitorGroup.Count);
+        Assert.Single(monitorGroup, m => m.MergeRole == "primary" && m.McpServerName == "monitor");
+        Assert.Single(monitorGroup, m => m.MergeRole == "secondary" && m.McpServerName == "workbooks");
+    }
+
+    private static string FindProjectRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "docs-generation.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find project root");
+    }
+}

--- a/docs-generation/data/brand-to-server-mapping.json
+++ b/docs-generation/data/brand-to-server-mapping.json
@@ -219,7 +219,10 @@
     "brandName": "Azure Monitor",
     "mcpServerName": "monitor",
     "shortName": "Monitor",
-    "fileName": "azure-monitor"
+    "fileName": "azure-monitor",
+    "mergeGroup": "azure-monitor",
+    "mergeOrder": 1,
+    "mergeRole": "primary"
   },
   {
     "brandName": "Azure Monitor Instrumentation",
@@ -345,6 +348,9 @@
     "brandName": "Azure Workbooks",
     "mcpServerName": "workbooks",
     "shortName": "Workbooks",
-    "fileName": "azure-workbooks"
+    "fileName": "azure-workbooks",
+    "mergeGroup": "azure-monitor",
+    "mergeOrder": 2,
+    "mergeRole": "secondary"
   }
 ]


### PR DESCRIPTION
## Summary
Lays the foundation for multi-namespace tool articles (e.g., monitor + workbooks → azure-monitor.md). This PR covers **Phase 1 (spec) and Phase 2 (config + validation)** only — the merge implementation will follow in a separate PR.

### AD-011: Post-Assembly Merge Design
Rather than threading multi-namespace awareness through all 6 pipeline steps, we use a **post-assembly merge** pattern:
1. Each namespace generates independently (no pipeline changes)
2. A merge step combines grouped namespace outputs after all processing completes
3. Groupings are config-driven in \rand-to-server-mapping.json\

### Schema Extensions (BrandMapping.cs)
| Field | Type | Description |
|-------|------|-------------|
| \mergeGroup\ | string? | Group ID for namespaces that merge (matches primary's fileName) |
| \mergeOrder\ | int? | Position within group (1 = first) |
| \mergeRole\ | string? | \primary\ (owns frontmatter/overview) or \secondary\ (tools only) |

All three fields are optional — namespaces without them work exactly as before.

### Config Added
- **monitor**: \mergeGroup: azure-monitor, mergeOrder: 1, mergeRole: primary\
- **workbooks**: \mergeGroup: azure-monitor, mergeOrder: 2, mergeRole: secondary\

### MergeGroupValidator
Validates: exactly 1 primary per group, no duplicate orders, all merge fields present together, valid role values.

### Changes
- \DocGeneration.Core.Shared/BrandMapping.cs\ — 3 new optional properties
- \DocGeneration.Core.Shared/MergeGroupValidator.cs\ — new validation class
- \data/brand-to-server-mapping.json\ — monitor + workbooks config
- \MergeGroupValidatorTests.cs\ — 10 behavioral tests
- \.squad/decisions.md\ — AD-011

### Testing
- 10 new tests (valid groups, missing primary, multiple primaries, incomplete fields, invalid roles, duplicate orders, production config verification)
- Full suite passes

Part of #150 — Phases 3-5 (implementation, wiring, docs) will follow