### PR TITLE
fix: consistent backtick formatting for enum values and single-quoted identifiers

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ParameterDescriptionBacktickerTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ParameterDescriptionBacktickerTests.cs
@@ -182,4 +182,97 @@ public class ParameterDescriptionBacktickerTests
         var result = ParameterDescriptionBackticker.Apply(input!);
         Assert.Equal(input, result);
     }
+
+    // ───────────────────────────────────────────────
+    // (k) Alphanumeric enum values (issue #283)
+    // ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(
+        "Accepted values: V1, V2.",
+        "Accepted values: `V1`, `V2`.")]
+    [InlineData(
+        "Accepted values: Premium_LRS, PremiumV2_LRS, Premium_ZRS, StandardSSD_LRS, StandardSSD_ZRS, Standard_LRS, UltraSSD_LRS.",
+        "Accepted values: `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Standard_LRS`, `UltraSSD_LRS`.")]
+    [InlineData(
+        "Hyper-V generation: V1 or V2.",
+        "Hyper-V generation: `V1` or `V2`.")]
+    public void BackticksAlphanumericEnumValues(string input, string expected)
+    {
+        var result = ParameterDescriptionBackticker.Apply(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ───────────────────────────────────────────────
+    // (l) Single-quoted values to backticks (issue #283)
+    // ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(
+        "OS disk type: 'Premium_LRS', 'StandardSSD_LRS', 'Standard_LRS'. Defaults based on VM size.",
+        "OS disk type: `Premium_LRS`, `StandardSSD_LRS`, `Standard_LRS`. Defaults based on VM size.")]
+    [InlineData(
+        "alias like 'Ubuntu2404', 'Win2022Datacenter'. Defaults to Ubuntu 24.04 LTS.",
+        "alias like `Ubuntu2404`, `Win2022Datacenter`. Defaults to Ubuntu 24.04 LTS.")]
+    [InlineData(
+        "Upgrade policy mode: 'Automatic', 'Manual', or 'Rolling'. Default is 'Manual'.",
+        "Upgrade policy mode: `Automatic`, `Manual`, or `Rolling`. Default is `Manual`.")]
+    [InlineData(
+        "License type: 'Windows_Server', 'Windows_Client', 'RHEL_BYOS', 'SLES_BYOS', or 'None' to disable.",
+        "License type: `Windows_Server`, `Windows_Client`, `RHEL_BYOS`, `SLES_BYOS`, or `None` to disable.")]
+    [InlineData(
+        "Scale-in policy: 'Default', 'NewestVM', or 'OldestVM'.",
+        "Scale-in policy: `Default`, `NewestVM`, or `OldestVM`.")]
+    [InlineData(
+        "hyper v generation 'V2'.",
+        "hyper v generation `V2`.")]
+    public void ConvertsSingleQuotedValuesToBackticks(string input, string expected)
+    {
+        var result = ParameterDescriptionBackticker.Apply(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ───────────────────────────────────────────────
+    // (m) Single-quoted booleans to backticks (issue #283)
+    // ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(
+        "with enable bursting 'true'.",
+        "with enable bursting `true`.")]
+    [InlineData(
+        "Set to 'false' to disable.",
+        "Set to `false` to disable.")]
+    public void ConvertsSingleQuotedBooleansToBackticks(string input, string expected)
+    {
+        var result = ParameterDescriptionBackticker.Apply(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ───────────────────────────────────────────────
+    // (n) Already-backticked alphanumeric — no change
+    // ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Accepted values: `V1`, `V2`.")]
+    [InlineData("Accepted values: `PremiumV2_LRS`, `Standard_LRS`.")]
+    [InlineData("Type: `Ubuntu2404`.")]
+    public void PreservesAlreadyBacktickedAlphanumeric(string input)
+    {
+        var result = ParameterDescriptionBackticker.Apply(input);
+        Assert.Equal(input, result);
+    }
+
+    // ───────────────────────────────────────────────
+    // (o) Prose single-quoted words — not converted
+    // ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("The resource group's location.")]
+    [InlineData("Use '' to clear existing tags.")]
+    public void PreservesNonTechnicalSingleQuotes(string input)
+    {
+        var result = ParameterDescriptionBackticker.Apply(input);
+        Assert.Equal(input, result);
+    }
 }

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ParameterDescriptionBackticker.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ParameterDescriptionBackticker.cs
@@ -7,7 +7,8 @@ namespace ToolFamilyCleanup.Services;
 
 /// <summary>
 /// Wraps technical values in parameter description text with backticks.
-/// Targets enum names, boolean literals, date formats, and CLI switches
+/// Targets enum names, boolean literals, date formats, CLI switches,
+/// and single-quoted technical identifiers
 /// to improve Acrolinx Spelling &amp; Grammar scores.
 /// </summary>
 public static class ParameterDescriptionBackticker
@@ -18,10 +19,18 @@ public static class ParameterDescriptionBackticker
     private static readonly Regex DateFormat = new(
         @"\b[Yy]{2,4}-[Mm]{2}-[Dd]{2}(?:T[Hh]{2}:[Mm]{2}:[Ss]{2})?\b", RegexOptions.Compiled);
     private static readonly Regex EnumListAfterColon = new(
-        @"(?<=:\s)([A-Z][a-zA-Z_]*(?:(?:\s*,\s*(?:or\s+)?|\s+or\s+)[A-Z][a-zA-Z_]*)+)",
+        @"(?<=:\s)([A-Z][a-zA-Z0-9_]*(?:(?:\s*,\s*(?:or\s+)?|\s+or\s+)[A-Z][a-zA-Z0-9_]*)+)",
         RegexOptions.Compiled);
-    private static readonly Regex EnumItem = new(@"[A-Z][a-zA-Z_]*", RegexOptions.Compiled);
+    private static readonly Regex EnumItem = new(@"[A-Z][a-zA-Z0-9_]*", RegexOptions.Compiled);
     private static readonly Regex Placeholder = new(@"\x00(\d+)\x00", RegexOptions.Compiled);
+
+    // Single-quoted PascalCase identifiers: 'Premium_LRS', 'V2', 'Ubuntu2404'
+    private static readonly Regex SingleQuotedIdentifier = new(
+        @"'([A-Z][a-zA-Z0-9_]*)'", RegexOptions.Compiled);
+
+    // Single-quoted boolean literals: 'true', 'false'
+    private static readonly Regex SingleQuotedBoolean = new(
+        @"'(true|false)'", RegexOptions.Compiled);
 
     /// <summary>
     /// Applies backtick wrapping to technical values in a parameter description string.
@@ -37,6 +46,18 @@ public static class ParameterDescriptionBackticker
 
         // Protect already-backticked spans from double-wrapping
         var protectedSpans = new List<string>();
+        result = BacktickedSpan.Replace(result, m =>
+        {
+            protectedSpans.Add(m.Value);
+            return $"\x00{protectedSpans.Count - 1}\x00";
+        });
+
+        // Convert single-quoted technical values to backtick-wrapped BEFORE
+        // other rules, so downstream patterns don't see stale single quotes.
+        result = SingleQuotedIdentifier.Replace(result, "`$1`");
+        result = SingleQuotedBoolean.Replace(result, "`$1`");
+
+        // Re-protect newly created backticked spans from double-wrapping
         result = BacktickedSpan.Replace(result, m =>
         {
             protectedSpans.Add(m.Value);


### PR DESCRIPTION
ParameterDescriptionBackticker missed digit-containing enums (V1, PremiumV2_LRS) and single-quoted values. Added digit support, single-quote conversion, and re-protection pass. 16 new tests, all 1674 passing. Fixes #283