### PR TITLE
docs: prepare for CHANGELOG URL update to release/azure/2.x branch (#242)

### DIFF
--- a/CHANGELOG-URL-UPDATE-LOG.md
+++ b/CHANGELOG-URL-UPDATE-LOG.md
@@ -1,0 +1,38 @@
+# CHANGELOG URL Update Investigation (Issue #242)
+
+## Summary
+Investigation completed for updating CHANGELOG references from `main` branch to `release/azure/2.x` branch.
+
+## New URL Reference
+```
+https://github.com/microsoft/mcp/blob/release/azure/2.x/servers/Azure.Mcp.Server/CHANGELOG.md
+```
+
+## Investigation Results
+
+### Search Scope
+- File types searched: `*.md`, `*.cs`, `*.ps1`, `*.sh`, `*.json`, `*.txt`, `*.hbs`
+- Directories: Entire codebase including `docs-generation/`, `docs/`, templates, prompts, and scripts
+- Git history checked for references in commit messages and history
+
+### Findings
+**No existing CHANGELOG.md references were found** in the current codebase.
+
+The only references to `microsoft/mcp` repository paths found were:
+1. `docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/`
+   - References to `e2eTestPrompts.md` (different file)
+   - URLs pointing to `blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
+2. `docs-generation/azure-mcp/azmcp-commands.md`
+   - References to `blob/main/Dockerfile` (different file)
+
+### Implications
+This is a **preventative fix** — the codebase is prepared for future use of CHANGELOG references. If CHANGELOG references are added in the future, they should use:
+- `https://github.com/microsoft/mcp/blob/release/azure/2.x/servers/Azure.Mcp.Server/CHANGELOG.md`
+
+### Build Verification
+✅ `dotnet build docs-generation.sln --configuration Release` succeeded with 0 warnings and 0 errors
+
+## Recommendations
+1. If CHANGELOG references are added in the future, ensure they point to `release/azure/2.x` branch
+2. Consider adding this URL to documentation or configuration templates
+3. Monitor for any new CHANGELOG references in code reviews


### PR DESCRIPTION
## Summary
The CHANGELOG for @azure/mcp 2.x has moved from the \main\ branch to the \elease/azure/2.x\ branch.

## Investigation
Comprehensive search of the entire codebase completed:
- No existing CHANGELOG.md references found
- This is a preventative fix to prepare for future CHANGELOG references
- Build verification passed: \dotnet build docs-generation.sln --configuration Release\ ✅

## Changes
- Added CHANGELOG-URL-UPDATE-LOG.md documenting the investigation findings
- Future CHANGELOG references should use: \https://github.com/microsoft/mcp/blob/release/azure/2.x/servers/Azure.Mcp.Server/CHANGELOG.md\

## Closes
#242