### PR TITLE
feat: Add pr-docs skill and CHANGELOG requirement (AD-026)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -392,6 +392,25 @@ pwsh ./Debug-MultiPageDocs.ps1  # Prepare environment
 
 **Reviewer checklist:** Would this test FAIL if the fix were reverted? If not, it's not a real test.
 
+## ⚠️ IMPORTANT: PR Documentation — CHANGELOG + Docs Update Required
+
+**Every PR must update documentation before team review.** See `.squad/decisions.md` AD-026 and `.squad/skills/pr-docs/SKILL.md`.
+
+**Before requesting review on any PR:**
+1. **Update `CHANGELOG.md`** — Add entry under `## [Unreleased]` with user-facing description and PR/issue numbers
+2. **Update user-facing docs** — Route to the correct file using the documentation routing table in the pr-docs skill
+3. **Update README navigation** — If a new doc file was created, add it to the Documentation section
+
+**Exemptions** (state in PR comment): test-only changes, internal refactors with no behavior change.
+
+**Documentation routing (quick reference):**
+- New tool/feature → `docs/PROJECT-GUIDE.md`
+- Pipeline changes → `docs/ARCHITECTURE.md`
+- Script changes → `docs/START-SCRIPTS.md`
+- Quality/compliance → `docs/acrolinx-compliance-strategy.md`
+- Config changes → `docs/PROJECT-GUIDE.md`
+- New prereqs → `README.md`
+
 ## ⚠️ IMPORTANT: Testing Projects with Generative AI
 
 **Critical for time management**: Any project that uses generative AI (Azure OpenAI) will make sequential API calls to generate content. This can take **15-30+ minutes** to complete a full run (~200+ tools × ~2-4 seconds per API call).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -465,6 +465,27 @@ See `.squad/orchestration-log/2026-03-24T15-06-32Z-riley.md` for full detailed r
 
 ---
 
