### PR TITLE
Fix dual-mode tool eligibility in deterministic prompt generator (#188)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicExamplePromptGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicExamplePromptGeneratorTests.cs
@@ -280,6 +280,150 @@ public class DeterministicExamplePromptGeneratorTests
             Assert.True(p.EndsWith(".") || p.EndsWith("?"), $"Bad punctuation: {p}"));
     }
 
+    // ── IsEligible: dual-mode tool exclusion (Bug #188) ────────────
+
+    [Fact]
+    public void IsEligible_GetVerb_NoOptionalParams_ReturnsTrue()
+    {
+        var tool = MakeTool("cosmos container get", "Get container",
+            new Option { Name = "account", Required = true, Description = "Account" });
+        Assert.True(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_GetVerb_OnlyCommonOptionalParams_ReturnsTrue()
+    {
+        var tool = new Tool
+        {
+            Name = "group_list",
+            Command = "group list",
+            Description = "List resource groups",
+            Option = new List<Option>
+            {
+                new() { Name = "subscription", Required = false, Description = "Subscription" },
+                new() { Name = "resource-group", Required = false, Description = "Resource group" },
+                new() { Name = "retry-delay", Required = false, Description = "Retry delay" },
+                new() { Name = "retry-max-delay", Required = false, Description = "Max delay" },
+                new() { Name = "retry-max-retries", Required = false, Description = "Max retries" },
+                new() { Name = "retry-mode", Required = false, Description = "Retry mode" },
+                new() { Name = "retry-network-timeout", Required = false, Description = "Network timeout" },
+                new() { Name = "auth-method", Required = false, Description = "Auth method" },
+                new() { Name = "tenant", Required = false, Description = "Tenant" },
+            }
+        };
+        Assert.True(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_GetVerb_NonCommonOptionalParams_ReturnsFalse()
+    {
+        var tool = new Tool
+        {
+            Name = "functions_template_get",
+            Command = "functions template get",
+            Description = "Get function templates",
+            Option = new List<Option>
+            {
+                new() { Name = "template", Required = false, Description = "Template name" },
+                new() { Name = "tenant", Required = false, Description = "Tenant" },
+            }
+        };
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_ListVerb_NonCommonOptionalParams_ReturnsFalse()
+    {
+        var tool = new Tool
+        {
+            Name = "storage_list",
+            Command = "storage list",
+            Description = "List storage",
+            Option = new List<Option>
+            {
+                new() { Name = "filter", Required = false, Description = "Filter expression" },
+            }
+        };
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_CreateVerb_NonCommonOptionalParams_ReturnsFalse()
+    {
+        var tool = new Tool
+        {
+            Name = "redis_create",
+            Command = "redis create",
+            Description = "Create Redis",
+            Option = new List<Option>
+            {
+                new() { Name = "name", Required = true, Description = "Name" },
+                new() { Name = "sku", Required = false, Description = "SKU tier" },
+            }
+        };
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_FunctionsTemplateGet_WithTemplateOptional_ReturnsFalse()
+    {
+        // Exact reproduction of Bug #188
+        var tool = new Tool
+        {
+            Name = "functions_template_get",
+            Command = "functions template get",
+            Description = "Get or list function templates",
+            Option = new List<Option>
+            {
+                new() { Name = "template", Required = false, Description = "Template name to generate" },
+                new() { Name = "language", Required = false, Description = "Programming language" },
+                new() { Name = "retry-delay", Required = false, Description = "Retry delay" },
+                new() { Name = "auth-method", Required = false, Description = "Auth method" },
+                new() { Name = "tenant", Required = false, Description = "Tenant" },
+            }
+        };
+        Assert.False(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    [Fact]
+    public void IsEligible_OnlySubscriptionAndResourceGroupOptional_ReturnsTrue()
+    {
+        var tool = new Tool
+        {
+            Name = "advisor_list",
+            Command = "advisor list",
+            Description = "List advisor recommendations",
+            Option = new List<Option>
+            {
+                new() { Name = "subscription", Required = false, Description = "Subscription" },
+                new() { Name = "resource-group", Required = false, Description = "Resource group" },
+            }
+        };
+        Assert.True(DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts: false));
+    }
+
+    // ── IsCommonParam ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("retry-delay", true)]
+    [InlineData("retry-max-delay", true)]
+    [InlineData("retry-max-retries", true)]
+    [InlineData("retry-mode", true)]
+    [InlineData("retry-network-timeout", true)]
+    [InlineData("auth-method", true)]
+    [InlineData("tenant", true)]
+    [InlineData("subscription", true)]
+    [InlineData("resource-group", true)]
+    [InlineData("template", false)]
+    [InlineData("filter", false)]
+    [InlineData("query", false)]
+    [InlineData("name", false)]
+    [InlineData("sku", false)]
+    public void IsCommonParam_ClassifiesCorrectly(string paramName, bool expected)
+    {
+        Assert.Equal(expected, DeterministicExamplePromptGenerator.IsCommonParam(paramName));
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────
 
     private static Tool MakeTool(string command, string description, params Option[] requiredOptions)

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
@@ -61,14 +61,39 @@ public static class DeterministicExamplePromptGenerator
         return StandardVerbs.Contains(lastSegment) ? lastSegment : null;
     }
 
+    private static readonly HashSet<string> CommonParamNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "retry-delay", "retry-max-delay", "retry-max-retries", "retry-mode",
+        "retry-network-timeout", "auth-method", "tenant", "subscription", "resource-group"
+    };
+
+    /// <summary>
+    /// Returns true if the parameter is a common infrastructure parameter
+    /// that does not change a tool's mode of operation.
+    /// </summary>
+    public static bool IsCommonParam(string paramName)
+    {
+        return CommonParamNames.Contains(paramName);
+    }
+
     /// <summary>
     /// Checks if a tool is eligible for deterministic prompt generation.
-    /// Returns false for non-standard verbs or when e2e prompts exist (they dictate style).
+    /// Returns false for non-standard verbs, when e2e prompts exist,
+    /// or when the tool has non-common optional parameters (dual-mode tools).
     /// </summary>
     public static bool IsEligible(Tool tool, bool hasE2ePrompts)
     {
         if (hasE2ePrompts) return false;
-        return ClassifyVerb(tool.Command) != null;
+        if (ClassifyVerb(tool.Command) == null) return false;
+
+        // Dual-mode tools with non-common optional params should use AI generation
+        var nonCommonOptionalParams = tool.Option?
+            .Where(o => !o.Required && !IsCommonParam(o.Name ?? ""))
+            .ToList() ?? new List<Option>();
+
+        if (nonCommonOptionalParams.Count > 0) return false;
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem
\unctions template get\ consistently fails Step 2 (example prompt generation) because \DeterministicExamplePromptGenerator.IsEligible()\ returns TRUE for any tool with a standard verb, regardless of optional parameters that change behavior.

## Root Cause
The tool is dual-mode: without \--template\ it lists templates, with \--template\ it generates code. Deterministic generation produces semantically wrong prompts for such tools.

## Fix
Added \IsCommonParam()\ method and updated \IsEligible()\ to exclude tools with non-common optional parameters (e.g., \--template\, \--filter\, \--language\). Common infrastructure params (\--retry-*\, \--auth-method\, \--tenant\, \--subscription\, \--resource-group\) are still allowed.

Dual-mode tools are now routed to AI generation instead.

## Tests (TDD)
- 7 new \IsEligible\ tests covering all cases (including exact Bug #188 reproduction)
- 14 new \IsCommonParam\ classification tests
- All 57 DeterministicExamplePromptGenerator tests pass
- Full solution test suite passes (1 pre-existing unrelated failure in PipelineRunner)

Fixes #188