### PR TITLE
fix: filter --subscription as common parameter when optional

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,10 +99,10 @@ Other configs:
 ### Parameter Counting Logic
 **Critical**: The parameter count shown in console output and `generation-summary.md` reflects only **non-common parameters** that appear in the documentation parameter tables.
 
-- **Common parameters** are defined in `docs-generation/common-parameters.json`:
+- **Common parameters** are defined in `docs-generation/data/common-parameters.json`:
   - `--tenant`, `--auth-method` (infrastructure params)
   - `--retry-delay`, `--retry-max-delay`, `--retry-max-retries`, `--retry-mode`, `--retry-network-timeout`
-  - Note: `--resource-group` and `--subscription` are **scoping params** — NOT in common-parameters.json because they are tool-specific and change behavior when present
+  - `--subscription` (scoping param — filtered when optional, kept when required)
 - **Exception**: Common parameters that are **required** for a specific tool are kept in the table
 - The count matches what users see in the parameter tables in the generated `.md` files
 - **Filtering occurs in**:
@@ -588,7 +588,7 @@ pwsh -File "$SCRIPT_DIR/MyScript.ps1" -ToolFamily "$TOOL_FAMILY" -Steps "$STEPS"
 - **Every bug fix MUST include tests**: When fixing a bug or error, add one or more unit tests that reproduce the bug and verify the fix. Tests must be placed in a `.Tests` project that is part of `docs-generation.sln` so that CI (`dotnet test docs-generation.sln`) runs them automatically. If no `.Tests` project exists for the affected project, create one (xunit, CPM, added to the solution). If the code under test has `private` methods that need testing, change them to `internal` and add `<InternalsVisibleTo Include="ProjectName.Tests" />` to the source project's `.csproj`.
 - **For new generators**: Place in `Generators/` directory, follow existing patterns
   - Use dependency injection for shared functions (brand mapping, filename cleaning)
-  - Filter infrastructure parameters (tenant, auth-method, retry-*) using `common-parameters.json` — scoping params like resource-group and subscription are NOT filtered
+  - Filter infrastructure parameters (tenant, auth-method, retry-*) and scoping params (subscription) using `common-parameters.json` — all are filtered when optional, kept when required
   - Document in separate README.md file within the generator directory
 - **For Azure OpenAI integration**:
   - Always implement retry logic with exponential backoff (see `GenerativeAIClient.cs`)

--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
@@ -138,10 +138,10 @@ public class ParameterGeneratorTests
     }
 
     [Fact]
-    public void CommonParameters_DoNotIncludeSubscription()
+    public void CommonParameters_IncludeSubscription()
     {
-        // subscription is also a scoping parameter — tools that declare it
-        // need it shown in their parameter table for user clarity.
+        // subscription is a scoping parameter that must be in common-parameters.json
+        // so that ParameterFilterHelper filters it when optional but keeps it when required (#276).
         var commonParamsPath = Path.Combine(
             FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
         var json = File.ReadAllText(commonParamsPath);
@@ -149,14 +149,14 @@ public class ParameterGeneratorTests
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         Assert.NotNull(commonParams);
-        Assert.DoesNotContain(commonParams, p => p.Name == "--subscription");
+        Assert.Contains(commonParams, p => p.Name == "--subscription");
     }
 
     [Fact]
-    public void CommonParameters_OnlyContainInfrastructureParams()
+    public void CommonParameters_OnlyContainInfrastructureAndScopingParams()
     {
-        // Only retry-*, auth-method, and tenant are true infrastructure params
-        // that appear on ALL tools and add no tool-specific information.
+        // Infrastructure params (retry-*, auth-method, tenant) and scoping
+        // params (subscription) are the allowed common parameters.
         var commonParamsPath = Path.Combine(
             FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
         var json = File.ReadAllText(commonParamsPath);
@@ -164,12 +164,12 @@ public class ParameterGeneratorTests
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         Assert.NotNull(commonParams);
-        var allowedPrefixes = new[] { "--retry-", "--auth-method", "--tenant" };
+        var allowedPrefixes = new[] { "--retry-", "--auth-method", "--tenant", "--subscription" };
         foreach (var param in commonParams)
         {
             Assert.True(
                 allowedPrefixes.Any(p => param.Name!.StartsWith(p, StringComparison.OrdinalIgnoreCase)),
-                $"Unexpected common parameter '{param.Name}' — scoping params like resource-group and subscription should not be common");
+                $"Unexpected common parameter '{param.Name}' — only infrastructure and scoping params should be common");
         }
     }
 

--- a/docs-generation/data/common-parameters.json
+++ b/docs-generation/data/common-parameters.json
@@ -40,5 +40,11 @@
     "type": "number",
     "description": "Network operation timeout in seconds. Operations taking longer than this will be canceled.",
     "isRequired": false
+  },
+  {
+    "name": "--subscription",
+    "type": "string",
+    "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name.",
+    "isRequired": false
   }
 ]


### PR DESCRIPTION
## Summary

\--subscription\ appeared in tool-family parameter tables when it should be filtered as a common/global parameter.

**Fix**: Added \--subscription\ to \common-parameters.json\ with \isRequired: false\. The existing \ParameterFilterHelper.ShouldInclude()\ logic handles the rest — optional common params are filtered, required ones are kept.

## Files changed (3)

- \docs-generation/data/common-parameters.json\ — Added \--subscription\ entry
- \ParameterGeneratorTests.cs\ — Updated tests for new common param
- \.github/copilot-instructions.md\ — Updated Parameter Counting Logic docs

## Validation

- ✅ All tests pass
- ✅ TDD: test written first, verified it failed, then implemented fix

Fixes #276