### PR TITLE
feat(#163): deterministic horizontal article structure helpers (Tier 2b)

### DIFF
--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
@@ -170,7 +170,7 @@ public class DeterministicHorizontalHelpersTests
         var capabilities = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
 
         Assert.That(capabilities, Has.Count.EqualTo(3));
-        Assert.That(capabilities, Has.All.Not.EndsWith("."));
+        Assert.That(capabilities.Values, Has.All.Not.EndsWith("."));
     }
 
     // ── PreComputeShortDescriptions ─────────────────────────────────
@@ -222,7 +222,77 @@ public class DeterministicHorizontalHelpersTests
         var caps2 = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
 
         Assert.That(order1.Select(t => t.Command), Is.EqualTo(order2.Select(t => t.Command)));
-        Assert.That(caps1, Is.EqualTo(caps2));
+        Assert.That(caps1.Values, Is.EqualTo(caps2.Values));
+    }
+
+    // ── Edge cases (review feedback) ────────────────────────────────
+
+    [Test]
+    public void ClassifyToolPlane_NullMetadata_DefaultsToVerbClassification()
+    {
+        var tool = new HorizontalToolSummary
+        {
+            Command = "storage account create",
+            Description = "Create account",
+            Metadata = null!
+        };
+        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("management"));
+    }
+
+    [Test]
+    public void ClassifyToolPlane_EmptyMetadata_DefaultsToVerbClassification()
+    {
+        var tool = new HorizontalToolSummary
+        {
+            Command = "cosmos container get",
+            Description = "Get container",
+            Metadata = new Dictionary<string, MetadataValue>()
+        };
+        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("data"));
+    }
+
+    [TestCase("appconfig createorupdate", "management")]
+    [TestCase("compute deploy", "management")]
+    [TestCase("functionapp publish", "management")]
+    public void ClassifyToolPlane_CompoundVerbs_CorrectlyClassified(string command, string expected)
+    {
+        var tool = MakeTool(command);
+        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void OrderToolsByPlane_EmptyList_ReturnsEmpty()
+    {
+        var result = DeterministicHorizontalHelpers.OrderToolsByPlane(new List<HorizontalToolSummary>());
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void PreComputeCapabilities_DuplicateCommands_FirstWins()
+    {
+        var tools = new List<HorizontalToolSummary>
+        {
+            MakeTool("storage list", description: "First description."),
+            MakeTool("storage list", description: "Second description."),
+        };
+
+        var caps = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
+        Assert.That(caps, Has.Count.EqualTo(1));
+        Assert.That(caps["storage list"], Is.EqualTo("First description"));
+    }
+
+    [Test]
+    public void TruncateDescription_EmptyString_ReturnsEmpty()
+    {
+        var result = DeterministicHorizontalHelpers.TruncateDescription("", maxWords: 10);
+        Assert.That(result, Is.EqualTo(""));
+    }
+
+    [Test]
+    public void TruncateDescription_SingleWord_ReturnsTrimmed()
+    {
+        var result = DeterministicHorizontalHelpers.TruncateDescription("List.", maxWords: 10);
+        Assert.That(result, Is.EqualTo("List"));
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/DeterministicHorizontalHelpers.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/DeterministicHorizontalHelpers.cs
@@ -15,12 +15,14 @@ public static class DeterministicHorizontalHelpers
 {
     private static readonly HashSet<string> ManagementVerbs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "create", "delete", "update", "add", "remove", "set", "import", "assign"
+        "create", "delete", "update", "add", "remove", "set", "import", "assign",
+        "cancel", "deploy", "publish", "send", "move", "copy", "upload"
     };
 
     private static readonly HashSet<string> DataVerbs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "list", "get", "query", "search", "find", "read", "export", "download"
+        "list", "get", "query", "search", "find", "read", "export", "download",
+        "recognize", "synthesize", "diagnose", "check_status"
     };
 
     /// <summary>
@@ -30,18 +32,29 @@ public static class DeterministicHorizontalHelpers
     /// </summary>
     public static string ClassifyToolPlane(HorizontalToolSummary tool)
     {
-        // Metadata takes priority
-        if (tool.Metadata.TryGetValue("destructive", out var destructive) && destructive.Value)
-            return "management";
-        if (tool.Metadata.TryGetValue("readOnly", out var readOnly) && readOnly.Value)
-            return "data";
+        // Metadata takes priority (null-safe)
+        if (tool.Metadata != null)
+        {
+            if (tool.Metadata.TryGetValue("destructive", out var destructive) && destructive.Value)
+                return "management";
+            if (tool.Metadata.TryGetValue("readOnly", out var readOnly) && readOnly.Value)
+                return "data";
+        }
 
         // Fall back to command verb classification
         var verb = ExtractVerb(tool.Command);
-        if (verb != null && ManagementVerbs.Contains(verb))
-            return "management";
-        if (verb != null && DataVerbs.Contains(verb))
-            return "data";
+        if (verb != null)
+        {
+            // Handle compound verbs like "createorupdate"
+            if (verb.Contains("create", StringComparison.OrdinalIgnoreCase) ||
+                verb.Contains("delete", StringComparison.OrdinalIgnoreCase) ||
+                verb.Contains("update", StringComparison.OrdinalIgnoreCase))
+                return "management";
+            if (ManagementVerbs.Contains(verb))
+                return "management";
+            if (DataVerbs.Contains(verb))
+                return "data";
+        }
 
         // Default to data plane (read-only assumption)
         return "data";
@@ -70,11 +83,18 @@ public static class DeterministicHorizontalHelpers
     }
 
     /// <summary>
-    /// Pre-computes one capability string per tool.
+    /// Pre-computes one capability string per tool, keyed by command.
     /// </summary>
-    public static List<string> PreComputeCapabilities(List<HorizontalToolSummary> tools)
+    public static Dictionary<string, string> PreComputeCapabilities(List<HorizontalToolSummary> tools)
     {
-        return tools.Select(ExtractCapability).ToList();
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tool in tools)
+        {
+            // Skip duplicates (first wins)
+            if (!result.ContainsKey(tool.Command))
+                result[tool.Command] = ExtractCapability(tool);
+        }
+        return result;
     }
 
     /// <summary>
@@ -82,9 +102,13 @@ public static class DeterministicHorizontalHelpers
     /// </summary>
     public static Dictionary<string, string> PreComputeShortDescriptions(List<HorizontalToolSummary> tools)
     {
-        return tools.ToDictionary(
-            t => t.Command,
-            t => TruncateDescription(t.Description?.Trim() ?? t.Command, maxWords: 12));
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tool in tools)
+        {
+            if (!result.ContainsKey(tool.Command))
+                result[tool.Command] = TruncateDescription(tool.Description?.Trim() ?? tool.Command, maxWords: 12);
+        }
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Pre-computes structural data for horizontal articles that the AI currently generates: tool plane classification, ordering, capabilities, and short descriptions. These helpers provide deterministic defaults, reducing AI cognitive load and token cost.

## What's Pre-Computed

- **Tool plane classification**: Management (create/delete/update) vs data (list/get/query) based on metadata flags and command verbs
- **Tool ordering**: Management tools first, then data tools, alphabetical within each group
- **Capabilities**: One per tool, derived from description, period-stripped, max 15 words
- **Short descriptions**: Truncated to 12 words max for tool table

## Files

- **DeterministicHorizontalHelpers.cs** (new) - Static helpers for pre-computation
- **DeterministicHorizontalHelpersTests.cs** (new) - 20 NUnit tests (TDD)

## Tests (20 new, TDD)

- ClassifyToolPlane: metadata priority, verb classification, defaults
- OrderToolsByPlane: management first, alphabetical within plane
- ExtractCapability/TruncateDescription: period stripping, word limits
- PreComputeCapabilities/ShortDescriptions: per-tool mapping
- Idempotency verification

## Next Steps

Wire helpers into HorizontalArticleGenerator Phase 1 to inject pre-computed data into the AI user prompt, reducing response size and token cost by ~30%.

Ref #163