### PR TITLE
fix: map compute namespace to Azure Virtual Machines brand (#230)

### DIFF
--- a/docs-generation/data/brand-to-server-mapping.json
+++ b/docs-generation/data/brand-to-server-mapping.json
@@ -78,10 +78,10 @@
     "fileName": "azure-communication-services"
   },
   {
-    "brandName": "Azure Compute",
+    "brandName": "Azure Virtual Machines",
     "mcpServerName": "compute",
-    "shortName": "Compute",
-    "fileName": "azure-compute"
+    "shortName": "Virtual Machines",
+    "fileName": "azure-virtual-machines"
   },
   {
     "brandName": "Azure Confidential Ledger",


### PR DESCRIPTION
Fixes #230

Updates brand-to-server-mapping.json:
- brandName: Azure Compute → Azure Virtual Machines
- shortName: Compute → Virtual Machines
- fileName: azure-compute → azure-virtual-machines

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>