### PR TITLE
fix: strengthen example prompt lead-in and required param enforcement (#228)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/prompts/system-prompt-example-prompt.txt
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/prompts/system-prompt-example-prompt.txt
@@ -231,7 +231,7 @@ Return a JSON object with the tool name as the key and an array of plain example
 ### YOUR RESPONSE MUST CONTAIN:
 
 1. **ONLY THE JSON OBJECT** - Nothing else
-2. **NO PREAMBLE** - Do not include "Here is the response:" or "Step 1:", etc.
+2. **NO PREAMBLE** - Do not include ANY lead-in text such as "Here is the response:", "Here are some example commands:", "Here are some example prompts:", "Following are:", "Step 1:", etc.
 3. **NO VERIFICATION TEXT** - Do not include your checklist, verification steps, or reasoning
 4. **NO CODE FENCES** - Do not wrap the JSON in ```json or ``` markers
 5. **NO EXTRA TEXT** - Do not add explanations before or after the JSON
@@ -263,12 +263,23 @@ Return a JSON object with the tool name as the key and an array of plain example
 
 ### INCORRECT EXAMPLES (DO NOT DO THIS):
 
-❌ **With preamble:**
+❌ **With preamble (any variation):**
 ```
 Here are the prompts:
 {
   "storage account list": [...]
 }
+```
+
+❌ **Other preamble variations to AVOID:**
+```
+Here are some example commands:
+```
+```
+Here are some example prompts for using this tool:
+```
+```
+Following are the prompts:
 ```
 
 ❌ **With verification:**

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/prompts/user-prompt-example-prompt.txt
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/prompts/user-prompt-example-prompt.txt
@@ -15,7 +15,7 @@ Parameters:
 
 This tool has **{REQUIRED_PARAM_COUNT} required parameter(s)**: {REQUIRED_PARAM_NAMES}
 
-**Every single example prompt MUST include ALL {REQUIRED_PARAM_COUNT} of these required parameters.** Each parameter value MUST appear in single quotes with a concrete, realistic example value (e.g., 'my-value'). Count them in each prompt before outputting. If any prompt has fewer than {REQUIRED_PARAM_COUNT} required parameters represented, regenerate it.
+**CRITICAL — Every single example prompt MUST include ALL {REQUIRED_PARAM_COUNT} of these required parameters.** Each parameter value MUST appear in single quotes with a concrete, realistic example value (e.g., 'my-value'). Before outputting your response, verify that every prompt contains all {REQUIRED_PARAM_COUNT} required parameters. Your response will be rejected if any required parameter is missing from any prompt.
 
 Rules for optional parameters:
 - If `resource-group` is Required, include it. If Optional, omit it.


### PR DESCRIPTION
Fixes #228

- Expand NO PREAMBLE rule with observed AI variations (e.g. 'Here are some example commands:')
- Add explicit incorrect preamble examples to avoid
- Strengthen required parameter verification language in user prompt

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>