### PR TITLE
fix: wire CredentialSanitizer into prompt generation pipeline (#271)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicExamplePromptGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using ExamplePromptGeneratorStandalone.Models;
+using ExamplePromptGeneratorStandalone.Sanitizers;
 
 namespace ExamplePromptGeneratorStandalone.Generators;
 
@@ -150,7 +151,7 @@ public static class DeterministicExamplePromptGenerator
                     .Replace(" from {params}", "").Replace(" for {params}", "");
             }
 
-            prompts.Add(prompt);
+            prompts.Add(CredentialSanitizer.Sanitize(prompt));
         }
 
         return prompts;


### PR DESCRIPTION
## Summary

One-line integration: calls \CredentialSanitizer.Sanitize()\ on every generated example prompt before it's written to output.

Follow-up from PR #268 which added the sanitizer class and tests.

### Change

**File:** \DeterministicExamplePromptGenerator.cs\ line 153
- Before: \prompts.Add(prompt);\
- After: \prompts.Add(CredentialSanitizer.Sanitize(prompt));\

Closes #271