### PR TITLE
fix: add ms.reviewer to frontmatter generation

### DIFF
--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
@@ -3,6 +3,7 @@ title: Azure MCP Server tools for {{serviceBrandName}}
 description: Use Azure MCP Server tools to manage {{genai-serviceShortDescription}} through AI-powered natural language interactions.
 author: diberry
 ms.author: diberry
+ms.reviewer: mbaldwin
 ms.service: azure-mcp-server
 ms.topic: how-to
 ms.date: {{formatDate generatedAt}}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterEnricherTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterEnricherTests.cs
@@ -37,6 +37,7 @@ tool_count: 5
         Assert.Contains("content_well_notification:", result);
         Assert.Contains("  - AI-contribution", result);
         Assert.Contains("ms.custom: build-2025", result);
+        Assert.Contains("ms.reviewer: mbaldwin", result);
     }
 
     [Fact]
@@ -131,6 +132,66 @@ List all Cosmos DB accounts.";
         Assert.Contains("The Azure MCP Server lets you manage Cosmos DB accounts.", result);
         Assert.Contains("## List accounts", result);
         Assert.Contains("List all Cosmos DB accounts.", result);
+    }
+
+    // ── ms.reviewer injection (#284) ────────────────────────────────
+
+    [Fact]
+    public void Enrich_InjectsMsReviewer()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Azure Storage
+description: Use Azure MCP Server tools to manage storage.
+ms.service: azure-mcp-server
+ms.topic: concept-article
+tool_count: 5
+---
+
+# Azure MCP Server tools for Azure Storage";
+
+        var result = FrontmatterEnricher.Enrich(markdown);
+
+        Assert.Contains("ms.reviewer: mbaldwin", result);
+    }
+
+    [Fact]
+    public void Enrich_DoesNotDuplicateExistingMsReviewer()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Key Vault
+ms.reviewer: mbaldwin
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Key Vault";
+
+        var result = FrontmatterEnricher.Enrich(markdown);
+
+        var count = CountOccurrences(result, "ms.reviewer: mbaldwin");
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Enrich_MsReviewerIsInsideFrontmatter()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Cosmos DB
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Cosmos DB
+
+Some body content.";
+
+        var result = FrontmatterEnricher.Enrich(markdown);
+        var normalized = result.Replace("\r\n", "\n");
+
+        // Extract frontmatter block
+        var fmStart = normalized.IndexOf("---");
+        var fmEnd = normalized.IndexOf("\n---", fmStart + 3);
+        var frontmatter = normalized.Substring(fmStart, fmEnd + 4 - fmStart);
+
+        Assert.Contains("ms.reviewer:", frontmatter);
     }
 
     // ── Edge cases ──────────────────────────────────────────────────

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterPipelineIntegrationTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterPipelineIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
 /// Integration tests verifying that required frontmatter fields survive
 /// the full pipeline: DeterministicFrontmatterGenerator → Assemble → FamilyFileStitcher.Stitch().
 /// The stitcher's post-processing chain includes FrontmatterEnricher which must inject
-/// ms.date, author, ms.author, ai-usage, content_well_notification, and ms.custom.
+/// ms.date, author, ms.author, ms.reviewer, ai-usage, content_well_notification, and ms.custom.
 ///
 /// Fixes: #219 — ms.date missing in generated tool-family files.
 /// Decision: AD-007 (TDD — write failing tests before implementing fix).
@@ -147,6 +147,23 @@ public class FrontmatterPipelineIntegrationTests
         Assert.Contains("ms.custom: build-2025", result);
     }
 
+    // ── ms.reviewer present after full pipeline (#284) ────────────
+
+    [Fact]
+    public void Stitch_DeterministicFrontmatter_ContainsMsReviewer()
+    {
+        var header = DeterministicFrontmatterGenerator.Generate(
+            TestBrandName, 2, TestCliVersion, TestSeoDescription);
+        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+
+        var familyContent = CreateFamilyContent("resourcehealth", metadata);
+        var stitcher = new FamilyFileStitcher();
+
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("ms.reviewer: mbaldwin", result);
+    }
+
     // ── All enriched fields are inside frontmatter delimiters ───────
 
     [Fact]
@@ -176,6 +193,7 @@ public class FrontmatterPipelineIntegrationTests
         Assert.Contains("ai-usage:", frontmatter);
         Assert.Contains("ms.custom:", frontmatter);
         Assert.Contains("content_well_notification:", frontmatter);
+        Assert.Contains("ms.reviewer:", frontmatter);
     }
 
     // ── Generator itself includes ms.date (defense in depth) ──────

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FrontmatterEnricher.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/FrontmatterEnricher.cs
@@ -10,7 +10,7 @@ namespace ToolFamilyCleanup.Services;
 /// fields into tool-family articles. Fields that already exist are preserved.
 /// 
 /// Required fields per Microsoft Learn publishing standards:
-/// - author, ms.author, ms.date, ms.service, ms.topic
+/// - author, ms.author, ms.reviewer, ms.date, ms.service, ms.topic
 /// - ai-usage (for AI-generated content)
 /// - content_well_notification (for AI-generated content)
 /// - ms.custom (for campaign tracking)
@@ -18,6 +18,7 @@ namespace ToolFamilyCleanup.Services;
 public static class FrontmatterEnricher
 {
     private const string Author = "diberry";
+    private const string Reviewer = "mbaldwin";
     private const string AiUsage = "ai-generated";
     private const string ContentWellValue = "AI-contribution";
     private const string MsCustom = "build-2025";
@@ -56,6 +57,7 @@ public static class FrontmatterEnricher
         // Inject missing fields
         InjectIfMissing(lines, "author", $"author: {Author}");
         InjectIfMissing(lines, "ms.author", $"ms.author: {Author}");
+        InjectIfMissing(lines, "ms.reviewer", $"ms.reviewer: {Reviewer}");
         InjectIfMissing(lines, "ms.date", $"ms.date: {DateTime.UtcNow:MM/dd/yyyy}");
         InjectIfMissing(lines, "ai-usage", $"ai-usage: {AiUsage}");
         InjectIfMissing(lines, "ms.custom", $"ms.custom: {MsCustom}");


### PR DESCRIPTION
## Summary

Add missing \ms.reviewer: mbaldwin\ field to generated frontmatter in both tool-family and horizontal articles.

**Fix**: Added to \FrontmatterEnricher.cs\ (tool-family) and \horizontal-article-template.hbs\ (horizontal articles).

## Files changed (4)
- \FrontmatterEnricher.cs\ — Added reviewer constant + InjectIfMissing call
- \horizontal-article-template.hbs\ — Added ms.reviewer field
- \FrontmatterEnricherTests.cs\ — 3 new tests + 1 updated
- \FrontmatterPipelineIntegrationTests.cs\ — 1 new + 1 updated

5 new tests, all passing. Fixes #284