### PR TITLE
fix: prevent spurious comma in If not specified phrases

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/IntroductoryCommaFixerTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/IntroductoryCommaFixerTests.cs
@@ -131,4 +131,47 @@ public class IntroductoryCommaFixerTests
         var result = IntroductoryCommaFixer.Fix(input);
         Assert.Contains("For example, you", result);
     }
+
+    // ── Issue #280: "If not" must not corrupt longer phrases ────────
+
+    [Theory]
+    [InlineData(
+        "If not specified the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+        "If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.")]
+    [InlineData(
+        "If not provided a default is generated.",
+        "If not provided, a default is generated.")]
+    public void Fix_IfNotSpecified_CommaAfterFullPhrase(string input, string expected)
+    {
+        var result = IntroductoryCommaFixer.Fix(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used.")]
+    [InlineData("If not provided, a default value is used.")]
+    public void Fix_IfNotSpecified_AlreadyCorrect_NoChange(string input)
+    {
+        var result = IntroductoryCommaFixer.Fix(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Fix_IfNotSpecified_InTableRow_NoSpuriousComma()
+    {
+        // Real-world pattern from generated parameter tables (issue #280)
+        var input = "| **Subscription** | Optional | Specifies the Azure subscription to use. If not specified the `AZURE_SUBSCRIPTION_ID` environment variable is used instead. |";
+        var result = IntroductoryCommaFixer.Fix(input);
+        Assert.Contains("If not specified, the", result);
+        Assert.DoesNotContain("If not, specified", result);
+    }
+
+    [Fact]
+    public void Fix_IfNot_StillWorksWhenNotPartOfLongerPhrase()
+    {
+        // Bare "If not" should still get a comma when it's the complete phrase
+        var input = "If not the tool returns an error.";
+        var result = IntroductoryCommaFixer.Fix(input);
+        Assert.Equal("If not, the tool returns an error.", result);
+    }
 }

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/IntroductoryCommaFixer.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/IntroductoryCommaFixer.cs
@@ -17,6 +17,8 @@ public static class IntroductoryCommaFixer
 {
     private static readonly string[] IntroductoryPhrases =
     [
+        "If not specified",
+        "If not provided",
         "For example",
         "In addition",
         "By default",
@@ -66,7 +68,7 @@ public static class IntroductoryCommaFixer
         // Apply comma insertion for each introductory phrase
         foreach (var phrase in IntroductoryPhrases)
         {
-            markdown = InsertCommaAfterPhrase(markdown, phrase);
+            markdown = InsertCommaAfterPhrase(markdown, phrase, IntroductoryPhrases);
         }
 
         // Restore placeholders
@@ -82,12 +84,25 @@ public static class IntroductoryCommaFixer
     /// Inserts a comma after the given phrase when it appears at a sentence
     /// boundary (start of string, after a period+space, after newline, after
     /// bullet marker) and is NOT already followed by a comma.
+    /// If this phrase is a prefix of a longer phrase in the list, a negative
+    /// lookahead prevents matching the longer phrase (fixes #280).
     /// </summary>
-    private static string InsertCommaAfterPhrase(string markdown, string phrase)
+    private static string InsertCommaAfterPhrase(string markdown, string phrase, string[] allPhrases)
     {
+        // Build negative lookahead so short phrases don't corrupt longer ones
+        var extensions = allPhrases
+            .Where(p => p.Length > phrase.Length &&
+                   p.StartsWith(phrase + " ", StringComparison.OrdinalIgnoreCase))
+            .Select(p => Regex.Escape(p[phrase.Length..]))
+            .ToList();
+
+        var extensionGuard = extensions.Count > 0
+            ? $"(?!{string.Join("|", extensions)})"
+            : "";
+
         // Match the phrase at sentence boundaries, NOT already followed by comma
         // Sentence boundaries: start of string, after ". ", after newline, after "- "
-        var pattern = $@"(?<=^|(?<=\.)\s|(?<=\n)|- )({Regex.Escape(phrase)})(?!,)\s";
+        var pattern = $@"(?<=^|(?<=\.)\s|(?<=\n)|- )({Regex.Escape(phrase)}){extensionGuard}(?!,)\s";
         return Regex.Replace(markdown, pattern, "$1, ", RegexOptions.Multiline);
     }
 }


### PR DESCRIPTION
Fix IntroductoryCommaFixer prefix overlap. Added phrases + negative-lookahead guard. 5 new tests. Fixes #280