### PR TITLE
feat(#163): deterministic verb-based example prompts (Tier 2a)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicExamplePromptGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicExamplePromptGeneratorTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ExamplePromptGeneratorStandalone.Generators;
+using ExamplePromptGeneratorStandalone.Models;
+using Xunit;
+
+namespace ExamplePromptGeneratorStandalone.Tests;
+
+public class DeterministicExamplePromptGeneratorTests
+{
+    // ── ClassifyVerb ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("storage account list", "list")]
+    [InlineData("keyvault secret create", "create")]
+    [InlineData("cosmos container get", "get")]
+    [InlineData("sql database delete", "delete")]
+    [InlineData("appservice webapp update", "update")]
+    [InlineData("storage blob list", "list")]
+    [InlineData("redis create", "create")]
+    public void ClassifyVerb_StandardVerbs_ReturnsCorrectVerb(string command, string expected)
+    {
+        var result = DeterministicExamplePromptGenerator.ClassifyVerb(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("monitor query")]
+    [InlineData("kusto execute")]
+    [InlineData("speech recognize")]
+    [InlineData("deploy generate_plan")]
+    public void ClassifyVerb_NonStandardVerbs_ReturnsNull(string command)
+    {
+        var result = DeterministicExamplePromptGenerator.ClassifyVerb(command);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ClassifyVerb_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(DeterministicExamplePromptGenerator.ClassifyVerb(""));
+        Assert.Null(DeterministicExamplePromptGenerator.ClassifyVerb(null!));
+    }
+
+    // ── IsEligible ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEligible_StandardVerbNoE2e_ReturnsTrue()
+    {
+        var tool = MakeTool("storage account list", "List storage accounts");
+        Assert.True(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_StandardVerbWithE2e_ReturnsFalse()
+    {
+        var tool = MakeTool("storage account list", "List storage accounts");
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: true));
+    }
+
+    [Fact]
+    public void IsEligible_NonStandardVerb_ReturnsFalse()
+    {
+        var tool = MakeTool("monitor query", "Execute a query");
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    // ── ExtractResource ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("storage account list", "account")]
+    [InlineData("keyvault secret create", "secret")]
+    [InlineData("cosmos container get", "container")]
+    [InlineData("storage blob list", "blob")]
+    [InlineData("redis list", "redis")]
+    public void ExtractResource_ReturnsMiddleSegments(string command, string expected)
+    {
+        var result = DeterministicExamplePromptGenerator.ExtractResource(command);
+        Assert.Equal(expected, result);
+    }
+
+    // ── Generate: structure ─────────────────────────────────────────
+
+    [Fact]
+    public void Generate_ReturnsExactlyFivePrompts()
+    {
+        var tool = MakeTool("storage account list", "List storage accounts",
+            new Option { Name = "subscription", Required = true, Description = "Azure subscription" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        Assert.NotNull(response);
+        Assert.Equal(5, response.Prompts.Count);
+    }
+
+    [Fact]
+    public void Generate_SetsToolName()
+    {
+        var tool = MakeTool("storage account list", "List storage accounts");
+        tool.Name = "storage_account_list";
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        Assert.Equal("storage_account_list", response.ToolName);
+    }
+
+    // ── Generate: required params in every prompt ───────────────────
+
+    [Fact]
+    public void Generate_AllPromptsContainRequiredParamValues()
+    {
+        var tool = MakeTool("storage blob list", "List blobs",
+            new Option { Name = "account", Required = true, Description = "Storage account name" },
+            new Option { Name = "container-name", Required = true, Description = "Container name" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        foreach (var prompt in response.Prompts)
+        {
+            // Each prompt must contain single-quoted values for both required params
+            Assert.Matches(@"'[^']+'", prompt); // at least one quoted value
+            // Count quoted values — should be at least 2 (one per required param)
+            var quoteCount = System.Text.RegularExpressions.Regex.Matches(prompt, @"'[^']+'").Count;
+            Assert.True(quoteCount >= 2,
+                $"Prompt should contain values for all 2 required params but has {quoteCount} quoted values: {prompt}");
+        }
+    }
+
+    [Fact]
+    public void Generate_NoRequiredParams_StillGeneratesFivePrompts()
+    {
+        var tool = MakeTool("advisor list", "List recommendations");
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        Assert.Equal(5, response.Prompts.Count);
+    }
+
+    // ── Generate: prompt quality ────────────────────────────────────
+
+    [Fact]
+    public void Generate_AllPromptsEndWithPunctuation()
+    {
+        var tool = MakeTool("keyvault secret create", "Create a secret",
+            new Option { Name = "vault", Required = true, Description = "Key vault name" },
+            new Option { Name = "secret-name", Required = true, Description = "Secret name" },
+            new Option { Name = "value", Required = true, Description = "Secret value" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        foreach (var prompt in response.Prompts)
+        {
+            Assert.True(
+                prompt.EndsWith(".") || prompt.EndsWith("?"),
+                $"Prompt should end with . or ? but got: {prompt}");
+        }
+    }
+
+    [Fact]
+    public void Generate_PromptsUseSingleQuotesForValues()
+    {
+        var tool = MakeTool("storage account get", "Get storage account",
+            new Option { Name = "account", Required = true, Description = "Storage account name" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        foreach (var prompt in response.Prompts)
+        {
+            Assert.Contains("'", prompt);
+            Assert.DoesNotContain("<", prompt); // no angle brackets
+            Assert.DoesNotContain("`", prompt); // no backticks
+        }
+    }
+
+    [Fact]
+    public void Generate_ListVerb_UsesListStyleLanguage()
+    {
+        var tool = MakeTool("storage table list", "List tables",
+            new Option { Name = "account", Required = true, Description = "Storage account" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        // At least one prompt should use list-style language
+        var hasListLanguage = response.Prompts.Any(p =>
+            p.Contains("List", StringComparison.OrdinalIgnoreCase) ||
+            p.Contains("Show", StringComparison.OrdinalIgnoreCase) ||
+            p.Contains("Display", StringComparison.OrdinalIgnoreCase) ||
+            p.Contains("What", StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(hasListLanguage, "List verb should produce list-style language");
+    }
+
+    [Fact]
+    public void Generate_CreateVerb_UsesCreateStyleLanguage()
+    {
+        var tool = MakeTool("storage account create", "Create storage account",
+            new Option { Name = "account", Required = true, Description = "Account name" },
+            new Option { Name = "location", Required = true, Description = "Location" },
+            new Option { Name = "resource-group", Required = true, Description = "Resource group" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        var hasCreateLanguage = response.Prompts.Any(p =>
+            p.Contains("Create", StringComparison.OrdinalIgnoreCase) ||
+            p.Contains("Set up", StringComparison.OrdinalIgnoreCase) ||
+            p.Contains("Add", StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(hasCreateLanguage, "Create verb should produce create-style language");
+    }
+
+    // ── Generate: idempotent ────────────────────────────────────────
+
+    [Fact]
+    public void Generate_SameInput_SameOutput()
+    {
+        var tool1 = MakeTool("storage account list", "List accounts",
+            new Option { Name = "subscription", Required = true, Description = "Subscription" });
+        var tool2 = MakeTool("storage account list", "List accounts",
+            new Option { Name = "subscription", Required = true, Description = "Subscription" });
+        tool1.Name = "storage_account_list";
+        tool2.Name = "storage_account_list";
+
+        var r1 = DeterministicExamplePromptGenerator.Generate(tool1);
+        var r2 = DeterministicExamplePromptGenerator.Generate(tool2);
+
+        Assert.Equal(r1.Prompts, r2.Prompts);
+    }
+
+    // ── Generate: varied prompts ────────────────────────────────────
+
+    [Fact]
+    public void Generate_FivePromptsAreNotAllIdentical()
+    {
+        var tool = MakeTool("keyvault secret list", "List secrets",
+            new Option { Name = "vault", Required = true, Description = "Key vault name" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        var distinct = response.Prompts.Distinct().Count();
+        Assert.True(distinct >= 3, $"Expected at least 3 distinct prompts but got {distinct}");
+    }
+
+    [Fact]
+    public void Generate_DifferentValuePerPrompt()
+    {
+        var tool = MakeTool("storage account list", "List accounts",
+            new Option { Name = "subscription", Required = true, Description = "Subscription" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        // Extract quoted values from each prompt
+        var values = response.Prompts.Select(p =>
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(p, @"'([^']+)'");
+            return match.Success ? match.Groups[1].Value : "";
+        }).ToList();
+
+        var distinct = values.Distinct().Count();
+        Assert.True(distinct >= 3, $"Expected at least 3 distinct values but got {distinct}: {string.Join(", ", values)}");
+    }
+
+    // ── Generate: various verb types ────────────────────────────────
+
+    [Theory]
+    [InlineData("storage account list")]
+    [InlineData("keyvault secret get")]
+    [InlineData("cosmos container create")]
+    [InlineData("sql database delete")]
+    [InlineData("appservice webapp update")]
+    public void Generate_AllVerbTypes_ProduceFivePrompts(string command)
+    {
+        var tool = MakeTool(command, "Test operation",
+            new Option { Name = "name", Required = true, Description = "Resource name" });
+
+        var response = DeterministicExamplePromptGenerator.Generate(tool);
+
+        Assert.Equal(5, response.Prompts.Count);
+        Assert.All(response.Prompts, p =>
+            Assert.True(p.EndsWith(".") || p.EndsWith("?"), $"Bad punctuation: {p}"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static Tool MakeTool(string command, string description, params Option[] requiredOptions)
+    {
+        return new Tool
+        {
+            Name = command.Replace(" ", "_"),
+            Command = command,
+            Description = description,
+            Option = requiredOptions.Length > 0
+                ? requiredOptions.ToList()
+                : new List<Option>()
+        };
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using ExamplePromptGeneratorStandalone.Models;
+
+namespace ExamplePromptGeneratorStandalone.Generators;
+
+/// <summary>
+/// Generates example prompts deterministically using verb-based templates
+/// instead of AI calls. Covers ~50% of tools (list, get, create, delete, update).
+/// Falls back to AI for complex or unusual operations.
+/// Fixes: #163 Tier 2a
+/// </summary>
+public static class DeterministicExamplePromptGenerator
+{
+    private static readonly HashSet<string> StandardVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "list", "get", "create", "delete", "update"
+    };
+
+    private static readonly Dictionary<string, string[]> ValueBank = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["account"] = ["mystorageacct", "prodstore2026", "companydata2024", "webappstorage", "mediaacct2024"],
+        ["vault"] = ["prod-kv", "dev-keyvault", "finance-kv", "webapp-kv", "backup-kv"],
+        ["vaultname"] = ["prod-kv", "dev-keyvault", "finance-kv", "webapp-kv", "backup-kv"],
+        ["resource-group"] = ["rg-prod", "my-resource-group", "rg-dev", "rg-company", "rg-analytics"],
+        ["subscription"] = ["my-subscription", "contoso-sub", "dev-subscription", "prod-sub", "test-sub"],
+        ["location"] = ["eastus", "westus2", "centralus", "northcentralus", "eastus2"],
+        ["server-name"] = ["prod-sql-server", "dev-pg-server", "test-server-01", "analytics-server", "backup-server"],
+        ["servername"] = ["prod-sql-server", "dev-pg-server", "test-server-01", "analytics-server", "backup-server"],
+        ["database-name"] = ["mydb", "prod-database", "analytics-db", "app-data", "user-store"],
+        ["databasename"] = ["mydb", "prod-database", "analytics-db", "app-data", "user-store"],
+        ["container-name"] = ["backups", "documents", "images", "logs", "media"],
+        ["containername"] = ["backups", "documents", "images", "logs", "media"],
+        ["name"] = ["my-resource", "prod-item-01", "dev-config", "test-resource-2026", "analytics-asset"],
+        ["secret-name"] = ["db-password", "api-key", "oauth-token", "storage-conn-string", "payment-key"],
+        ["secretname"] = ["db-password", "api-key", "oauth-token", "storage-conn-string", "payment-key"],
+        ["key-name"] = ["signing-key", "encryption-key", "rsa-key-01", "auth-key", "backup-key"],
+        ["keyname"] = ["signing-key", "encryption-key", "rsa-key-01", "auth-key", "backup-key"],
+        ["value"] = ["P@ssw0rd!2026", "sk_live_4f3b2a", "DefaultEndpointsProtocol=https", "eyJhbGciOi", "pg_live_98zxy"],
+        ["query"] = ["Heartbeat | take 10", "AzureMetrics | summarize count()", "requests | where success == false", "traces | top 5 by timestamp", "exceptions | count"],
+        ["planid"] = ["plan-001", "marketing-plan", "dev-sprint-q1", "onboarding-plan", "project-alpha"],
+        ["taskid"] = ["task-001", "review-docs", "fix-bug-42", "deploy-staging", "update-config"],
+        ["groupid"] = ["group-engineering", "team-marketing", "dept-finance", "org-contoso", "project-alpha"],
+        ["indexname"] = ["products-index", "search-docs", "knowledge-base", "catalog-idx", "content-index"],
+    };
+
+    private static readonly string[] DefaultValues = ["my-value-1", "prod-value-02", "test-config-a", "dev-item-2026", "sample-value"];
+
+    /// <summary>
+    /// Classifies the verb from a tool command string.
+    /// Returns null if the verb is not a standard verb.
+    /// </summary>
+    public static string? ClassifyVerb(string? command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return null;
+        var segments = command.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0) return null;
+        var lastSegment = segments[^1].ToLowerInvariant();
+        return StandardVerbs.Contains(lastSegment) ? lastSegment : null;
+    }
+
+    /// <summary>
+    /// Checks if a tool is eligible for deterministic prompt generation.
+    /// Returns false for non-standard verbs or when e2e prompts exist (they dictate style).
+    /// </summary>
+    public static bool IsEligible(Tool tool, bool hasE2ePrompts)
+    {
+        if (hasE2ePrompts) return false;
+        return ClassifyVerb(tool.Command) != null;
+    }
+
+    /// <summary>
+    /// Extracts the resource type from a command string.
+    /// For "storage account list" returns "account".
+    /// For "redis list" returns "redis".
+    /// </summary>
+    public static string ExtractResource(string command)
+    {
+        var segments = command.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length <= 2) return segments[0];
+        // Middle segments (skip namespace and verb)
+        return string.Join(" ", segments.Skip(1).Take(segments.Length - 2));
+    }
+
+    /// <summary>
+    /// Generates an ExamplePromptsResponse deterministically for a tool.
+    /// </summary>
+    public static ExamplePromptsResponse Generate(Tool tool)
+    {
+        var verb = ClassifyVerb(tool.Command!)!;
+        var resource = ExtractResource(tool.Command!);
+        var requiredParams = tool.Option?
+            .Where(o => o.Required)
+            .ToList() ?? new List<Option>();
+
+        var prompts = GeneratePrompts(verb, resource, requiredParams);
+
+        return new ExamplePromptsResponse
+        {
+            ToolName = tool.Name,
+            Prompts = prompts
+        };
+    }
+
+    private static List<string> GeneratePrompts(string verb, string resource, List<Option> requiredParams)
+    {
+        var templates = GetTemplates(verb, resource);
+        var prompts = new List<string>();
+
+        for (int i = 0; i < 5; i++)
+        {
+            var paramPhrase = BuildParamPhrase(requiredParams, i);
+            var prompt = templates[i];
+
+            if (!string.IsNullOrEmpty(paramPhrase))
+            {
+                prompt = prompt.Replace("{params}", paramPhrase);
+            }
+            else
+            {
+                // No required params — remove placeholder
+                prompt = prompt.Replace(" in {params}", "").Replace(" with {params}", "")
+                    .Replace(" from {params}", "").Replace(" for {params}", "");
+            }
+
+            prompts.Add(prompt);
+        }
+
+        return prompts;
+    }
+
+    private static string[] GetTemplates(string verb, string resource)
+    {
+        var r = FormatResource(resource);
+        var rPlural = Pluralize(r);
+
+        return verb.ToLowerInvariant() switch
+        {
+            "list" =>
+            [
+                $"List all {rPlural} in {{params}}.",
+                $"Show me the {rPlural} in {{params}}.",
+                $"What {rPlural} exist in {{params}}?",
+                $"Get all {rPlural} from {{params}}.",
+                $"Display {rPlural} in {{params}}.",
+            ],
+            "get" =>
+            [
+                $"Get {r} details from {{params}}.",
+                $"Show me the {r} in {{params}}.",
+                $"Retrieve {r} information from {{params}}.",
+                $"Display the {r} in {{params}}.",
+                $"What are the {r} details in {{params}}?",
+            ],
+            "create" =>
+            [
+                $"Create a new {r} in {{params}}.",
+                $"Set up a {r} in {{params}}.",
+                $"Add a {r} in {{params}}.",
+                $"Create {r} in {{params}}.",
+                $"Can you create a {r} in {{params}}?",
+            ],
+            "delete" =>
+            [
+                $"Delete the {r} in {{params}}.",
+                $"Remove the {r} from {{params}}.",
+                $"Delete {r} in {{params}}.",
+                $"Can you remove the {r} from {{params}}?",
+                $"Remove {r} in {{params}}.",
+            ],
+            "update" =>
+            [
+                $"Update the {r} in {{params}}.",
+                $"Modify the {r} in {{params}}.",
+                $"Change the {r} settings in {{params}}.",
+                $"Update {r} in {{params}}.",
+                $"Can you update the {r} in {{params}}?",
+            ],
+            _ => throw new ArgumentException($"Unsupported verb: {verb}")
+        };
+    }
+
+    private static string BuildParamPhrase(List<Option> requiredParams, int valueIndex)
+    {
+        if (requiredParams.Count == 0) return string.Empty;
+
+        var phrases = requiredParams.Select(p =>
+        {
+            var displayName = FormatParamDisplayName(p.Name!);
+            var value = GetValue(p.Name!, valueIndex);
+            return $"{displayName} '{value}'";
+        });
+
+        return string.Join(" and ", phrases);
+    }
+
+    private static string FormatParamDisplayName(string paramName)
+    {
+        // Map common parameter names to natural display names
+        var normalized = paramName.ToLowerInvariant().Replace("-", "");
+        return normalized switch
+        {
+            "account" => "storage account",
+            "vault" or "vaultname" => "key vault",
+            "resourcegroup" => "resource group",
+            "subscription" => "subscription",
+            "location" => "location",
+            "servername" => "server",
+            "databasename" => "database",
+            "containername" => "container",
+            "secretname" => "secret",
+            "keyname" => "key",
+            "indexname" => "index",
+            "planid" => "plan",
+            "taskid" => "task",
+            "groupid" => "group",
+            _ => paramName.Replace("-", " ")
+        };
+    }
+
+    private static string GetValue(string paramName, int index)
+    {
+        var normalized = paramName.ToLowerInvariant().Replace("-", "");
+        // Try exact match first, then normalized
+        if (ValueBank.TryGetValue(paramName, out var values))
+            return values[index % values.Length];
+        if (ValueBank.TryGetValue(normalized, out values))
+            return values[index % values.Length];
+        return DefaultValues[index % DefaultValues.Length];
+    }
+
+    private static string FormatResource(string resource)
+    {
+        // Clean up resource name for natural language
+        return resource.Replace("-", " ").Replace("_", " ").ToLowerInvariant();
+    }
+
+    private static string Pluralize(string resource)
+    {
+        if (string.IsNullOrEmpty(resource)) return resource;
+        if (resource.EndsWith("s") || resource.EndsWith("x") || resource.EndsWith("sh") || resource.EndsWith("ch"))
+            return resource + "es";
+        if (resource.EndsWith("y") && !resource.EndsWith("ay") && !resource.EndsWith("ey") && !resource.EndsWith("oy") && !resource.EndsWith("uy"))
+            return resource[..^1] + "ies";
+        return resource + "s";
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Program.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Program.cs
@@ -205,6 +205,7 @@ internal static class Program
 
         var successCount = 0;
         var failureCount = 0;
+        var deterministicCount = 0;
         var e2eMatchCount = 0;
         var e2eMissCount = 0;
         var e2eLogEntries = new List<string>();
@@ -258,15 +259,31 @@ internal static class Program
             }
 
             var parameterManifest = await LoadParameterManifestAsync(tool.Command, paramManifestsDir, nameContext);
-            var result = await generator.GenerateAsync(tool, referencePrompts, parameterManifest, validationFeedback);
-            if (!result.HasValue)
-            {
-                failureCount++;
-                Console.WriteLine($"  ❌ {tool.Command}");
-                continue;
-            }
 
-            var (userPrompt, promptsResponse, rawResponse) = result.Value;
+            // Check if tool is eligible for deterministic generation (#163 Tier 2a)
+            bool hasE2ePrompts = referencePrompts != null && referencePrompts.Count > 0;
+            string userPrompt;
+            ExamplePromptsResponse? promptsResponse;
+            string rawResponse;
+
+            if (DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts))
+            {
+                promptsResponse = DeterministicExamplePromptGenerator.Generate(tool);
+                userPrompt = $"deterministic — no AI call (#163 Tier 2a)\nVerb: {DeterministicExamplePromptGenerator.ClassifyVerb(tool.Command!)}\nResource: {DeterministicExamplePromptGenerator.ExtractResource(tool.Command!)}";
+                rawResponse = "{}";
+                deterministicCount++;
+            }
+            else
+            {
+                var result = await generator.GenerateAsync(tool, referencePrompts, parameterManifest, validationFeedback);
+                if (!result.HasValue)
+                {
+                    failureCount++;
+                    Console.WriteLine($"  ❌ {tool.Command}");
+                    continue;
+                }
+                (userPrompt, promptsResponse, rawResponse) = result.Value;
+            }
 
             // Use shared deterministic filename builder
             var inputPromptFileName = ToolFileNameBuilder.BuildInputPromptFileName(
@@ -336,11 +353,12 @@ internal static class Program
             }
 
             await File.WriteAllTextAsync(examplePromptPath, exampleContent);
-            Console.WriteLine($"  ✅ {tool.Command,-50} → {examplePromptFileName}");
+            var modeLabel = DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts) ? "deterministic" : "AI";
+            Console.WriteLine($"  ✅ {tool.Command,-50} → {examplePromptFileName} ({modeLabel})");
         }
 
         Console.WriteLine($"\n📊 Summary:");
-        Console.WriteLine($"  ✅ Generated: {successCount}");
+        Console.WriteLine($"  ✅ Generated: {successCount} ({deterministicCount} deterministic, {successCount - deterministicCount} AI)");
         Console.WriteLine($"  ❌ Failed:    {failureCount}");
         if (e2eLookup != null)
         {


### PR DESCRIPTION
## Summary

Replaces AI calls with deterministic template generation for tools with standard verbs (list, get, create, delete, update). Estimated ~50% of 208 tools (~104) will use deterministic generation, eliminating ~104 AI calls per full pipeline run.

## How It Works

Tools are classified by their command verb. Standard verbs get 5 template variations with parameter value injection. Non-standard verbs and tools with e2e reference prompts fall back to AI.

Supported verbs: list, get, create, delete, update

## Files

- **DeterministicExamplePromptGenerator.cs** (new) - ClassifyVerb, IsEligible, ExtractResource, Generate, value bank with 20+ parameter types
- **Program.cs** - Wire deterministic check before AI call, track counts, label output
- **DeterministicExamplePromptGeneratorTests.cs** (new) - 20 TDD tests

## Tests (20 new, TDD)

- ClassifyVerb: 7 standard verbs, 4 non-standard, null/empty
- IsEligible: standard verb +/- e2e prompts, non-standard
- ExtractResource: various command structures
- Generate: 5 prompts, required params, punctuation, quotes, verb styles, idempotency, variation

All 960+ tests pass across the full solution.

Ref #163