### PR TITLE
feat(#150): implement NamespaceMerger for multi-namespace articles (Phase 3)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/NamespaceMergerTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/NamespaceMergerTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Shared;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for NamespaceMerger — merges tool-family articles from grouped
+/// namespaces into a single article per AD-011.
+/// </summary>
+public class NamespaceMergerTests
+{
+    private static string BuildArticle(string title, string service, int toolCount,
+        string overview, string[] tools, string relatedContent) =>
+        string.Join("\n", new[]
+        {
+            "---",
+            $"title: Azure MCP Server tools for {title}",
+            $"description: Use Azure MCP Server tools for {title}.",
+            "ms.service: azure-mcp-server",
+            "ms.topic: concept-article",
+            $"tool_count: {toolCount}",
+            "---",
+            "",
+            $"# Azure MCP Server tools for {title}",
+            "",
+            overview,
+            "",
+            "[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]",
+            ""
+        }.Concat(tools.SelectMany(t => new[] { t, "" }))
+         .Concat(new[] { "## Related content", "", relatedContent }));
+
+    // ── Core merge behavior ─────────────────────────────────────────
+
+    [Fact]
+    public void Merge_TwoNamespaces_CombinesToolSections()
+    {
+        var primary = BuildArticle("Azure Monitor", "monitor", 2,
+            "Monitor overview.",
+            new[] { "## Query metrics\n\nQuery metrics content.", "## List activity logs\n\nActivity log content." },
+            "- [Monitor docs](/azure/azure-monitor/)");
+
+        var secondary = BuildArticle("Azure Workbooks", "workbooks", 1,
+            "Workbooks overview.",
+            new[] { "## Create workbook\n\nCreate workbook content." },
+            "- [Workbooks docs](/azure/azure-monitor/visualize/)");
+
+        var config = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", FileName = "azure-monitor",
+                     MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary" },
+            new() { McpServerName = "workbooks", FileName = "azure-workbooks",
+                     MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary" }
+        };
+
+        var articles = new Dictionary<string, string>
+        {
+            ["monitor"] = primary,
+            ["workbooks"] = secondary
+        };
+
+        var result = NamespaceMerger.Merge(articles, config);
+
+        // Should have one merged article
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("azure-monitor"));
+
+        var merged = result["azure-monitor"];
+
+        // Primary's H1 and overview preserved
+        Assert.Contains("# Azure MCP Server tools for Azure Monitor", merged);
+        Assert.Contains("Monitor overview.", merged);
+
+        // All 3 tool sections present
+        Assert.Contains("## Query metrics", merged);
+        Assert.Contains("## List activity logs", merged);
+        Assert.Contains("## Create workbook", merged);
+
+        // Secondary's overview NOT included
+        Assert.DoesNotContain("Workbooks overview.", merged);
+
+        // Related content from primary
+        Assert.Contains("## Related content", merged);
+        Assert.Contains("Monitor docs", merged);
+    }
+
+    [Fact]
+    public void Merge_UpdatesToolCount()
+    {
+        var primary = BuildArticle("Azure Monitor", "monitor", 2,
+            "Overview.",
+            new[] { "## Tool A\n\nContent A.", "## Tool B\n\nContent B." },
+            "- [Link](/azure/)");
+
+        var secondary = BuildArticle("Azure Workbooks", "workbooks", 1,
+            "Overview.",
+            new[] { "## Tool C\n\nContent C." },
+            "- [Link](/azure/)");
+
+        var config = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary", FileName = "azure-monitor" },
+            new() { McpServerName = "workbooks", MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary", FileName = "azure-workbooks" }
+        };
+
+        var articles = new Dictionary<string, string> { ["monitor"] = primary, ["workbooks"] = secondary };
+        var result = NamespaceMerger.Merge(articles, config);
+
+        // tool_count should be 3 (2 + 1)
+        Assert.Contains("tool_count: 3", result["azure-monitor"]);
+    }
+
+    // ── Ungrouped namespaces pass through ───────────────────────────
+
+    [Fact]
+    public void Merge_UngroupedNamespaces_PassThrough()
+    {
+        var storage = BuildArticle("Azure Storage", "storage", 3,
+            "Storage overview.",
+            new[] { "## List accounts\n\nContent.", "## Get blob\n\nContent.", "## Upload file\n\nContent." },
+            "- [Storage docs](/azure/storage/)");
+
+        var config = new List<BrandMapping>
+        {
+            new() { McpServerName = "storage", FileName = "azure-storage" }
+        };
+
+        var articles = new Dictionary<string, string> { ["storage"] = storage };
+        var result = NamespaceMerger.Merge(articles, config);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("storage"));
+        Assert.Equal(storage, result["storage"]);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Merge_EmptyArticleMap_ReturnsEmpty()
+    {
+        var result = NamespaceMerger.Merge(
+            new Dictionary<string, string>(),
+            new List<BrandMapping>());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Merge_MissingSecondaryArticle_UsesOnlyPrimary()
+    {
+        var primary = BuildArticle("Azure Monitor", "monitor", 2,
+            "Overview.",
+            new[] { "## Tool A\n\nContent.", "## Tool B\n\nContent." },
+            "- [Link](/azure/)");
+
+        var config = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary", FileName = "azure-monitor" },
+            new() { McpServerName = "workbooks", MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary", FileName = "azure-workbooks" }
+        };
+
+        // Only primary provided, secondary missing
+        var articles = new Dictionary<string, string> { ["monitor"] = primary };
+        var result = NamespaceMerger.Merge(articles, config);
+
+        Assert.Single(result);
+        Assert.Contains("## Tool A", result["azure-monitor"]);
+        Assert.Contains("tool_count: 2", result["azure-monitor"]);
+    }
+
+    [Fact]
+    public void Merge_OrderRespected_SecondaryToolsAfterPrimary()
+    {
+        var primary = BuildArticle("Azure Monitor", "monitor", 1,
+            "Overview.",
+            new[] { "## AAA Primary Tool\n\nFirst." },
+            "- [Link](/azure/)");
+
+        var secondary = BuildArticle("Azure Workbooks", "workbooks", 1,
+            "Overview.",
+            new[] { "## ZZZ Secondary Tool\n\nSecond." },
+            "- [Link](/azure/)");
+
+        var config = new List<BrandMapping>
+        {
+            new() { McpServerName = "monitor", MergeGroup = "azure-monitor", MergeOrder = 1, MergeRole = "primary", FileName = "azure-monitor" },
+            new() { McpServerName = "workbooks", MergeGroup = "azure-monitor", MergeOrder = 2, MergeRole = "secondary", FileName = "azure-workbooks" }
+        };
+
+        var articles = new Dictionary<string, string> { ["monitor"] = primary, ["workbooks"] = secondary };
+        var result = NamespaceMerger.Merge(articles, config);
+
+        var merged = result["azure-monitor"];
+        var primaryIdx = merged.IndexOf("## AAA Primary Tool");
+        var secondaryIdx = merged.IndexOf("## ZZZ Secondary Tool");
+        var relatedIdx = merged.IndexOf("## Related content");
+
+        Assert.True(primaryIdx < secondaryIdx, "Primary tools should come before secondary");
+        Assert.True(secondaryIdx < relatedIdx, "Secondary tools should come before Related content");
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/NamespaceMerger.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/NamespaceMerger.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Shared;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Merges tool-family articles from grouped namespaces into a single article.
+/// Per AD-011: post-assembly merge using config from brand-to-server-mapping.json.
+///
+/// Primary namespace contributes: frontmatter, H1, overview, related content.
+/// Secondary namespaces contribute: tool H2 sections only.
+/// </summary>
+public static partial class NamespaceMerger
+{
+    [GeneratedRegex(@"^tool_count:\s*(\d+)", RegexOptions.Multiline)]
+    private static partial Regex ToolCountPattern();
+
+    /// <summary>
+    /// Merges articles based on merge group configuration.
+    /// Returns a dictionary of outputKey → merged markdown.
+    /// Ungrouped namespaces pass through unchanged.
+    /// </summary>
+    public static Dictionary<string, string> Merge(
+        Dictionary<string, string> articles,
+        IReadOnlyList<BrandMapping> mappings)
+    {
+        var result = new Dictionary<string, string>();
+
+        // Find merge groups
+        var groups = mappings
+            .Where(m => !string.IsNullOrEmpty(m.MergeGroup))
+            .GroupBy(m => m.MergeGroup!)
+            .ToDictionary(g => g.Key, g => g.OrderBy(m => m.MergeOrder ?? 99).ToList());
+
+        // Track which namespaces are in a merge group
+        var groupedNamespaces = new HashSet<string>(
+            groups.Values.SelectMany(g => g.Select(m => m.McpServerName)),
+            StringComparer.OrdinalIgnoreCase);
+
+        // Pass through ungrouped namespaces unchanged
+        foreach (var (ns, content) in articles)
+        {
+            if (!groupedNamespaces.Contains(ns))
+                result[ns] = content;
+        }
+
+        // Process each merge group
+        foreach (var (groupKey, members) in groups)
+        {
+            var primary = members.FirstOrDefault(m =>
+                string.Equals(m.MergeRole, "primary", StringComparison.OrdinalIgnoreCase));
+
+            if (primary == null || !articles.ContainsKey(primary.McpServerName))
+                continue;
+
+            var primaryContent = articles[primary.McpServerName];
+            var (header, primaryTools, relatedContent) = ParseArticle(primaryContent);
+
+            // Collect tool sections from all members in order
+            var allTools = new List<string>(primaryTools);
+            foreach (var member in members)
+            {
+                if (string.Equals(member.MergeRole, "primary", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!articles.TryGetValue(member.McpServerName, out var secondaryContent))
+                    continue;
+
+                var (_, secondaryTools, _) = ParseArticle(secondaryContent);
+                allTools.AddRange(secondaryTools);
+            }
+
+            // Build merged article
+            var totalToolCount = allTools.Count;
+            var updatedHeader = UpdateToolCount(header, totalToolCount);
+
+            var sb = new StringBuilder();
+            sb.Append(updatedHeader);
+
+            foreach (var tool in allTools)
+            {
+                sb.AppendLine(tool);
+                sb.AppendLine();
+            }
+
+            sb.AppendLine("## Related content");
+            sb.AppendLine();
+            sb.Append(relatedContent);
+
+            result[groupKey] = sb.ToString().TrimEnd() + "\n";
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses an article into header (frontmatter + H1 + overview),
+    /// tool H2 sections, and related content.
+    /// </summary>
+    internal static (string Header, List<string> Tools, string RelatedContent) ParseArticle(string markdown)
+    {
+        var lines = markdown.Split('\n');
+        var header = new StringBuilder();
+        var tools = new List<string>();
+        var relatedContent = new StringBuilder();
+
+        var currentSection = new StringBuilder();
+        var inHeader = true;
+        var inRelated = false;
+        var foundFirstH2 = false;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith("## "))
+            {
+                if (inHeader)
+                {
+                    inHeader = false;
+                    // Flush header (everything before first H2)
+                }
+
+                if (string.Equals(line.TrimEnd(), "## Related content", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Save any current tool section
+                    if (currentSection.Length > 0 && foundFirstH2)
+                        tools.Add(currentSection.ToString().TrimEnd());
+
+                    currentSection.Clear();
+                    inRelated = true;
+                    continue;
+                }
+
+                // Save previous tool section
+                if (foundFirstH2 && currentSection.Length > 0)
+                    tools.Add(currentSection.ToString().TrimEnd());
+
+                currentSection.Clear();
+                currentSection.AppendLine(line);
+                foundFirstH2 = true;
+                continue;
+            }
+
+            if (inRelated)
+            {
+                relatedContent.AppendLine(line);
+            }
+            else if (inHeader)
+            {
+                header.AppendLine(line);
+            }
+            else
+            {
+                currentSection.AppendLine(line);
+            }
+        }
+
+        // Flush last section
+        if (!inRelated && foundFirstH2 && currentSection.Length > 0)
+            tools.Add(currentSection.ToString().TrimEnd());
+
+        return (header.ToString(), tools, relatedContent.ToString().TrimEnd());
+    }
+
+    /// <summary>
+    /// Updates the tool_count value in frontmatter.
+    /// </summary>
+    internal static string UpdateToolCount(string header, int newCount)
+    {
+        return ToolCountPattern().Replace(header, $"tool_count: {newCount}");
+    }
+}


### PR DESCRIPTION
## Summary
Implements **NamespaceMerger** — the core merge logic that combines tool-family articles from grouped namespaces into a single article.

### How It Works
1. **ParseArticle()** splits markdown into: header (frontmatter + H1 + overview), tool H2 sections, related content
2. **Merge()** takes primary's header + all namespaces' tools (in mergeOrder) + primary's related content
3. **UpdateToolCount()** patches frontmatter with combined tool count
4. Ungrouped namespaces pass through unchanged

### Example
\\\
monitor (15 tools) + workbooks (5 tools)
→ azure-monitor.md (20 tools, monitor's frontmatter/overview)
\\\

### Changes
- \Services/NamespaceMerger.cs\ — merge logic with ParseArticle + UpdateToolCount
- \NamespaceMergerTests.cs\ — 6 behavioral tests

### Testing
- 6 tests: core merge, tool_count update, ungrouped passthrough, empty input, missing secondary graceful handling, ordering verification
- Full suite passes

Part of #150 — Phase 4 (start.sh wiring) and Phase 5 (docs) still pending