+### AD-026: PR Documentation Skill — CHANGELOG + Docs Update Required
+**Date:** 2026-03-29
+**Author:** Dina Berry (via Copilot)
+**Status:** Active
+**Extends:** AD-004
+
+**Every PR must run the `pr-docs` skill before team review.** This means:
+
+1. **CHANGELOG.md** must be updated with a user-facing entry under `## [Unreleased]`
+2. **User-facing documentation** must be updated based on the documentation routing table in `.squad/skills/pr-docs/SKILL.md`
+3. **README navigation** must be updated if new documentation files are created
+
+**Exemptions** (must be stated in PR comment):
+- Test-only changes: "Test coverage addition, no user-facing change"
+- Internal refactors: "Internal refactor, no behavior change"
+- Docs-only PRs: The PR itself IS the docs update (still needs CHANGELOG entry)
+
+**Enforcement:** The `pr-docs` skill is called before the `pr-review` skill. Reeve validates completeness during team review.
+
+---
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/skills/pr-docs/SKILL.md
+++ b/.squad/skills/pr-docs/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: "PR Documentation Update"
+description: "Update CHANGELOG and user-facing documentation for every PR before merge"
+domain: "documentation"
+confidence: "high"
+source: "manual"
+tools:
+  - name: "view"
+    description: "Read existing documentation files"
+    when: "To understand current state of docs before updating"
+  - name: "edit"
+    description: "Update documentation files"
+    when: "To add changelog entries and update user docs"
+  - name: "github-mcp-server-pull_request_read"
+    description: "Read PR details and changed files"
+    when: "To understand what changed and needs documenting"
+---
+
+## Context
+
+Every PR must update documentation before merge (AD-004, AD-026). This skill defines **what** to update and **where**. It runs AFTER code changes are complete but BEFORE the PR review.
+
+## When to Run
+
+- **Trigger**: Before requesting team review on any PR
+- **Blocking**: PR cannot be reviewed until docs are updated
+- **Exemptions**: Test-only PRs and internal refactors (must state exemption in PR comment)
+
+## Step 1: Determine Documentation Impact
+
+Read the PR diff and classify the change:
+
+| Change Type | CHANGELOG | Docs Update | README |
+|-------------|:---------:|:-----------:|:------:|
+| New feature / tool | ✅ Required | ✅ Required | ✅ If public-facing |
+| Bug fix (behavior change) | ✅ Required | ✅ Update affected docs | ❌ |
+| Bug fix (internal) | ✅ Required | ❌ | ❌ |
+| Pipeline step change | ✅ Required | ✅ ARCHITECTURE.md | ❌ |
+| Prompt change | ✅ Required | ✅ Note in relevant step docs | ❌ |
+| Config change | ✅ Required | ✅ Update config reference | ❌ |
+| Script/CI change | ✅ Required | ✅ START-SCRIPTS.md or CI docs | ❌ |
+| Docs-only change | ❌ | ✅ (that's the PR itself) | ❌ |
+| Test-only change | ❌ Exempt | ❌ Exempt | ❌ |
+| Internal refactor | ❌ Exempt | ❌ Exempt | ❌ |
+
+## Step 2: Update CHANGELOG.md
+
+Add an entry under `## [Unreleased]` in the appropriate subsection:
+
+```markdown
+### Added      — New features, tools, capabilities
+### Changed    — Changes to existing functionality
+### Fixed      — Bug fixes
+### Removed    — Removed features
+### Deprecated — Soon-to-be-removed features
+```
+
+**Entry format:**
+```markdown
+- **Brief description** — One sentence explaining what and why. (PR #NNN, Issue #NNN)
+```
+
+**Rules:**
+- Write from user perspective, not developer perspective
+- Include PR number and issue number if applicable
+- Be specific: "Added Azure AD branding detection" not "Updated regex patterns"
+- Group related changes into a single entry
+
+## Step 3: Update User-Facing Documentation
+
+Route to the appropriate documentation file(s) based on what changed:
+
+### Documentation Routing Table
+
+| What Changed | Update This File | Section to Update |
+|-------------|-----------------|-------------------|
+| New CLI tool or command | `docs/PROJECT-GUIDE.md` | "Tools" or relevant section |
+| New pipeline step or step change | `docs/ARCHITECTURE.md` | Step description |
+| Start script options | `docs/START-SCRIPTS.md` | Command reference |
+| AI prompt behavior | `docs/tool-generation-and-ai-improvements.md` | Relevant strategy section |
+| Quality/compliance change | `docs/acrolinx-compliance-strategy.md` | Relevant rule section |
+| Test infrastructure | `docs/test-strategy.md` | Coverage or framework section |
+| Fingerprint/regression tool | `docs/FINGERPRINTING.md` | Relevant section |
+| Config file format | `docs/PROJECT-GUIDE.md` | Configuration section |
+| New dependency or prereq | `README.md` | Prerequisites section |
+| New output file or directory | `README.md` | Output Structure section |
+| Common error or fix | `docs/PROJECT-GUIDE.md` | Troubleshooting section |
+| Breaking change | `README.md` + `docs/QUICK-START.md` | Migration note |
+
+### What to Write
+
+- **New feature**: Add a brief description of what it does, when to use it, and a minimal example
+- **Behavior change**: Update any docs that describe the old behavior
+- **Bug fix**: If users might encounter the old bug, add a note in troubleshooting
+- **Config change**: Update the config reference with new fields/values
+
+## Step 4: Update README Navigation (if applicable)
+
+If a new documentation file was created, add it to the appropriate category in the README's Documentation section:
+
+```markdown
+## Documentation
+
+### {Category}
+
+| Document | Description |
+|----------|-------------|
+| [docs/NEW-FILE.md](docs/NEW-FILE.md) | Brief description |
+```
+
+## Step 5: Verify
+
+Before marking docs as complete:
+
+1. All new docs links in README are valid files
+2. CHANGELOG entry is under `## [Unreleased]`
+3. No stale references to old behavior remain in updated docs
+4. Examples in docs are copy-pasteable and correct
+
+## Anti-Patterns
+
+- ❌ Skipping CHANGELOG for "small" changes
+- ❌ Writing developer-facing changelog entries ("refactored regex") instead of user-facing ("improved branding detection")
+- ❌ Updating CHANGELOG but not the actual documentation
+- ❌ Adding a new doc file without linking it from README
+- ❌ Leaving outdated examples in docs after a behavior change
+
+## Related Decisions
+
+- **AD-004**: PR Documentation Requirement (merge-blocking)
+- **AD-026**: PR Documentation Skill — CHANGELOG + docs update required for every PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the Azure MCP Documentation Generator are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- **Baseline fingerprinting tool** (`DocGeneration.Tools.Fingerprint`) — Snapshot and diff generated output for regression detection. Supports `--snapshot` and `--diff` modes with CI-gatable exit codes. 58 tests. (PR #324, Issue #209)
+- **Comprehensive README documentation navigation** — 22 documents organized across 8 categories replacing flat 6-link list. (PR #325)
+- **Prompt review P0/P1 fixes** — Removed redundancy, dead code, and fixed bugs across pipeline prompts. (PR #323, Issue #294)
+- **Shared Acrolinx rules** — Standardized compliance rules across all AI system prompts. (PR #323)

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ To modify AI-generated content quality or style:
 
 | Document | Description |
 |----------|-------------|
+| [CHANGELOG.md](CHANGELOG.md) | All notable changes to the project |
 | [docs/QUICK-START.md](docs/QUICK-START.md) | 5-minute setup guide |
 | [docs/PROJECT-GUIDE.md](docs/PROJECT-GUIDE.md) | Full developer guide — extending, testing, troubleshooting |
 


### PR DESCRIPTION
## Summary

Establishes a mandatory documentation workflow for every PR. Creates the pr-docs squad skill and CHANGELOG.md.

### 1. CHANGELOG.md - Initialized with recent merged PRs
### 2. Squad Skill pr-docs - Step-by-step process with routing table
### 3. AD-026 Decision - Extends AD-004
### 4. Copilot Directive - Quick-reference routing table

Documentation-only PR for AD-026.
