### PR TITLE
Fix missing tool detection with actionable errors (#196)

### DIFF
--- a/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -50,7 +50,8 @@ public class ToolFamilyPostAssemblyValidatorTests
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Warnings, warning => warning.Contains("Blocking: Tool count integrity check failed.", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning => warning.Contains("Blocking: Tool count integrity check failed (", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning => warning.Contains("frontmatter tool_count: 1, actual tool files: 2", StringComparison.Ordinal));
             Assert.Contains("RESULT: FAIL", File.ReadAllText(Path.Combine(context.OutputPath, "reports", "tool-family-validation-compute.txt")), StringComparison.Ordinal);
         }
         finally
@@ -340,6 +341,63 @@ public class ToolFamilyPostAssemblyValidatorTests
             Directory.Delete(path, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task ValidateAsync_MissingToolFromArticle_ListsToolNameInError()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            // 3 tool files but article only has 2 H2 sections
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-create.md"), "compute create");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithMissingTool());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.False(result.Success);
+            // The error should name the missing tool file
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("Cross-reference check failed", StringComparison.Ordinal)
+                && warning.Contains("compute-create.md", StringComparison.Ordinal)
+                && warning.Contains("Regenerate the namespace to include them", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static string ArticleWithMissingTool()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 3
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List resources where resource group name is 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+
+        ## Show virtual machine
+        <!-- @mcpcli compute show -->
+        Example prompts include:
+        - Show the VM named 'vm-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+
+        ## Related content
+        - Link
+        """;
 
     private sealed class FakeStep : IPipelineStep
     {

--- a/docs-generation/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -78,7 +78,20 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
                 if (toolFileCount != articleSectionCount || frontmatterToolCount is null || frontmatterToolCount != toolFileCount)
                 {
-                    blockingIssues.Add("Tool count integrity check failed.");
+                    var details = new List<string>();
+                    if (toolFileCount != articleSectionCount)
+                    {
+                        details.Add($"tool files: {toolFileCount}, article sections: {articleSectionCount}");
+                    }
+                    if (frontmatterToolCount is null)
+                    {
+                        details.Add("frontmatter tool_count is missing");
+                    }
+                    else if (frontmatterToolCount != toolFileCount)
+                    {
+                        details.Add($"frontmatter tool_count: {frontmatterToolCount}, actual tool files: {toolFileCount}");
+                    }
+                    blockingIssues.Add($"Tool count integrity check failed ({string.Join("; ", details)}).");
                 }
 
                 foreach (var duplicate in toolFileLookup.Where(pair => pair.Value.Count > 1))
@@ -106,7 +119,18 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
                 if (missingFromArticle.Length > 0 || missingFromFiles.Length > 0)
                 {
-                    blockingIssues.Add("Cross-reference check failed.");
+                    var parts = new List<string>();
+                    if (missingFromArticle.Length > 0)
+                    {
+                        var toolNames = string.Join(", ", missingFromArticle.Select(name => $"'{name}'"));
+                        parts.Add($"{missingFromArticle.Length} tool(s) exist in /tools/ but have no H2 section in the article: {toolNames}. Regenerate the namespace to include them");
+                    }
+                    if (missingFromFiles.Length > 0)
+                    {
+                        var sectionNames = string.Join(", ", missingFromFiles.Select(name => $"'{name}'"));
+                        parts.Add($"{missingFromFiles.Length} article section(s) have no matching tool file: {sectionNames}");
+                    }
+                    blockingIssues.Add($"Cross-reference check failed. {string.Join(". ", parts)}.");
                 }
 
                 // With section freezing (AD-017), missing required params

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/MissingToolDetectorTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/MissingToolDetectorTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+public class MissingToolDetectorTests
+{
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — all tools present
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_AllToolsPresent_ReturnsEmptyList()
+    {
+        var expectedTools = new[] { "List storage accounts", "Get storage account" };
+        var article = string.Join("\n", new[]
+        {
+            "---",
+            "title: Storage tools",
+            "tool_count: 2",
+            "---",
+            "# Storage tools",
+            "",
+            "## List storage accounts",
+            "<!-- @mcpcli storage account list -->",
+            "Lists all storage accounts.",
+            "",
+            "## Get storage account",
+            "<!-- @mcpcli storage account get -->",
+            "Gets a storage account.",
+            "",
+            "## Related content",
+            "- [Link](https://example.com)"
+        });
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — one tool missing
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_OneMissing_ReturnsMissingTool()
+    {
+        var expectedTools = new[] { "List storage accounts", "Get storage account", "Create storage account" };
+        var article = string.Join("\n", new[]
+        {
+            "---",
+            "title: Storage tools",
+            "tool_count: 3",
+            "---",
+            "# Storage tools",
+            "",
+            "## List storage accounts",
+            "<!-- @mcpcli storage account list -->",
+            "Lists all storage accounts.",
+            "",
+            "## Get storage account",
+            "<!-- @mcpcli storage account get -->",
+            "Gets a storage account.",
+            "",
+            "## Related content",
+            "- [Link](https://example.com)"
+        });
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Single(missing);
+        Assert.Equal("Create storage account", missing[0]);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — multiple tools missing
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_MultipleMissing_ReturnsAllMissingSorted()
+    {
+        var expectedTools = new[]
+        {
+            "List Key Vault secrets",
+            "Get Key Vault secret",
+            "Delete Key Vault secret",
+            "Set Key Vault secret"
+        };
+        var article = string.Join("\n", new[]
+        {
+            "# Key Vault tools",
+            "",
+            "## List Key Vault secrets",
+            "Lists secrets.",
+            "",
+            "## Related content",
+            "- Link"
+        });
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Equal(3, missing.Count);
+        Assert.Equal("Delete Key Vault secret", missing[0]);
+        Assert.Equal("Get Key Vault secret", missing[1]);
+        Assert.Equal("Set Key Vault secret", missing[2]);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — empty article
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_EmptyArticle_ReturnsAllToolsAsMissing()
+    {
+        var expectedTools = new[] { "List Cosmos DB containers", "Query Cosmos DB container" };
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, "");
+
+        Assert.Equal(2, missing.Count);
+        Assert.Contains("List Cosmos DB containers", missing);
+        Assert.Contains("Query Cosmos DB container", missing);
+    }
+
+    [Fact]
+    public void DetectMissingTools_NullArticle_ReturnsAllToolsAsMissing()
+    {
+        var expectedTools = new[] { "List VMs", "Create VM" };
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, null!);
+
+        Assert.Equal(2, missing.Count);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — empty tool list
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_EmptyToolList_ReturnsEmptyList()
+    {
+        var article = "## Some heading\nContent";
+
+        var missing = MissingToolDetector.DetectMissingTools(Array.Empty<string>(), article);
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — case insensitive matching
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_CaseInsensitiveMatch_ToolFound()
+    {
+        var expectedTools = new[] { "list storage accounts" };
+        var article = "## List Storage Accounts\nContent";
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — Related content excluded from matching
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_RelatedContentNotCountedAsToolSection()
+    {
+        var expectedTools = new[] { "Related content" };
+        var article = string.Join("\n", new[]
+        {
+            "## Related content",
+            "- Link"
+        });
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        // "Related content" H2 is excluded from tool section matching
+        Assert.Single(missing);
+        Assert.Equal("Related content", missing[0]);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — tool names with special characters
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_ToolNamesWithSpecialCharacters_HandledCorrectly()
+    {
+        var expectedTools = new[] { "Get AI Foundry agent's status", "List (preview) resources" };
+        var article = string.Join("\n", new[]
+        {
+            "## Get AI Foundry agent's status",
+            "Gets the status.",
+            "",
+            "## List (preview) resources",
+            "Lists preview resources."
+        });
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  DetectMissingTools — whitespace in tool names
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DetectMissingTools_WhitespaceInToolNames_TrimmedBeforeMatching()
+    {
+        var expectedTools = new[] { "  List VMs  " };
+        var article = "## List VMs\nContent";
+
+        var missing = MissingToolDetector.DetectMissingTools(expectedTools, article);
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  FormatMissingToolsWarning
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void FormatWarning_NoMissingTools_ReturnsNull()
+    {
+        var result = MissingToolDetector.FormatMissingToolsWarning(
+            Array.Empty<string>(), "compute");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FormatWarning_SingleMissingTool_SingularGrammar()
+    {
+        var result = MissingToolDetector.FormatMissingToolsWarning(
+            new[] { "Create VM" }, "compute");
+
+        Assert.NotNull(result);
+        Assert.Contains("1 tool has no H2 section", result);
+        Assert.Contains("'Create VM'", result);
+        Assert.Contains("Regenerate the 'compute' namespace", result);
+    }
+
+    [Fact]
+    public void FormatWarning_MultipleMissingTools_PluralGrammarAndAllListed()
+    {
+        var result = MissingToolDetector.FormatMissingToolsWarning(
+            new[] { "Create VM", "Delete VM", "Restart VM" }, "compute");
+
+        Assert.NotNull(result);
+        Assert.Contains("3 tools have no H2 section", result);
+        Assert.Contains("'Create VM'", result);
+        Assert.Contains("'Delete VM'", result);
+        Assert.Contains("'Restart VM'", result);
+        Assert.Contains("Regenerate the 'compute' namespace", result);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  ExtractH2Headings
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ExtractH2Headings_EmptyContent_ReturnsEmptyList()
+    {
+        var headings = MissingToolDetector.ExtractH2Headings("");
+
+        Assert.Empty(headings);
+    }
+
+    [Fact]
+    public void ExtractH2Headings_ExcludesRelatedContent()
+    {
+        var article = string.Join("\n", new[]
+        {
+            "## List resources",
+            "Content",
+            "## Related content",
+            "- Link"
+        });
+
+        var headings = MissingToolDetector.ExtractH2Headings(article);
+
+        Assert.Single(headings);
+        Assert.Equal("List resources", headings[0]);
+    }
+
+    [Fact]
+    public void ExtractH2Headings_MultipleH2s_ReturnsAll()
+    {
+        var article = string.Join("\n", new[]
+        {
+            "## List VMs",
+            "Content",
+            "## Create VM",
+            "Content",
+            "## Delete VM",
+            "Content"
+        });
+
+        var headings = MissingToolDetector.ExtractH2Headings(article);
+
+        Assert.Equal(3, headings.Count);
+        Assert.Equal("List VMs", headings[0]);
+        Assert.Equal("Create VM", headings[1]);
+        Assert.Equal("Delete VM", headings[2]);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/PhantomH2Tests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/PhantomH2Tests.cs
@@ -536,6 +536,45 @@ public class PhantomH2Tests
     }
 
     [Fact]
+    public void ValidateAndFix_FewerH2sThanExpected_WarnsWithToolNames()
+    {
+        // One tool is missing its H2 heading entirely — verify console output names it
+        var contentMissingH2 = string.Join("\n", new[]
+        {
+            "<!-- @mcpcli monitor alert create -->",
+            "",
+            "Creates a metric alert rule.",
+            "",
+            "| Parameter | Required | Description |",
+            "| --- | --- | --- |",
+            "| `alertName` | Yes | The alert rule name. |"
+        });
+
+        var family = BuildFamily("monitor",
+            ("alert create", contentMissingH2),
+            ("alert get", BuildToolContent("Get Monitor alert", "monitor alert get")));
+
+        // Capture console output
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+
+        try
+        {
+            CleanupGenerator.ValidateAndFixPhantomH2Sections(family, "  [1/1]");
+
+            var output = writer.ToString();
+            // The output should identify the tool missing its H2
+            Assert.Contains("alert create", output);
+            Assert.Contains("no H2 heading", output);
+            Assert.Contains("Regenerate", output);
+        }
+        finally
+        {
+            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+        }
+    }
+
+    [Fact]
     public void ValidateAndFix_EmptyToolsList_NoException()
     {
         var family = new FamilyContent

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
@@ -660,9 +660,36 @@ public class CleanupGenerator
             Console.WriteLine($"{progress}     H2: \"{heading}\" (in tool #{toolIndex + 1}: {familyContent.Tools[toolIndex].ToolName})");
         }
 
-        if (actualH2Count <= expectedToolCount)
+        if (actualH2Count < expectedToolCount)
         {
-            Console.WriteLine($"{progress}   ⚠ Fewer H2s than expected — cannot auto-fix (tools may be missing headings)");
+            // Identify which specific tools are missing H2 headings
+            var toolsMissingH2 = familyContent.Tools
+                .Where(t =>
+                {
+                    var toolH2s = H2HeadingRegex.Matches(t.Content)
+                        .Select(m => m.Groups[1].Value.Trim())
+                        .Where(h => !string.Equals(h, "Related content", StringComparison.OrdinalIgnoreCase));
+                    return !toolH2s.Any();
+                })
+                .Select(t => t.ToolName)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (toolsMissingH2.Count > 0)
+            {
+                var toolList = string.Join(", ", toolsMissingH2.Select(n => $"'{n}'"));
+                Console.WriteLine($"{progress}   ⚠ {toolsMissingH2.Count} tool(s) have no H2 heading: {toolList}");
+                Console.WriteLine($"{progress}   ⚠ Regenerate the '{familyContent.FamilyName}' namespace to include them.");
+            }
+            else
+            {
+                Console.WriteLine($"{progress}   ⚠ Fewer H2s than expected — cannot auto-fix (tools may be missing headings)");
+            }
+            return;
+        }
+
+        if (actualH2Count == expectedToolCount)
+        {
             return;
         }
 

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/MissingToolDetector.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/MissingToolDetector.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Detects tools that exist in the tool list but have no corresponding H2 section
+/// in the assembled article content. Provides actionable information about which
+/// tools are missing, enabling clear error messages for content PR workflows.
+/// </summary>
+public static class MissingToolDetector
+{
+    private static readonly Regex H2HeadingRegex = new(
+        @"^##\s+(.+)$",
+        RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Identifies tool names that have no corresponding H2 heading in the given article content.
+    /// </summary>
+    /// <param name="expectedToolNames">List of tool names expected to appear as H2 sections.</param>
+    /// <param name="articleContent">The assembled article markdown content.</param>
+    /// <returns>
+    /// An ordered list of tool names that have no matching H2 heading in the article.
+    /// Matching is case-insensitive and ignores leading/trailing whitespace.
+    /// </returns>
+    public static IReadOnlyList<string> DetectMissingTools(
+        IReadOnlyList<string> expectedToolNames,
+        string articleContent)
+    {
+        ArgumentNullException.ThrowIfNull(expectedToolNames);
+
+        if (string.IsNullOrEmpty(articleContent))
+        {
+            return expectedToolNames
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        var h2Headings = ExtractH2Headings(articleContent);
+
+        var missing = expectedToolNames
+            .Where(toolName => !h2Headings.Contains(toolName.Trim(), StringComparer.OrdinalIgnoreCase))
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return missing;
+    }
+
+    /// <summary>
+    /// Extracts all H2 heading texts from the article content, excluding "Related content".
+    /// </summary>
+    internal static IReadOnlyList<string> ExtractH2Headings(string articleContent)
+    {
+        if (string.IsNullOrEmpty(articleContent))
+        {
+            return Array.Empty<string>();
+        }
+
+        var matches = H2HeadingRegex.Matches(articleContent);
+        return matches
+            .Select(m => m.Groups[1].Value.Trim())
+            .Where(h => !string.Equals(h, "Related content", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Formats a human-readable warning message listing the missing tools and guidance.
+    /// </summary>
+    /// <param name="missingTools">The list of missing tool names.</param>
+    /// <param name="familyName">The tool family/namespace name.</param>
+    /// <returns>A formatted multi-line warning string, or null if no tools are missing.</returns>
+    public static string? FormatMissingToolsWarning(
+        IReadOnlyList<string> missingTools,
+        string familyName)
+    {
+        if (missingTools.Count == 0)
+        {
+            return null;
+        }
+
+        var toolList = string.Join(", ", missingTools.Select(t => $"'{t}'"));
+        var plural = missingTools.Count == 1 ? "tool has" : "tools have";
+
+        return $"{missingTools.Count} {plural} no H2 section in the article: {toolList}. " +
+               $"Regenerate the '{familyName}' namespace to include them.";
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #196. When new tools are added between MCP versions, the pipeline now reports which specific tools are missing from the generated article instead of generic error messages.

## Changes

### New: MissingToolDetector utility
- Static utility class with DetectMissingTools(), ExtractH2Headings(), FormatMissingToolsWarning()
- 16 unit tests covering all edge cases

### Improved: ValidateAndFixPhantomH2Sections (CleanupGenerator.cs)
- Reports which tools have no H2 heading by name
- Includes regeneration guidance

### Improved: ToolFamilyPostAssemblyValidator
- Tool count integrity errors include counts breakdown
- Cross-reference errors list missing tool filenames with guidance
- 1 new test verifying missing tool filename appears in error output

## Test Results
- 1,350+ tests pass (only pre-existing StripsEmbeddedExamplePromptMarkers failure, unrelated)
- 18 new tests added (16 MissingToolDetector + 1 PhantomH2 + 1 PostAssemblyValidator)
