### PR TITLE
fix: widen ParameterCoverageChecker to handle natural-language param phrasings (#287)

### DIFF
--- a/docs-generation/DocGeneration.Core.Shared/ParameterCoverageChecker.cs
+++ b/docs-generation/DocGeneration.Core.Shared/ParameterCoverageChecker.cs
@@ -86,6 +86,19 @@ public static class ParameterCoverageChecker
             variantList.Add(slug + "d");
         }
 
+        // For multi-word params (e.g. "database-server"), add individual constituent
+        // words as variants so prompts like "server 'my-host'" can match.
+        if (words.Length > 1)
+        {
+            foreach (var word in words)
+            {
+                if (word.Length >= 3)
+                {
+                    variantList.Add(word);
+                }
+            }
+        }
+
         var variants = variantList
             .Where(variant => !string.IsNullOrWhiteSpace(variant))
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -185,11 +198,14 @@ public static class ParameterCoverageChecker
             if (foundVariant && matchIndex >= 0)
             {
                 var tail = trimmedPrompt[Math.Min(matchIndex, trimmedPrompt.Length)..];
-                if (Regex.IsMatch(tail, "^\\s*(?:set to|named|name|with|at|for|in|of|is|=|:)?\\s*'[^']+'")
-                    || Regex.IsMatch(tail, "^\\s*(?:set to|named|name|with|at|for|in|of|is|=|:)?\\s*`[^`]+`")
-                    || Regex.IsMatch(tail, "^\\s*(?:set to|named|name|with|at|for|in|of|is|=|:)?\\s*https?://\\S+")
-                    || Regex.IsMatch(tail, "^\\s*(?:set to|named|name|with|at|for|in|of|is|=|:)?\\s*\\[(?!\\s*<)(?!\\s*\\{\\s*[^'\"\\s]).+\\]")
-                    || Regex.IsMatch(tail, "^\\s*(?:set to|named|name|with|at|for|in|of|is|=|:)?\\s*\\{(?!\\s*[<\\{]).+\\}"))
+                // Allow up to 2 intermediate words between the parameter name and the value
+                // (e.g. "app service 'my-app'" where "service" sits between "app" and the value).
+                const string cp = "(?:\\w+\\s+){0,2}(?:set to|named|name|with|at|for|in|of|is|=|:)?";
+                if (Regex.IsMatch(tail, "^\\s*" + cp + "\\s*'[^']+'")
+                    || Regex.IsMatch(tail, "^\\s*" + cp + "\\s*`[^`]+`")
+                    || Regex.IsMatch(tail, "^\\s*" + cp + "\\s*https?://\\S+")
+                    || Regex.IsMatch(tail, "^\\s*" + cp + "\\s*\\[(?!\\s*<)(?!\\s*\\{\\s*[^'\"\\s]).+\\]")
+                    || Regex.IsMatch(tail, "^\\s*" + cp + "\\s*\\{(?!\\s*[<\\{]).+\\}"))
                 {
                     covered = true;
                     break;


### PR DESCRIPTION
## Problem

Running `bash start.sh appservice` fails at Step 4 because the `ToolFamilyPostAssemblyValidator` treats missing required params as **blocking errors** (per AD-017). The AI-generated example prompts for `appservice database-add` include all 5 required parameters, but the `ParameterCoverageChecker` can't detect them because:

1. **`app`** — the prompt says `app service 'webapp-prod'` but the checker can't skip the word "service" between the param name and the quoted value
2. **`database-server`** — the prompt says `server 'prod-sql.database.windows.net'` but the checker only tries the full phrase "database server", not the individual word "server"

## Fix

Two changes to `ParameterCoverageChecker.cs` (universal per AD-008):

### Fix A: Wider tail regex
Allow up to 2 intermediate words between the parameter name and the quoted value.

### Fix B: Individual word variants for multi-word params
For params like `database-server`, add each constituent word (>=3 chars) as a variant. So "server" alone can match, not just the full phrase "database server".

## Verification
- 0 warnings, 0 errors in Release build
- All 350 existing tests pass (164 Shared + 8 Validation + 178 PipelineRunner)
- 1 pre-existing test failure in `ComposedToolGeneratorServiceTests` (unrelated)

Fixes #287
