### PR TITLE
fix: filter --resource-group as common parameter when optional

### DIFF
--- a/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
@@ -123,10 +123,9 @@ public class ParameterGeneratorTests
     // ── Common Parameter Filtering (#147) ──────────────────────────
 
     [Fact]
-    public void CommonParameters_DoNotIncludeResourceGroup()
+    public void CommonParameters_IncludeResourceGroup()
     {
-        // resource-group is a scoping parameter used by only ~35 tools,
-        // NOT a universal infrastructure param. It must NOT be in common-parameters.json.
+        // resource-group is a scoping parameter filtered when optional, kept when required.
         var commonParamsPath = Path.Combine(
             FindProjectRoot(), "docs-generation", "data", "common-parameters.json");
         var json = File.ReadAllText(commonParamsPath);
@@ -134,7 +133,7 @@ public class ParameterGeneratorTests
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         Assert.NotNull(commonParams);
-        Assert.DoesNotContain(commonParams, p => p.Name == "--resource-group");
+        Assert.Contains(commonParams, p => p.Name == "--resource-group");
     }
 
     [Fact]
@@ -164,12 +163,12 @@ public class ParameterGeneratorTests
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         Assert.NotNull(commonParams);
-        var allowedPrefixes = new[] { "--retry-", "--auth-method", "--tenant", "--subscription" };
+        var allowedPrefixes = new[] { "--retry-", "--auth-method", "--tenant", "--subscription", "--resource-group" };
         foreach (var param in commonParams)
         {
             Assert.True(
                 allowedPrefixes.Any(p => param.Name!.StartsWith(p, StringComparison.OrdinalIgnoreCase)),
-                $"Unexpected common parameter '{param.Name}' — only infrastructure and scoping params should be common");
+                $"Unexpected common parameter '{param.Name}'");
         }
     }
 

--- a/docs-generation/data/common-parameters.json
+++ b/docs-generation/data/common-parameters.json
@@ -46,5 +46,11 @@
     "type": "string",
     "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name.",
     "isRequired": false
+  },
+  {
+    "name": "--resource-group",
+    "type": "string",
+    "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+    "isRequired": false
   }
 ]


### PR DESCRIPTION
## Summary

\--resource-group\ appeared in tool-family parameter tables when optional. Same pattern as #276 (subscription).

**Fix**: Added \--resource-group\ to \common-parameters.json\ with \isRequired: false\. The existing \ParameterFilterHelper.ShouldInclude()\ logic filters optional common params and keeps required ones.

## Files changed (2)

- \docs-generation/data/common-parameters.json\ — Added \--resource-group\ entry
- \ParameterGeneratorTests.cs\ — Updated 2 tests for new common param

## Validation

- ✅ 292/292 Annotations tests pass
- ✅ TDD verified

Fixes #277