### PR TITLE
fix: update Acrolinx tests to use step-specific prompt paths

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/AcrolinxComplianceSectionTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/AcrolinxComplianceSectionTests.cs
@@ -205,7 +205,7 @@ public class AcrolinxComplianceSectionTests
     public void SharedPrompt_Step3_ContainsAcrolinxSection()
     {
         var content = File.ReadAllText(Path.Combine(
-            ProjectRoot, "docs-generation", "prompts", "system-prompt.txt"));
+            ProjectRoot, "docs-generation", "DocGeneration.Steps.ToolGeneration.Improvements", "Prompts", "system-prompt.txt"));
         Assert.Contains("present tense", content, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("contraction", content, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("active voice", content, StringComparison.OrdinalIgnoreCase);
@@ -215,7 +215,7 @@ public class AcrolinxComplianceSectionTests
     public void SharedPrompt_Step4_ContainsAcrolinxSection()
     {
         var content = File.ReadAllText(Path.Combine(
-            ProjectRoot, "docs-generation", "prompts", "tool-family-cleanup-system-prompt.txt"));
+            ProjectRoot, "docs-generation", "DocGeneration.Steps.ToolFamilyCleanup", "prompts", "tool-family-cleanup-system-prompt.txt"));
         Assert.Contains("present tense", content, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("contraction", content, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("active voice", content, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

Fix 2 broken CI tests caused by #299 (legacy prompt file removal).

### Tests fixed

| Test | Old path (deleted in #299) | New path (step-specific) |
|------|---------------------------|--------------------------|
| `SharedPrompt_Step3_ContainsAcrolinxSection` | `prompts/system-prompt.txt` | `DocGeneration.Steps.ToolGeneration.Improvements/Prompts/system-prompt.txt` |
| `SharedPrompt_Step4_ContainsAcrolinxSection` | `prompts/tool-family-cleanup-system-prompt.txt` | `DocGeneration.Steps.ToolFamilyCleanup/prompts/tool-family-cleanup-system-prompt.txt` |

### Pre-existing failure (not in this PR)

`StripsEmbeddedExamplePromptMarkers` in PipelineRunner.Tests is a separate issue — the test creates files with hardcoded names but the service now uses `ToolFileNameBuilder` which requires brand mappings. This predates our changes.

### Validation

- ✅ Both Acrolinx tests now pass
- ✅ Full ToolFamilyCleanup.Tests: 391/391 passing