### PR TITLE
fix: update Azure subscription link to tracked URL

### DIFF
--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/examples/horizontal-article-keyvault-correct.md
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/examples/horizontal-article-keyvault-correct.md
@@ -41,7 +41,7 @@ To use the Azure MCP Server with Azure Key Vault, you need:
 
 ### Azure requirements
 
-- **Azure subscription**: An active Azure subscription. [Create one for free](https://azure.microsoft.com/free/).
+- **Azure subscription**: An active Azure subscription. [Create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
 - **Azure Key Vault resources**: At least one key vault in your subscription. You can create a key vault using the [Azure CLI](/azure/key-vault/general/quick-create-cli), [Azure PowerShell](/azure/key-vault/general/quick-create-powershell), or the [Azure portal](/azure/key-vault/general/quick-create-portal).
 - **Azure permissions**: Appropriate [Azure RBAC roles](/azure/key-vault/general/rbac-guide#azure-built-in-roles-for-key-vault-data-plane-operations) like Key Vault Administrator, Key Vault Secrets Officer, Key Vault Certificates Officer, or Key Vault Crypto Officer to perform the operations you want. See [Provide access to Key Vault keys, certificates, and secrets with Azure role-based access control](/azure/key-vault/general/rbac-guide).
 

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
@@ -35,7 +35,7 @@ For {{serviceBrandName}} users, this means you can:
 
 To use the Azure MCP Server with {{serviceBrandName}}, you need:
 
-- **Azure subscription**: An active Azure subscription. [Create one for free](https://azure.microsoft.com/free/).
+- **Azure subscription**: An active Azure subscription. [Create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
 {{#if genai-serviceSpecificPrerequisites}}
 {{#each genai-serviceSpecificPrerequisites}}
 - **{{this.title}}**: {{this.description}}


### PR DESCRIPTION
## Summary

Update the 'Create one for free' Azure subscription link in horizontal article template and example file to the official tracked URL.

**Before**: `https://azure.microsoft.com/free/`
**After**: `https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn`

## Files Changed (2)

- `horizontal-article-template.hbs` — template source (line 38)
- `horizontal-article-keyvault-correct.md` — example file (line 44)

## Validation

- Build passes (0 warnings, 0 errors)
- No test references to the old URL

Fixes #296