### PR TITLE
fix: render annotations inline instead of [!INCLUDE] references (#193, #191)

### DIFF
--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/PageGeneratorStripFrontmatterTests.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/PageGeneratorStripFrontmatterTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CSharpGenerator.Generators;
+using Xunit;
+
+namespace DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests;
+
+/// <summary>
+/// Tests for PageGenerator.StripFrontmatter — ensures YAML frontmatter
+/// is removed from annotation file content before inline rendering.
+/// Fixes: #193
+/// </summary>
+public class PageGeneratorStripFrontmatterTests
+{
+    [Fact]
+    public void StripFrontmatter_RemovesFrontmatter_ReturnsContentAfter()
+    {
+        var input = "---\nms.topic: include\nms.date: 2026-03-20\n---\nDestructive: ❌ | Idempotent: ✅\n";
+        var result = PageGenerator.StripFrontmatter(input);
+
+        Assert.Contains("Destructive: ❌ | Idempotent: ✅", result);
+        Assert.DoesNotContain("ms.topic", result);
+        Assert.DoesNotContain("---", result.Trim());
+    }
+
+    [Fact]
+    public void StripFrontmatter_NoFrontmatter_ReturnsOriginal()
+    {
+        var input = "Destructive: ❌ | Idempotent: ✅\n";
+        var result = PageGenerator.StripFrontmatter(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void StripFrontmatter_EmptyString_ReturnsEmpty()
+    {
+        Assert.Equal("", PageGenerator.StripFrontmatter(""));
+    }
+
+    [Fact]
+    public void StripFrontmatter_NullString_ReturnsNull()
+    {
+        Assert.Null(PageGenerator.StripFrontmatter(null!));
+    }
+
+    [Fact]
+    public void StripFrontmatter_OnlyFrontmatter_ReturnsEmptyContent()
+    {
+        var input = "---\nms.topic: include\n---\n";
+        var result = PageGenerator.StripFrontmatter(input);
+
+        Assert.DoesNotContain("ms.topic", result.Trim());
+    }
+
+    [Fact]
+    public void StripFrontmatter_FullAnnotationFile_ReturnsAnnotationLine()
+    {
+        var input = string.Join("\n", new[]
+        {
+            "---",
+            "ms.topic: include",
+            "ms.date: 2026-03-20",
+            "mcp-cli.version: 1.0.0",
+            "---",
+            "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌",
+            ""
+        });
+
+        var result = PageGenerator.StripFrontmatter(input).Trim();
+
+        Assert.Equal(
+            "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌",
+            result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
@@ -80,7 +80,8 @@ public class PageGenerator
                     {
                         try
                         {
-                            filteredTool.AnnotationContent = File.ReadAllText(annotationFilePath);
+                            var rawContent = File.ReadAllText(annotationFilePath);
+                            filteredTool.AnnotationContent = StripFrontmatter(rawContent).Trim();
                             filteredTool.AnnotationFileName = annotationFileName;
                         }
                         catch
@@ -225,5 +226,36 @@ public class PageGenerator
         var outputFile = Path.Combine(commonGeneralDir, "azmcp-commands.md");
         await File.WriteAllTextAsync(outputFile, result);
         LogFileHelper.WriteDebug("Generated commands page: common-general/azmcp-commands.md");
+    }
+
+    /// <summary>
+    /// Strips YAML frontmatter (--- ... ---) from markdown content.
+    /// Returns the content after the closing --- delimiter.
+    /// </summary>
+    internal static string StripFrontmatter(string content)
+    {
+        if (string.IsNullOrEmpty(content) || !content.TrimStart().StartsWith("---"))
+            return content;
+
+        var lines = content.Split('\n');
+        var foundStart = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Trim() == "---")
+            {
+                if (!foundStart)
+                {
+                    foundStart = true;
+                }
+                else
+                {
+                    // Return everything after the closing ---
+                    return string.Join('\n', lines.Skip(i + 1));
+                }
+            }
+        }
+
+        return content;
     }
 }

--- a/docs-generation/templates/tool-family-page.hbs
+++ b/docs-generation/templates/tool-family-page.hbs
@@ -45,10 +45,10 @@ mcp-cli.version: {{version}}
 | *No parameters* |  | |
 
 {{/if}}
-{{#if AnnotationFileName}}
+{{#if AnnotationContent}}
 [Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):
 
-[!INCLUDE [{{Command}}](../annotations/{{AnnotationFileName}})]
+{{{AnnotationContent}}}
 {{else}}
 <!-- No tool annotations for this tool -->
 {{/if}}


### PR DESCRIPTION
## Summary

Fixes two related annotation rendering bugs in the tool-family-page template:

### #193: Annotations rendered as [!INCLUDE] instead of inline values

The \	ool-family-page.hbs\ template used \[!INCLUDE]\ references to annotation files, which are not rendered in all contexts. Changed to render annotation values inline using \{{{AnnotationContent}}}\ triple-stache rendering.

### #191: Missing blank line between annotation link and values

Ensured a blank line exists between the \[Tool annotation hints]\ link and the annotation values line. Without this blank line, Markdown renders them as one paragraph.

## Changes

- **\docs-generation/templates/tool-family-page.hbs\**: Replace \[!INCLUDE]\ annotation reference with \{{{AnnotationContent}}}\ inline rendering
- **\PageGenerator.cs\**: Strip YAML frontmatter from annotation file content before passing to template context
- **\PageGeneratorStripFrontmatterTests.cs\**: 6 unit tests for the new \StripFrontmatter\ helper

## Testing

- \dotnet build docs-generation.sln --configuration Release\ — 0 warnings, 0 errors
- \dotnet test docs-generation.sln\ — all tests pass including 6 new tests

Fixes #193
Fixes #191