### PR TITLE
Fix double ending punctuation in example prompts (#243)

### DIFF
--- a/docs-generation/DocGeneration.Core.NaturalLanguage.Tests/TextCleanupTests.cs
+++ b/docs-generation/DocGeneration.Core.NaturalLanguage.Tests/TextCleanupTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 using NaturalLanguageGenerator;
 
 namespace DocGeneration.Core.NaturalLanguage.Tests;
@@ -152,6 +152,62 @@ public class TextCleanupTests : IDisposable
     {
         var result = TextCleanup.EnsureEndsPeriod("  The Cosmos DB account name  ");
         Assert.Equal("The Cosmos DB account name.", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_QuestionMarkBeforeSingleQuote_NoChange()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Ask 'Why are requests timing out?'");
+        Assert.Equal("Ask 'Why are requests timing out?'", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_QuestionMarkBeforeDoubleQuote_NoChange()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Ask \"What is the status?\"");
+        Assert.Equal("Ask \"What is the status?\"", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_ExclamationBeforeDoubleQuote_NoChange()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Alert said \"Critical failure!\"");
+        Assert.Equal("Alert said \"Critical failure!\"", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_PeriodBeforeSingleQuote_NoChange()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Run command 'az show.'");
+        Assert.Equal("Run command 'az show.'", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_NoPunctuationBeforeSingleQuote_AddsPeriod()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Use resource 'my-resource'");
+        Assert.Equal("Use resource 'my-resource'.", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_NoPunctuationBeforeDoubleQuote_AddsPeriod()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Show vault \"my-vault\"");
+        Assert.Equal("Show vault \"my-vault\".", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_QuestionMarkBeforeBacktick_NoChange()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Ask `Why is latency high?`");
+        Assert.Equal("Ask `Why is latency high?`", result);
+    }
+
+    [Fact]
+    public void EnsureEndsPeriod_NoPunctuationBeforeBacktick_AddsPeriod()
+    {
+        var result = TextCleanup.EnsureEndsPeriod("Run `az account show`");
+        Assert.Equal("Run `az account show`.", result);
     }
 
     // ─────────────────────────────────────────────

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/EnsureEndingPunctuationTests.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/EnsureEndingPunctuationTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 using ExamplePromptGeneratorStandalone.Generators;
 
 namespace ExamplePromptGeneratorStandalone.Tests;
@@ -82,5 +82,71 @@ public class EnsureEndingPunctuationTests
     {
         var result = ExamplePromptGenerator.EnsureEndingPunctuation("   ");
         Assert.Equal("", result);
+    }
+
+    // Punctuation before closing quotes - no double punctuation
+
+    [Fact]
+    public void NoPeriodWhenQuestionMarkBeforeSingleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Ask the question 'Why are requests timing out?'");
+        Assert.Equal("Ask the question 'Why are requests timing out?'", result);
+    }
+
+    [Fact]
+    public void NoPeriodWhenQuestionMarkBeforeDoubleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Ask \"What is the status?\"");
+        Assert.Equal("Ask \"What is the status?\"", result);
+    }
+
+    [Fact]
+    public void NoPeriodWhenPeriodBeforeSingleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Run the command 'az account show.'");
+        Assert.Equal("Run the command 'az account show.'", result);
+    }
+
+    [Fact]
+    public void NoPeriodWhenExclamationBeforeDoubleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Alert said \"Critical failure!\"");
+        Assert.Equal("Alert said \"Critical failure!\"", result);
+    }
+
+    [Fact]
+    public void AppendsPeriodWhenNoEndPunctuationBeforeSingleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Use resource 'my-resource'");
+        Assert.Equal("Use resource 'my-resource'.", result);
+    }
+
+    [Fact]
+    public void AppendsPeriodWhenNoEndPunctuationBeforeDoubleQuote()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Show details for vault \"my-vault\"");
+        Assert.Equal("Show details for vault \"my-vault\".", result);
+    }
+
+    [Fact]
+    public void NoPeriodWhenQuestionMarkBeforeBacktick()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Ask `Why is latency high?`");
+        Assert.Equal("Ask `Why is latency high?`", result);
+    }
+
+    [Fact]
+    public void AppendsPeriodWhenNoEndPunctuationBeforeBacktick()
+    {
+        var result = ExamplePromptGenerator.EnsureEndingPunctuation(
+            "Run `az account show`");
+        Assert.Equal("Run `az account show`.", result);
     }
 }

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/ExamplePromptGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/ExamplePromptGenerator.cs
@@ -402,6 +402,17 @@ public sealed class ExamplePromptGenerator
         if (trimmed.Length == 0) return trimmed;
         var lastChar = trimmed[^1];
         if (lastChar == '.' || lastChar == '?' || lastChar == '!') return trimmed;
+
+        // Check for punctuation before trailing closing quotes
+        if (lastChar == '\'' || lastChar == '"' || lastChar == '`')
+        {
+            var i = trimmed.Length - 1;
+            while (i > 0 && (trimmed[i] == '\'' || trimmed[i] == '"' || trimmed[i] == '`'))
+                i--;
+            if (i >= 0 && (trimmed[i] == '.' || trimmed[i] == '?' || trimmed[i] == '!'))
+                return trimmed;
+        }
+
         return trimmed + ".";
     }
 


### PR DESCRIPTION
## Summary
Fixes #243. EnsureEndingPunctuation() and EnsureEndsPeriod() now check for punctuation before closing quotes to prevent double punctuation in generated example prompts.

## Changes
- **ExamplePromptGenerator.cs**: After checking the last char, also check if trailing quote chars have punctuation before them
- **EnsureEndingPunctuationTests.cs**: +8 tests for quote-aware punctuation handling
- **TextCleanupTests.cs**: +8 tests for EnsureEndsPeriod quote-aware handling (source fix was already on main)

## TDD Workflow
1. Tests written first and verified to FAIL against unfixed code
2. Fix applied
3. All tests pass (1 pre-existing unrelated failure in PipelineRunner)