### PR TITLE
fix: remove dead monitorinstrumentation namespace

### DIFF
--- a/docs-generation/data/brand-to-server-mapping.json
+++ b/docs-generation/data/brand-to-server-mapping.json
@@ -225,12 +225,6 @@
     "mergeRole": "primary"
   },
   {
-    "brandName": "Azure Monitor Instrumentation",
-    "mcpServerName": "monitorinstrumentation",
-    "shortName": "Monitor Instrumentation",
-    "fileName": "azure-monitor-instrumentation"
-  },
-  {
     "brandName": "Azure Database for MySQL",
     "mcpServerName": "mysql",
     "shortName": "MySQL",

--- a/docs-generation/data/service-doc-links.json
+++ b/docs-generation/data/service-doc-links.json
@@ -1,58 +1,277 @@
 {
-  "acr": { "title": "Azure Container Registry documentation", "url": "/azure/container-registry/", "seoDescription": "Use Azure MCP Server tools to manage Azure Container Registry resources such as registries and registry configurations with natural language prompts from your IDE." },
-  "advisor": { "title": "Azure Advisor documentation", "url": "/azure/advisor/", "seoDescription": "Use Azure MCP Server tools to manage Azure Advisor recommendations and optimizations with natural language prompts from your IDE." },
-  "aks": { "title": "Azure Kubernetes Service documentation", "url": "/azure/aks/", "seoDescription": "Use Azure MCP Server tools to manage Azure Kubernetes Service clusters and node pools with natural language prompts from your IDE." },
-  "appconfig": { "title": "Azure App Configuration documentation", "url": "/azure/azure-app-configuration/", "seoDescription": "Use Azure MCP Server tools to manage Azure App Configuration stores and key-value settings with natural language prompts from your IDE." },
-  "applens": { "title": "Azure App Service diagnostics documentation", "url": "/azure/app-service/troubleshoot-diagnostic-tools", "seoDescription": "Use Azure MCP Server tools to manage diagnostics and troubleshooting for Azure App Service resources with natural language prompts from your IDE." },
-  "applicationinsights": { "title": "Azure Application Insights documentation", "url": "/azure/azure-monitor/app/app-insights-overview", "seoDescription": "Use Azure MCP Server tools to manage Azure Application Insights components and monitoring resources with natural language prompts from your IDE." },
-  "appservice": { "title": "Azure App Service documentation", "url": "/azure/app-service/", "seoDescription": "Use Azure MCP Server tools to manage web apps, APIs, and mobile back ends with natural language prompts from your IDE." },
-  "azuremigrate": { "title": "Azure Migrate documentation", "url": "/azure/migrate/", "seoDescription": "Use Azure MCP Server tools to manage Azure Platform Landing Zone configurations and Terraform-ready generation with natural language prompts from your IDE." },
-  "azureterraformbestpractices": { "title": "Terraform on Azure documentation", "url": "/azure/developer/terraform/", "seoDescription": "Use Azure MCP Server tools to get Terraform best practices for Azure with natural language prompts from your IDE." },
-  "bicepschema": { "title": "Azure Bicep documentation", "url": "/azure/azure-resource-manager/bicep/", "seoDescription": "Use Azure MCP Server tools to manage Azure Bicep schemas, templates, and resource definitions with natural language prompts from your IDE." },
-  "cloudarchitect": { "title": "Azure Architecture Center documentation", "url": "/azure/architecture/", "seoDescription": "Use Azure MCP Server tools to manage cloud architecture design, generate diagrams and templates, validate architectures against best practices, and estimate costs with natural language prompts from your IDE." },
-  "communication": { "title": "Azure Communication Services documentation", "url": "/azure/communication-services/", "seoDescription": "Use Azure MCP Server tools to manage Azure Communication Services resources such as SMS messaging with natural language prompts from your IDE." },
-  "compute": { "title": "Azure Virtual Machines documentation", "url": "/azure/virtual-machines/", "seoDescription": "Use Azure MCP Server tools to manage compute resources such as virtual machines, managed disks, and virtual machine scale sets with natural language prompts from your IDE." },
-  "confidentialledger": { "title": "Azure Confidential Ledger documentation", "url": "/azure/confidential-ledger/", "seoDescription": "Use Azure MCP Server tools to manage Azure Confidential Ledger entries for tamper-proof audit records with natural language prompts from your IDE." },
-  "containerapps": { "title": "Azure Container Apps documentation", "url": "/azure/container-apps/", "seoDescription": "Use Azure MCP Server tools to manage containerized applications and serverless container instances in Azure Container Apps with natural language prompts from your IDE." },
-  "cosmos": { "title": "Azure Cosmos DB documentation", "url": "/azure/cosmos-db/", "seoDescription": "Use Azure MCP Server tools to manage globally distributed, multi-model NoSQL databases with natural language prompts from your IDE." },
-  "datadog": { "title": "Datadog on Azure documentation", "url": "/azure/partner-solutions/datadog/", "seoDescription": "Use Azure MCP Server tools to manage and monitor Azure resources through Datadog integration with natural language prompts from your IDE." },
-  "deploy": { "title": "Azure deployment documentation", "url": "/azure/azure-resource-manager/templates/", "seoDescription": "Use Azure MCP Server tools to manage deployments and deployment pipelines for Azure applications and infrastructure with natural language prompts from your IDE." },
-  "deviceregistry": { "title": "Azure Device Registry documentation", "url": "/azure/iot-operations/discover-manage-assets/overview-manage-assets", "seoDescription": "Use Azure MCP Server tools to manage Azure Device Registry resources and IoT device assets with natural language prompts from your IDE." },
-  "eventgrid": { "title": "Azure Event Grid documentation", "url": "/azure/event-grid/", "seoDescription": "Use Azure MCP Server tools to manage Azure Event Grid topics, domains, and event subscriptions with natural language prompts from your IDE." },
-  "eventhubs": { "title": "Azure Event Hubs documentation", "url": "/azure/event-hubs/", "seoDescription": "Use Azure MCP Server tools to manage Azure Event Hubs namespaces and event hubs with natural language prompts from your IDE." },
-  "extension": { "title": "Azure CLI extensions documentation", "url": "/azure/developer/azure-cli/", "seoDescription": "Use Azure MCP Server tools to generate and manage Azure CLI commands with natural language prompts from your IDE." },
-  "fileshares": { "title": "Azure Files documentation", "url": "/azure/storage/files/", "seoDescription": "Use Azure MCP Server tools to manage Azure File Shares (managed SMB and NFS file shares on Azure Files) with natural language prompts from your IDE." },
-  "foundry": { "title": "Microsoft Foundry documentation", "url": "/azure/ai-foundry/", "seoDescription": "Use Azure MCP Server tools to manage Microsoft Foundry resources such as models, agents, and evaluation workflows with natural language prompts from your IDE." },
-  "foundryextensions": { "title": "Microsoft Foundry documentation", "url": "/azure/ai-foundry/", "seoDescription": "Use Azure MCP Server tools to manage Microsoft Foundry Extensions resources such as chat completions, embeddings, models, and knowledge indexes with natural language prompts from your IDE." },
-  "functionapp": { "title": "Azure Functions documentation", "url": "/azure/azure-functions/", "seoDescription": "Use Azure MCP Server tools to manage Azure Function App resources and serverless functions with natural language prompts from your IDE." },
-  "functions": { "title": "Azure Functions documentation", "url": "/azure/azure-functions/", "seoDescription": "Use Azure MCP Server tools to generate Azure Functions code and explore function templates with natural language prompts from your IDE." },
-  "grafana": { "title": "Azure Managed Grafana documentation", "url": "/azure/managed-grafana/", "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Grafana workspaces and monitoring dashboards with natural language prompts from your IDE." },
-  "group": { "title": "Azure Resource Manager documentation", "url": "/azure/azure-resource-manager/", "seoDescription": "Use Azure MCP Server tools to manage Azure resource groups and their resources with natural language prompts from your IDE." },
-  "keyvault": { "title": "Azure Key Vault documentation", "url": "/azure/key-vault/", "seoDescription": "Use Azure MCP Server tools to manage keys, secrets, and certificates in Azure Key Vault with natural language prompts from your IDE." },
-  "kusto": { "title": "Azure Data Explorer documentation", "url": "/azure/data-explorer/", "seoDescription": "Use Azure MCP Server tools to manage Azure Data Explorer clusters, databases, and KQL queries with natural language prompts from your IDE." },
-  "loadtesting": { "title": "Azure Load Testing documentation", "url": "/azure/load-testing/", "seoDescription": "Use Azure MCP Server tools to manage Azure Load Testing resources, test configurations, and performance test runs with natural language prompts from your IDE." },
-  "managedlustre": { "title": "Azure Managed Lustre documentation", "url": "/azure/azure-managed-lustre/", "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Lustre file systems for high-performance computing workloads with natural language prompts from your IDE." },
-  "marketplace": { "title": "Azure Marketplace documentation", "url": "/azure/marketplace/", "seoDescription": "Use Azure MCP Server tools to manage Azure Marketplace products and offers with natural language prompts from your IDE." },
-  "monitor": { "title": "Azure Monitor documentation", "url": "/azure/azure-monitor/", "seoDescription": "Use Azure MCP Server tools to manage monitoring, metrics, logs, alerts, and diagnostics for Azure resources with natural language prompts from your IDE." },
-  "monitorinstrumentation": { "title": "Azure Monitor documentation", "url": "/azure/azure-monitor/", "seoDescription": "Use Azure MCP Server tools to manage Azure Monitor instrumentation and telemetry resources with natural language prompts from your IDE." },
-  "mysql": { "title": "Azure Database for MySQL documentation", "url": "/azure/mysql/", "seoDescription": "Use Azure MCP Server tools to manage Azure Database for MySQL Flexible Server resources with natural language prompts from your IDE." },
-  "policy": { "title": "Azure Policy documentation", "url": "/azure/governance/policy/", "seoDescription": "Use Azure MCP Server tools to manage Azure Policy assignments and definitions with natural language prompts from your IDE." },
-  "postgres": { "title": "Azure Database for PostgreSQL documentation", "url": "/azure/postgresql/", "seoDescription": "Use Azure MCP Server tools to manage Azure Database for PostgreSQL servers and databases with natural language prompts from your IDE." },
-  "pricing": { "title": "Azure pricing documentation", "url": "/azure/cost-management-billing/", "seoDescription": "Use Azure MCP Server tools to manage pricing calculations and estimates for Azure services with natural language prompts from your IDE." },
-  "quota": { "title": "Azure Quota documentation", "url": "/azure/quotas/", "seoDescription": "Use Azure MCP Server tools to manage Azure resource quotas and usage across regions with natural language prompts from your IDE." },
-  "redis": { "title": "Azure Managed Redis documentation", "url": "/azure/azure-cache-for-redis/", "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Redis and Azure Cache for Redis resources with natural language prompts from your IDE." },
-  "resourcehealth": { "title": "Azure Resource Health documentation", "url": "/azure/service-health/resource-health-overview", "seoDescription": "Use Azure MCP Server tools to manage resource health and availability of Azure resources with natural language prompts from your IDE." },
-  "role": { "title": "Azure RBAC documentation", "url": "/azure/role-based-access-control/", "seoDescription": "Use Azure MCP Server tools to manage Azure role-based access control assignments and permissions with natural language prompts from your IDE." },
-  "search": { "title": "Azure AI Search documentation", "url": "/azure/search/", "seoDescription": "Use Azure MCP Server tools to manage search services, indexes, and knowledge sources with natural language prompts from your IDE." },
-  "servicebus": { "title": "Azure Service Bus documentation", "url": "/azure/service-bus-messaging/", "seoDescription": "Use Azure MCP Server tools to manage Azure Service Bus queues, topics, and subscriptions with natural language prompts from your IDE." },
-  "servicefabric": { "title": "Azure Service Fabric documentation", "url": "/azure/service-fabric/", "seoDescription": "Use Azure MCP Server tools to manage Azure Service Fabric managed clusters and node types with natural language prompts from your IDE." },
-  "signalr": { "title": "Azure SignalR Service documentation", "url": "/azure/azure-signalr/", "seoDescription": "Use Azure MCP Server tools to manage Azure SignalR Service resources with natural language prompts from your IDE." },
-  "speech": { "title": "Azure AI Speech documentation", "url": "/azure/ai-services/speech-service/", "seoDescription": "Use Azure MCP Server tools to manage Azure AI Speech resources for speech-to-text and text-to-speech with natural language prompts from your IDE." },
-  "sql": { "title": "Azure SQL Database documentation", "url": "/azure/azure-sql/", "seoDescription": "Use Azure MCP Server tools to manage Azure SQL Database instances with natural language prompts from your IDE." },
-  "storage": { "title": "Azure Storage documentation", "url": "/azure/storage/", "seoDescription": "Use Azure MCP Server tools to manage Azure Storage resources such as storage accounts, blob containers, blobs, and tables with natural language prompts from your IDE." },
-  "storagesync": { "title": "Azure File Sync documentation", "url": "/azure/storage/file-sync/", "seoDescription": "Use Azure MCP Server tools to manage Azure File Sync services, sync groups, and server endpoints with natural language prompts from your IDE." },
-  "subscription": { "title": "Azure subscription documentation", "url": "/azure/cost-management-billing/manage/", "seoDescription": "Use Azure MCP Server tools to manage Azure subscriptions and account information with natural language prompts from your IDE." },
-  "virtualdesktop": { "title": "Azure Virtual Desktop documentation", "url": "/azure/virtual-desktop/", "seoDescription": "Use Azure MCP Server tools to manage Azure Virtual Desktop host pools, session hosts, and user sessions with natural language prompts from your IDE." },
-  "wellarchitectedframework": { "title": "Azure Well-Architected Framework documentation", "url": "/azure/well-architected/", "seoDescription": "Use Azure MCP Server tools to manage Azure Well-Architected Framework assessments and recommendations for cloud workloads with natural language prompts from your IDE." },
-  "workbooks": { "title": "Azure Monitor Workbooks documentation", "url": "/azure/azure-monitor/visualize/workbooks-overview", "seoDescription": "Use Azure MCP Server tools to manage Azure Workbooks resources and interactive data visualization dashboards with natural language prompts from your IDE." }
+  "acr": {
+    "title": "Azure Container Registry documentation",
+    "url": "/azure/container-registry/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Container Registry resources such as registries and registry configurations with natural language prompts from your IDE."
+  },
+  "advisor": {
+    "title": "Azure Advisor documentation",
+    "url": "/azure/advisor/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Advisor recommendations and optimizations with natural language prompts from your IDE."
+  },
+  "aks": {
+    "title": "Azure Kubernetes Service documentation",
+    "url": "/azure/aks/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Kubernetes Service clusters and node pools with natural language prompts from your IDE."
+  },
+  "appconfig": {
+    "title": "Azure App Configuration documentation",
+    "url": "/azure/azure-app-configuration/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure App Configuration stores and key-value settings with natural language prompts from your IDE."
+  },
+  "applens": {
+    "title": "Azure App Service diagnostics documentation",
+    "url": "/azure/app-service/troubleshoot-diagnostic-tools",
+    "seoDescription": "Use Azure MCP Server tools to manage diagnostics and troubleshooting for Azure App Service resources with natural language prompts from your IDE."
+  },
+  "applicationinsights": {
+    "title": "Azure Application Insights documentation",
+    "url": "/azure/azure-monitor/app/app-insights-overview",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Application Insights components and monitoring resources with natural language prompts from your IDE."
+  },
+  "appservice": {
+    "title": "Azure App Service documentation",
+    "url": "/azure/app-service/",
+    "seoDescription": "Use Azure MCP Server tools to manage web apps, APIs, and mobile back ends with natural language prompts from your IDE."
+  },
+  "azuremigrate": {
+    "title": "Azure Migrate documentation",
+    "url": "/azure/migrate/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Platform Landing Zone configurations and Terraform-ready generation with natural language prompts from your IDE."
+  },
+  "azureterraformbestpractices": {
+    "title": "Terraform on Azure documentation",
+    "url": "/azure/developer/terraform/",
+    "seoDescription": "Use Azure MCP Server tools to get Terraform best practices for Azure with natural language prompts from your IDE."
+  },
+  "bicepschema": {
+    "title": "Azure Bicep documentation",
+    "url": "/azure/azure-resource-manager/bicep/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Bicep schemas, templates, and resource definitions with natural language prompts from your IDE."
+  },
+  "cloudarchitect": {
+    "title": "Azure Architecture Center documentation",
+    "url": "/azure/architecture/",
+    "seoDescription": "Use Azure MCP Server tools to manage cloud architecture design, generate diagrams and templates, validate architectures against best practices, and estimate costs with natural language prompts from your IDE."
+  },
+  "communication": {
+    "title": "Azure Communication Services documentation",
+    "url": "/azure/communication-services/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Communication Services resources such as SMS messaging with natural language prompts from your IDE."
+  },
+  "compute": {
+    "title": "Azure Virtual Machines documentation",
+    "url": "/azure/virtual-machines/",
+    "seoDescription": "Use Azure MCP Server tools to manage compute resources such as virtual machines, managed disks, and virtual machine scale sets with natural language prompts from your IDE."
+  },
+  "confidentialledger": {
+    "title": "Azure Confidential Ledger documentation",
+    "url": "/azure/confidential-ledger/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Confidential Ledger entries for tamper-proof audit records with natural language prompts from your IDE."
+  },
+  "containerapps": {
+    "title": "Azure Container Apps documentation",
+    "url": "/azure/container-apps/",
+    "seoDescription": "Use Azure MCP Server tools to manage containerized applications and serverless container instances in Azure Container Apps with natural language prompts from your IDE."
+  },
+  "cosmos": {
+    "title": "Azure Cosmos DB documentation",
+    "url": "/azure/cosmos-db/",
+    "seoDescription": "Use Azure MCP Server tools to manage globally distributed, multi-model NoSQL databases with natural language prompts from your IDE."
+  },
+  "datadog": {
+    "title": "Datadog on Azure documentation",
+    "url": "/azure/partner-solutions/datadog/",
+    "seoDescription": "Use Azure MCP Server tools to manage and monitor Azure resources through Datadog integration with natural language prompts from your IDE."
+  },
+  "deploy": {
+    "title": "Azure deployment documentation",
+    "url": "/azure/azure-resource-manager/templates/",
+    "seoDescription": "Use Azure MCP Server tools to manage deployments and deployment pipelines for Azure applications and infrastructure with natural language prompts from your IDE."
+  },
+  "deviceregistry": {
+    "title": "Azure Device Registry documentation",
+    "url": "/azure/iot-operations/discover-manage-assets/overview-manage-assets",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Device Registry resources and IoT device assets with natural language prompts from your IDE."
+  },
+  "eventgrid": {
+    "title": "Azure Event Grid documentation",
+    "url": "/azure/event-grid/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Event Grid topics, domains, and event subscriptions with natural language prompts from your IDE."
+  },
+  "eventhubs": {
+    "title": "Azure Event Hubs documentation",
+    "url": "/azure/event-hubs/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Event Hubs namespaces and event hubs with natural language prompts from your IDE."
+  },
+  "extension": {
+    "title": "Azure CLI extensions documentation",
+    "url": "/azure/developer/azure-cli/",
+    "seoDescription": "Use Azure MCP Server tools to generate and manage Azure CLI commands with natural language prompts from your IDE."
+  },
+  "fileshares": {
+    "title": "Azure Files documentation",
+    "url": "/azure/storage/files/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure File Shares (managed SMB and NFS file shares on Azure Files) with natural language prompts from your IDE."
+  },
+  "foundry": {
+    "title": "Microsoft Foundry documentation",
+    "url": "/azure/ai-foundry/",
+    "seoDescription": "Use Azure MCP Server tools to manage Microsoft Foundry resources such as models, agents, and evaluation workflows with natural language prompts from your IDE."
+  },
+  "foundryextensions": {
+    "title": "Microsoft Foundry documentation",
+    "url": "/azure/ai-foundry/",
+    "seoDescription": "Use Azure MCP Server tools to manage Microsoft Foundry Extensions resources such as chat completions, embeddings, models, and knowledge indexes with natural language prompts from your IDE."
+  },
+  "functionapp": {
+    "title": "Azure Functions documentation",
+    "url": "/azure/azure-functions/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Function App resources and serverless functions with natural language prompts from your IDE."
+  },
+  "functions": {
+    "title": "Azure Functions documentation",
+    "url": "/azure/azure-functions/",
+    "seoDescription": "Use Azure MCP Server tools to generate Azure Functions code and explore function templates with natural language prompts from your IDE."
+  },
+  "grafana": {
+    "title": "Azure Managed Grafana documentation",
+    "url": "/azure/managed-grafana/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Grafana workspaces and monitoring dashboards with natural language prompts from your IDE."
+  },
+  "group": {
+    "title": "Azure Resource Manager documentation",
+    "url": "/azure/azure-resource-manager/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure resource groups and their resources with natural language prompts from your IDE."
+  },
+  "keyvault": {
+    "title": "Azure Key Vault documentation",
+    "url": "/azure/key-vault/",
+    "seoDescription": "Use Azure MCP Server tools to manage keys, secrets, and certificates in Azure Key Vault with natural language prompts from your IDE."
+  },
+  "kusto": {
+    "title": "Azure Data Explorer documentation",
+    "url": "/azure/data-explorer/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Data Explorer clusters, databases, and KQL queries with natural language prompts from your IDE."
+  },
+  "loadtesting": {
+    "title": "Azure Load Testing documentation",
+    "url": "/azure/load-testing/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Load Testing resources, test configurations, and performance test runs with natural language prompts from your IDE."
+  },
+  "managedlustre": {
+    "title": "Azure Managed Lustre documentation",
+    "url": "/azure/azure-managed-lustre/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Lustre file systems for high-performance computing workloads with natural language prompts from your IDE."
+  },
+  "marketplace": {
+    "title": "Azure Marketplace documentation",
+    "url": "/azure/marketplace/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Marketplace products and offers with natural language prompts from your IDE."
+  },
+  "monitor": {
+    "title": "Azure Monitor documentation",
+    "url": "/azure/azure-monitor/",
+    "seoDescription": "Use Azure MCP Server tools to manage monitoring, metrics, logs, alerts, and diagnostics for Azure resources with natural language prompts from your IDE."
+  },
+  "mysql": {
+    "title": "Azure Database for MySQL documentation",
+    "url": "/azure/mysql/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Database for MySQL Flexible Server resources with natural language prompts from your IDE."
+  },
+  "policy": {
+    "title": "Azure Policy documentation",
+    "url": "/azure/governance/policy/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Policy assignments and definitions with natural language prompts from your IDE."
+  },
+  "postgres": {
+    "title": "Azure Database for PostgreSQL documentation",
+    "url": "/azure/postgresql/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Database for PostgreSQL servers and databases with natural language prompts from your IDE."
+  },
+  "pricing": {
+    "title": "Azure pricing documentation",
+    "url": "/azure/cost-management-billing/",
+    "seoDescription": "Use Azure MCP Server tools to manage pricing calculations and estimates for Azure services with natural language prompts from your IDE."
+  },
+  "quota": {
+    "title": "Azure Quota documentation",
+    "url": "/azure/quotas/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure resource quotas and usage across regions with natural language prompts from your IDE."
+  },
+  "redis": {
+    "title": "Azure Managed Redis documentation",
+    "url": "/azure/azure-cache-for-redis/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Managed Redis and Azure Cache for Redis resources with natural language prompts from your IDE."
+  },
+  "resourcehealth": {
+    "title": "Azure Resource Health documentation",
+    "url": "/azure/service-health/resource-health-overview",
+    "seoDescription": "Use Azure MCP Server tools to manage resource health and availability of Azure resources with natural language prompts from your IDE."
+  },
+  "role": {
+    "title": "Azure RBAC documentation",
+    "url": "/azure/role-based-access-control/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure role-based access control assignments and permissions with natural language prompts from your IDE."
+  },
+  "search": {
+    "title": "Azure AI Search documentation",
+    "url": "/azure/search/",
+    "seoDescription": "Use Azure MCP Server tools to manage search services, indexes, and knowledge sources with natural language prompts from your IDE."
+  },
+  "servicebus": {
+    "title": "Azure Service Bus documentation",
+    "url": "/azure/service-bus-messaging/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Service Bus queues, topics, and subscriptions with natural language prompts from your IDE."
+  },
+  "servicefabric": {
+    "title": "Azure Service Fabric documentation",
+    "url": "/azure/service-fabric/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Service Fabric managed clusters and node types with natural language prompts from your IDE."
+  },
+  "signalr": {
+    "title": "Azure SignalR Service documentation",
+    "url": "/azure/azure-signalr/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure SignalR Service resources with natural language prompts from your IDE."
+  },
+  "speech": {
+    "title": "Azure AI Speech documentation",
+    "url": "/azure/ai-services/speech-service/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure AI Speech resources for speech-to-text and text-to-speech with natural language prompts from your IDE."
+  },
+  "sql": {
+    "title": "Azure SQL Database documentation",
+    "url": "/azure/azure-sql/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure SQL Database instances with natural language prompts from your IDE."
+  },
+  "storage": {
+    "title": "Azure Storage documentation",
+    "url": "/azure/storage/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Storage resources such as storage accounts, blob containers, blobs, and tables with natural language prompts from your IDE."
+  },
+  "storagesync": {
+    "title": "Azure File Sync documentation",
+    "url": "/azure/storage/file-sync/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure File Sync services, sync groups, and server endpoints with natural language prompts from your IDE."
+  },
+  "subscription": {
+    "title": "Azure subscription documentation",
+    "url": "/azure/cost-management-billing/manage/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure subscriptions and account information with natural language prompts from your IDE."
+  },
+  "virtualdesktop": {
+    "title": "Azure Virtual Desktop documentation",
+    "url": "/azure/virtual-desktop/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Virtual Desktop host pools, session hosts, and user sessions with natural language prompts from your IDE."
+  },
+  "wellarchitectedframework": {
+    "title": "Azure Well-Architected Framework documentation",
+    "url": "/azure/well-architected/",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Well-Architected Framework assessments and recommendations for cloud workloads with natural language prompts from your IDE."
+  },
+  "workbooks": {
+    "title": "Azure Monitor Workbooks documentation",
+    "url": "/azure/azure-monitor/visualize/workbooks-overview",
+    "seoDescription": "Use Azure MCP Server tools to manage Azure Workbooks resources and interactive data visualization dashboards with natural language prompts from your IDE."
+  }
 }


### PR DESCRIPTION
## Summary

Removes the orphaned `monitorinstrumentation` namespace. Its tools were moved to the `monitor` namespace in beta.30 (BREAKING change). Running `./start.sh monitorinstrumentation` fails with 'No tools found'.

## What Changed

- **brand-to-server-mapping.json**: Removed monitorinstrumentation entry (58->57)
- **service-doc-links.json**: Removed monitorinstrumentation entry (57->56)
- **generated-monitorinstrumentation/**: Deleted (only contained empty bootstrap output)

## Context

CHANGELOG beta.30:
> Moved the following tools from `monitorinstrumentation` to `monitor` namespace: list_learning_resources, get_learning_resource, orchestrator_start, orchestrator_next, send_brownfield_analysis

The 4 surviving tools now live as `monitor instrumentation *` sub-commands within the `monitor` namespace, which already has generated output.

## Verification

- Build passes
- Production link tests pass (2/2)
- `monitor` namespace validated output already includes instrumentation tools