### PR TITLE
fix: add Azure endpoint sanitization to CredentialSanitizer (#275)

### DIFF
--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/CredentialSanitizerTests.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation.Tests/CredentialSanitizerTests.cs
@@ -249,4 +249,181 @@ public class CredentialSanitizerTests
         // This is a protocol prefix, not a credential — should be preserved
         Assert.Contains("DefaultEndpointsProtocol=https", result);
     }
+
+    // ── Azure endpoint sanitization (issue #275) ────────────────────
+
+    [Theory]
+    [InlineData("sql-prod.database.windows.net", "contoso-sql.database.windows.net")]
+    [InlineData("sql-inventory.database.windows.net", "contoso-sql.database.windows.net")]
+    [InlineData("orders-sql.database.windows.net", "contoso-sql.database.windows.net")]
+    [InlineData("myserver.database.windows.net", "contoso-sql.database.windows.net")]
+    public void SanitizesEndpoints_SqlDatabase(string endpoint, string expected)
+    {
+        var prompt = $"Connect to '{endpoint}' and run the query.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("mystorage.blob.core.windows.net", "contoso.blob.core.windows.net")]
+    [InlineData("data-lake.blob.core.windows.net", "contoso.blob.core.windows.net")]
+    public void SanitizesEndpoints_BlobStorage(string endpoint, string expected)
+    {
+        var prompt = $"Upload file to '{endpoint}/container/blob.txt'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("mystorage.table.core.windows.net", "contoso.table.core.windows.net")]
+    [InlineData("mystorage.queue.core.windows.net", "contoso.queue.core.windows.net")]
+    public void SanitizesEndpoints_TableAndQueue(string endpoint, string expected)
+    {
+        var prompt = $"Query data from '{endpoint}'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("prod-kv.vault.azure.net", "contoso-kv.vault.azure.net")]
+    [InlineData("finance-kv.vault.azure.net", "contoso-kv.vault.azure.net")]
+    public void SanitizesEndpoints_KeyVault(string endpoint, string expected)
+    {
+        var prompt = $"Get secret from '{endpoint}/secrets/my-secret'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("my-webapp.azurewebsites.net", "contoso-app.azurewebsites.net")]
+    [InlineData("api-prod.azurewebsites.net", "contoso-app.azurewebsites.net")]
+    public void SanitizesEndpoints_WebApps(string endpoint, string expected)
+    {
+        var prompt = $"Deploy code to '{endpoint}'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("my-cache.redis.cache.windows.net", "contoso-cache.redis.cache.windows.net")]
+    public void SanitizesEndpoints_Redis(string endpoint, string expected)
+    {
+        var prompt = $"Connect to Redis cache at '{endpoint}'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("my-bus.servicebus.windows.net", "contoso-bus.servicebus.windows.net")]
+    public void SanitizesEndpoints_ServiceBus(string endpoint, string expected)
+    {
+        var prompt = $"Send message to '{endpoint}/my-queue'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("my-cosmos.documents.azure.com", "contoso-cosmos.documents.azure.com")]
+    public void SanitizesEndpoints_CosmosDb(string endpoint, string expected)
+    {
+        var prompt = $"Query items from '{endpoint}/dbs/mydb'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain(endpoint, result);
+        Assert.Contains(expected, result);
+    }
+
+    [Theory]
+    [InlineData("contoso-sql.database.windows.net")]
+    [InlineData("contoso.blob.core.windows.net")]
+    [InlineData("fabrikam-kv.vault.azure.net")]
+    [InlineData("adventure-works-app.azurewebsites.net")]
+    [InlineData("example-bus.servicebus.windows.net")]
+    [InlineData("fictional-cache.redis.cache.windows.net")]
+    public void PreservesFictionalEndpoints_NoModification(string endpoint)
+    {
+        var prompt = $"Connect to '{endpoint}' for testing.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.Contains(endpoint, result);
+    }
+
+    [Fact]
+    public void SanitizesEndpoints_PreservesPathAfterHostname()
+    {
+        var prompt = "Connect to 'myserver.database.windows.net/mydb' with user 'admin'.";
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.Contains("contoso-sql.database.windows.net/mydb", result);
+        Assert.DoesNotContain("myserver.database.windows.net", result);
+    }
+
+    [Fact]
+    public void SanitizesEndpoints_MixedWithCredentials()
+    {
+        var prompt =
+            "Connect to 'Server=myserver.database.windows.net;User ID=admin;Password=P@ssw0rd!2026' " +
+            "and upload to 'data-lake.blob.core.windows.net/backups'.";
+
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        // Credentials sanitized
+        Assert.DoesNotContain("P@ssw0rd!2026", result);
+        // Endpoints sanitized
+        Assert.DoesNotContain("myserver.database.windows.net", result);
+        Assert.Contains("contoso-sql.database.windows.net", result);
+        Assert.DoesNotContain("data-lake.blob.core.windows.net", result);
+        Assert.Contains("contoso.blob.core.windows.net", result);
+    }
+
+    [Fact]
+    public void SanitizesEndpoints_MultipleEndpointsInOnePrompt()
+    {
+        var prompt =
+            "Copy data from 'source-sql.database.windows.net' " +
+            "to 'backup-storage.blob.core.windows.net/archive'.";
+
+        var result = CredentialSanitizer.Sanitize(prompt);
+
+        Assert.DoesNotContain("source-sql.database.windows.net", result);
+        Assert.DoesNotContain("backup-storage.blob.core.windows.net", result);
+        Assert.Contains("contoso-sql.database.windows.net", result);
+        Assert.Contains("contoso.blob.core.windows.net/archive", result);
+    }
+
+    [Fact]
+    public void SanitizesEndpoints_Issue275_AppServiceRealWorld()
+    {
+        // Exact patterns from the issue report
+        var endpoints = new[]
+        {
+            "sql-prod.database.windows.net",
+            "sql-inventory.database.windows.net",
+            "orders-sql.database.windows.net",
+            "myserver.database.windows.net",
+        };
+
+        foreach (var endpoint in endpoints)
+        {
+            var prompt = $"Query the database at '{endpoint}'.";
+            var result = CredentialSanitizer.Sanitize(prompt);
+
+            Assert.DoesNotContain(endpoint, result);
+            Assert.Contains("contoso-sql.database.windows.net", result);
+        }
+    }
 }

--- a/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Sanitizers/CredentialSanitizer.cs
+++ b/docs-generation/DocGeneration.Steps.ExamplePrompts.Generation/Sanitizers/CredentialSanitizer.cs
@@ -39,6 +39,56 @@ public static partial class CredentialSanitizer
     [GeneratedRegex(@"[A-Za-z]")]
     private static partial Regex HasLettersRegex();
 
+    // ── Azure endpoint patterns (issue #275) ────────────────────────
+    // Each regex captures any hostname prefix before the Azure service suffix.
+    // Hosts already containing fictional domain names are excluded via a
+    // negative lookahead so we don't double-replace safe values.
+
+    private static readonly string[] FictionalMarkers = ["contoso", "fabrikam", "adventure-works", "example", "fictional"];
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.database\.windows\.net")]
+    private static partial Regex SqlEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.blob\.core\.windows\.net")]
+    private static partial Regex BlobEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.table\.core\.windows\.net")]
+    private static partial Regex TableEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.queue\.core\.windows\.net")]
+    private static partial Regex QueueEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.vault\.azure\.net")]
+    private static partial Regex KeyVaultEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.azurewebsites\.net")]
+    private static partial Regex WebAppEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.redis\.cache\.windows\.net")]
+    private static partial Regex RedisEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.servicebus\.windows\.net")]
+    private static partial Regex ServiceBusEndpointRegex();
+
+    [GeneratedRegex(@"[A-Za-z0-9][\w.-]*\.documents\.azure\.com")]
+    private static partial Regex CosmosEndpointRegex();
+
+    /// <summary>
+    /// Endpoint patterns and their safe replacements for Azure service hostnames.
+    /// </summary>
+    private static readonly (Func<Regex> Pattern, string Replacement)[] EndpointRules =
+    [
+        (() => SqlEndpointRegex(),        "contoso-sql.database.windows.net"),
+        (() => BlobEndpointRegex(),       "contoso.blob.core.windows.net"),
+        (() => TableEndpointRegex(),      "contoso.table.core.windows.net"),
+        (() => QueueEndpointRegex(),      "contoso.queue.core.windows.net"),
+        (() => KeyVaultEndpointRegex(),   "contoso-kv.vault.azure.net"),
+        (() => WebAppEndpointRegex(),     "contoso-app.azurewebsites.net"),
+        (() => RedisEndpointRegex(),      "contoso-cache.redis.cache.windows.net"),
+        (() => ServiceBusEndpointRegex(), "contoso-bus.servicebus.windows.net"),
+        (() => CosmosEndpointRegex(),     "contoso-cosmos.documents.azure.com"),
+    ];
+
     /// <summary>
     /// Scans <paramref name="prompt"/> for credential patterns and replaces
     /// them with safe placeholders. Returns the sanitized string.
@@ -75,6 +125,22 @@ public static partial class CredentialSanitizer
                 return "'<secure-password>'";
             return match.Value;
         });
+
+        // 7. Azure service endpoints — replace realistic hostnames with contoso (issue #275)
+        foreach (var (pattern, replacement) in EndpointRules)
+        {
+            prompt = pattern().Replace(prompt, match =>
+            {
+                // Skip endpoints that already use fictional domain names
+                var host = match.Value;
+                foreach (var marker in FictionalMarkers)
+                {
+                    if (host.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                        return host;
+                }
+                return replacement;
+            });
+        }
 
         return prompt;
     }


### PR DESCRIPTION
## Problem

AI-generated example prompts produce realistic-looking Azure endpoints (e.g. \sql-prod.database.windows.net\, \myserver.database.windows.net\) that trigger secret scanning in CI.

Fixes #275

## Solution

Added 9 regex-based endpoint sanitization rules to the existing \CredentialSanitizer\ that replace realistic Azure service hostnames with clearly fictional \contoso\-prefixed equivalents:

| Pattern | Replacement |
|---------|-------------|
| \*.database.windows.net\ | \contoso-sql.database.windows.net\ |
| \*.blob.core.windows.net\ | \contoso.blob.core.windows.net\ |
| \*.table.core.windows.net\ | \contoso.table.core.windows.net\ |
| \*.queue.core.windows.net\ | \contoso.queue.core.windows.net\ |
| \*.vault.azure.net\ | \contoso-kv.vault.azure.net\ |
| \*.azurewebsites.net\ | \contoso-app.azurewebsites.net\ |
| \*.redis.cache.windows.net\ | \contoso-cache.redis.cache.windows.net\ |
| \*.servicebus.windows.net\ | \contoso-bus.servicebus.windows.net\ |
| \*.documents.azure.com\ | \contoso-cosmos.documents.azure.com\ |

**Key behaviors:**
- Endpoints already containing \contoso\, \abrikam\, \dventure-works\, \xample\, or \ictional\ are preserved
- URL paths after the hostname are preserved (e.g. \.../mydb\ stays intact)
- Works alongside existing credential sanitization (passwords, API keys, tokens)

## Tests

15 new test cases covering:
- Each of the 9 endpoint patterns
- Fictional endpoint preservation (6 cases)
- URL path preservation after hostname
- Mixed credentials + endpoints in one prompt
- Multiple endpoints in one prompt
- Exact patterns from the issue report

All 57 CredentialSanitizer tests pass. Zero build warnings.