### PR TITLE
fix: order tools by resource type instead of verb

### DIFF
--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolReaderSortOrderTests.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolReaderSortOrderTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for ToolReader.GetResourceSortKey and the resource-type-first ordering
+/// of tools within each family (Issue #279).
+/// </summary>
+public class ToolReaderSortOrderTests
+{
+    // --- GetResourceSortKey unit tests ---
+
+    [Theory]
+    [InlineData("compute disk create", "disk\0create")]
+    [InlineData("compute disk delete", "disk\0delete")]
+    [InlineData("compute vm create", "vm\0create")]
+    [InlineData("compute vmss update", "vmss\0update")]
+    [InlineData("storage account create", "account\0create")]
+    [InlineData("storage blob list", "blob\0list")]
+    public void GetResourceSortKey_ThreeSegmentCommand_ReturnsResourceThenVerb(
+        string command, string expected)
+    {
+        var result = ToolReader.GetResourceSortKey(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("foundry agent thread create", "agent thread\0create")]
+    [InlineData("cosmos db container query", "db container\0query")]
+    public void GetResourceSortKey_MultiResourceCommand_ReturnsResourcesThenVerb(
+        string command, string expected)
+    {
+        var result = ToolReader.GetResourceSortKey(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("advisor list", "\0list")]
+    [InlineData("storage list", "\0list")]
+    public void GetResourceSortKey_TwoSegmentCommand_PutsVerbAfterSeparator(
+        string command, string expected)
+    {
+        var result = ToolReader.GetResourceSortKey(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetResourceSortKey_SingleSegment_ReturnsFallback()
+    {
+        var result = ToolReader.GetResourceSortKey("advisor");
+        Assert.Equal("advisor", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetResourceSortKey_NullOrEmpty_ReturnsEmpty(string? command)
+    {
+        var result = ToolReader.GetResourceSortKey(command);
+        Assert.Equal(string.Empty, result);
+    }
+
+    // --- Integration-level ordering test ---
+
+    [Fact]
+    public void Tools_SortedByResourceSortKey_GroupByResourceThenVerb()
+    {
+        // Arrange: tools in verb-first order (the current buggy behavior)
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Create compute disk",    "compute disk create"),
+            MakeTool("Create virtual machine", "compute vm create"),
+            MakeTool("Create VMSS",            "compute vmss create"),
+            MakeTool("Delete compute disk",    "compute disk delete"),
+            MakeTool("Delete virtual machine", "compute vm delete"),
+            MakeTool("Delete VMSS",            "compute vmss delete"),
+            MakeTool("Get compute disk",       "compute disk get"),
+            MakeTool("Get virtual machine",    "compute vm get"),
+            MakeTool("Get VMSS",               "compute vmss get"),
+            MakeTool("Update compute disk",    "compute disk update"),
+            MakeTool("Update virtual machine", "compute vm update"),
+            MakeTool("Update VMSS",            "compute vmss update"),
+        };
+
+        // Act: sort with the resource-first key (must use StringComparer.Ordinal
+        // to match production code — culture-sensitive comparison ignores \0)
+        var sorted = tools
+            .OrderBy(t => ToolReader.GetResourceSortKey(t.Command), StringComparer.Ordinal)
+            .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+            .ToList();
+
+        // Assert: expected resource-first ordering
+        //   disk (create, delete, get, update) → vm (create, ...) → vmss (create, ...)
+        var commands = sorted.Select(t => t.Command).ToList();
+
+        Assert.Equal("compute disk create", commands[0]);
+        Assert.Equal("compute disk delete", commands[1]);
+        Assert.Equal("compute disk get", commands[2]);
+        Assert.Equal("compute disk update", commands[3]);
+        Assert.Equal("compute vm create", commands[4]);
+        Assert.Equal("compute vm delete", commands[5]);
+        Assert.Equal("compute vm get", commands[6]);
+        Assert.Equal("compute vm update", commands[7]);
+        Assert.Equal("compute vmss create", commands[8]);
+        Assert.Equal("compute vmss delete", commands[9]);
+        Assert.Equal("compute vmss get", commands[10]);
+        Assert.Equal("compute vmss update", commands[11]);
+    }
+
+    [Fact]
+    public void Tools_WithMixedCommandLengths_SortBareVerbsFirst()
+    {
+        // Bare namespace+verb commands should sort before resource-specific ones,
+        // not interleave with resource groups.
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Get storage accounts",   "storage account list"),
+            MakeTool("Create storage account",  "storage account create"),
+            MakeTool("Get blob",               "storage blob get"),
+            MakeTool("Get storage",            "storage list"),
+        };
+
+        var sorted = tools
+            .OrderBy(t => ToolReader.GetResourceSortKey(t.Command), StringComparer.Ordinal)
+            .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+            .ToList();
+
+        var commands = sorted.Select(t => t.Command).ToList();
+
+        // Bare verb ("storage list") has empty resource → sorts first
+        Assert.Equal("storage list", commands[0]);
+        // Then account group
+        Assert.Equal("storage account create", commands[1]);
+        Assert.Equal("storage account list", commands[2]);
+        // Then blob group
+        Assert.Equal("storage blob get", commands[3]);
+    }
+
+    [Fact]
+    public void Tools_WithNullCommand_FallBackToToolNameSort()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Zebra tool", null),
+            MakeTool("Alpha tool", null),
+            MakeTool("Middle tool", null),
+        };
+
+        var sorted = tools
+            .OrderBy(t => ToolReader.GetResourceSortKey(t.Command), StringComparer.Ordinal)
+            .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal("Alpha tool", sorted[0].ToolName);
+        Assert.Equal("Middle tool", sorted[1].ToolName);
+        Assert.Equal("Zebra tool", sorted[2].ToolName);
+    }
+
+    private static ToolContent MakeTool(string toolName, string? command)
+    {
+        return new ToolContent
+        {
+            ToolName = toolName,
+            FileName = $"{(command ?? toolName).Replace(' ', '-')}.md",
+            FamilyName = "test",
+            Content = $"# {toolName}\n\nSome content.",
+            Command = command,
+        };
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Models/FamilyContent.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Models/FamilyContent.cs
@@ -28,7 +28,7 @@ public class FamilyContent
     public required string Metadata { get; set; }
     
     /// <summary>
-    /// List of tools belonging to this family, ordered alphabetically
+    /// List of tools belonging to this family, ordered by resource type then verb (#279)
     /// </summary>
     public required List<ToolContent> Tools { get; init; }
     

--- a/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
+++ b/docs-generation/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
@@ -78,11 +78,14 @@ public class ToolReader
             }
         }
 
-        // Sort tools within each family alphabetically
+        // Sort tools within each family by resource type first, then by verb (#279).
+        // Command format: "namespace resource [resource2…] verb"
+        // Sort key groups all operations on the same resource together.
         foreach (var family in toolsByFamily.Keys)
         {
             toolsByFamily[family] = toolsByFamily[family]
-                .OrderBy(t => t.ToolName)
+                .OrderBy(t => GetResourceSortKey(t.Command), StringComparer.Ordinal)
+                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
                 .ToList();
         }
 
@@ -268,5 +271,33 @@ public class ToolReader
     private string StripFrontmatter(string content)
     {
         return FrontmatterRegex.Replace(content, string.Empty);
+    }
+
+    /// <summary>
+    /// Builds a sort key from a command that groups by resource type first, then by verb.
+    /// Command format: "namespace resource1 [resource2…] verb"
+    /// Result format:  "resource1 resource2\0verb"
+    /// The NUL separator ensures resource groups sort together regardless of verb names.
+    /// For two-segment commands (namespace + verb), returns "\0verb" so bare verbs sort
+    /// before any resource-specific tools within the same family.
+    /// </summary>
+    internal static string GetResourceSortKey(string? command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+            return string.Empty;
+
+        var segments = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length <= 1)
+            return command;
+
+        // Two-segment: "namespace verb" → sort by "\0verb" (bare verbs first)
+        if (segments.Length == 2)
+            return $"\0{segments[1]}";
+
+        // Three+ segments: "namespace resource… verb"
+        var resource = string.Join(" ", segments[1..^1]);
+        var verb = segments[^1];
+        return $"{resource}\0{verb}";
     }
 }


### PR DESCRIPTION
Tools grouped by verb (all creates, all deletes) instead of resource type. Changed ToolReader sort to resource-first ordering. 17 new tests, all passing. Fixes #279