### PR TITLE
fix: prompt review P2/P3 — de-duplicate rules, add Acrolinx to Step 6, delete legacy (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Comprehensive README documentation navigation** — 22 documents organized across 8 categories replacing flat 6-link list. (PR #325)
 - **Prompt review P0/P1 fixes** — Removed redundancy, dead code, and fixed bugs across pipeline prompts. (PR #323, Issue #294)
 - **Shared Acrolinx rules** — Standardized compliance rules across all AI system prompts. (PR #323)
+- **Prompt hygiene tests** — 14 cross-cutting tests enforcing no legacy duplicate prompts, shared Acrolinx rules in all AI steps, and Step 3 scope boundaries. (Issue #294)
+
+### Changed
+
+- **Step 3 prompt scope narrowed** — Removed 35 lines of formatting/style rules (backtick formatting, CLI switch conversion, LLM guidance removal) that duplicated Step 4. Step 3 now focuses on content quality improvement only. (Issue #294)

--- a/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/PromptHygieneTests.cs
+++ b/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/PromptHygieneTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace DocGeneration.PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Cross-cutting tests that enforce prompt hygiene rules across all pipeline steps.
+/// Prevents re-introduction of legacy duplicate prompts, ensures shared Acrolinx rules
+/// are referenced by all AI steps, and validates Step 3 scope boundaries.
+/// </summary>
+public class PromptHygieneTests
+{
+    private readonly string _docsGenDir;
+
+    public PromptHygieneTests()
+    {
+        _docsGenDir = Path.Combine(FindProjectRoot(), "docs-generation");
+    }
+
+    // ── P1: No legacy duplicate prompts ─────────────────────────────
+
+    /// <summary>
+    /// The top-level docs-generation/prompts/ directory must NOT contain prompt files
+    /// that duplicate step-specific prompts. These were cleaned up and must not be
+    /// re-introduced. The only allowed subdirectory is instruction-generation/.
+    /// </summary>
+    [Theory]
+    [InlineData("system-prompt-example-prompt.txt")]
+    [InlineData("user-prompt-example-prompt.txt")]
+    [InlineData("system-prompt-example-prompt-validation.txt")]
+    [InlineData("user-prompt-example-prompt-validation.txt")]
+    [InlineData("tool-family-cleanup-system-prompt.txt")]
+    [InlineData("tool-family-cleanup-user-prompt.txt")]
+    public void LegacyPromptFile_MustNotExist(string filename)
+    {
+        var legacyPath = Path.Combine(_docsGenDir, "prompts", filename);
+        Assert.False(
+            File.Exists(legacyPath),
+            $"Legacy duplicate prompt file must not exist: prompts/{filename}. " +
+            "Step-specific prompts live in their respective project directories.");
+    }
+
+    // ── P2: All AI steps reference {{ACROLINX_RULES}} ──────────────
+
+    /// <summary>
+    /// Every AI-powered pipeline step (Steps 2, 3, 4, 6) must reference the shared
+    /// {{ACROLINX_RULES}} token in its system prompt so that Acrolinx compliance rules
+    /// are applied uniformly across all generated content.
+    /// </summary>
+    [Theory]
+    [InlineData(
+        "Step 2 (Example Prompts Generation)",
+        "DocGeneration.Steps.ExamplePrompts.Generation",
+        "prompts/system-prompt-example-prompt.txt")]
+    [InlineData(
+        "Step 3 (Tool Generation Improvements)",
+        "DocGeneration.Steps.ToolGeneration.Improvements",
+        "prompts/system-prompt.txt")]
+    [InlineData(
+        "Step 4 (Tool Family Cleanup)",
+        "DocGeneration.Steps.ToolFamilyCleanup",
+        "prompts/tool-family-cleanup-system-prompt.txt")]
+    [InlineData(
+        "Step 6 (Horizontal Articles)",
+        "DocGeneration.Steps.HorizontalArticles",
+        "prompts/horizontal-article-system-prompt.txt")]
+    public void AiStep_SystemPrompt_ReferencesAcrolinxRules(
+        string stepName, string projectDir, string promptRelPath)
+    {
+        var promptPath = Path.Combine(_docsGenDir, projectDir, promptRelPath);
+        Assert.True(File.Exists(promptPath), $"System prompt not found for {stepName}: {promptPath}");
+
+        var content = File.ReadAllText(promptPath);
+        Assert.Contains(
+            "{{ACROLINX_RULES}}",
+            content,
+            StringComparison.Ordinal);
+    }
+
+    // ── P2: Step 3 must NOT contain formatting rules that belong to Step 4 ──
+
+    /// <summary>
+    /// Step 3 (ToolGeneration.Improvements) focuses on content improvement — better
+    /// descriptions, clearer explanations, technical accuracy. Formatting rules
+    /// (backtick formatting, CLI switch conversion, LLM guidance removal) are Step 4's
+    /// responsibility. This test catches scope creep if formatting rules are re-added.
+    /// </summary>
+    [Fact]
+    public void Step3_SystemPrompt_DoesNotContain_CliSwitchConversionRules()
+    {
+        var content = ReadStep3SystemPrompt();
+
+        // Step 3 must not contain CLI switch name conversion rules
+        Assert.DoesNotContain("--switch-name", content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("--resource-group", content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("--vm-name", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Step3_SystemPrompt_DoesNotContain_LlmGuidanceRemovalRules()
+    {
+        var content = ReadStep3SystemPrompt();
+
+        // Step 3 must not contain LLM guidance removal instructions
+        Assert.DoesNotContain(
+            "Use this tool when",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "Do not use this tool",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "LLM-specific usage guidance",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Step3_SystemPrompt_DoesNotContain_BacktickFormattingRules()
+    {
+        var content = ReadStep3SystemPrompt();
+
+        // Step 3 must not contain backtick formatting rules
+        Assert.DoesNotContain(
+            "Do NOT use backticks around parameter names in tables",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "Backtick formatting consistency",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "Convert quoted parameter values to backticks",
+            content,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Step3_SystemPrompt_StillContains_ContentQualityRules()
+    {
+        var content = ReadStep3SystemPrompt();
+
+        // Step 3 MUST still contain content quality guidance
+        Assert.Contains("Technical Accuracy", content);
+        Assert.Contains("Content Quality", content);
+        Assert.Contains("Voice and Tone", content);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private string ReadStep3SystemPrompt()
+    {
+        var path = Path.Combine(
+            _docsGenDir,
+            "DocGeneration.Steps.ToolGeneration.Improvements",
+            "prompts",
+            "system-prompt.txt");
+        Assert.True(File.Exists(path), $"Step 3 system prompt not found: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string FindProjectRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "docs-generation.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find project root (docs-generation.sln)");
+    }
+}

--- a/docs-generation/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
+++ b/docs-generation/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
@@ -24,18 +24,7 @@ Your task is to review and improve tool documentation files for the Azure Model 
    - Check that example prompts are realistic and would work with the tool
    - Use proper Azure terminology
 
-3. **Formatting**
-   - Use proper markdown formatting
-   - Ensure headings follow proper hierarchy
-   - Tables should be properly formatted with alignment
-   - **Do NOT use backticks around parameter names in tables or headings** (use bold text only)
-   - **Use backticks for inline code, parameter values, and technical terms in body text**
-   - **Convert quoted parameter values to backticks in body text** (e.g., 'check' → `check`, "update" → `update`)
-   - **Wrap action values, parameter names, and resource names in backticks when referenced in descriptive text**
-   - **EXCEPTION**: Keep single quotes in example prompts (e.g., "Update resource group 'my-rg'")
-   - Code blocks and inline code should be appropriately marked
-
-4. **Azure-Specific Guidelines**
+3. **Azure-Specific Guidelines**
    - **Use proper capitalization for Azure services in titles**: "Azure Pricing", "Azure Migrate", "Azure Advisor"
    - **In body text**, you may use lowercase when context is clear: "the Azure pricing calculator helps you..."
    - Use the official product name, not generic descriptions (e.g., "Azure Pricing" not "the pricing service")
@@ -47,37 +36,13 @@ Your task is to review and improve tool documentation files for the Azure Model 
    - Ensure example prompts use single quotes for parameter values
    - Keep technical descriptions clear but not overly verbose
 
-5. **Content Quality**
+4. **Content Quality**
    - Remove redundant or repetitive content
    - Improve clarity without changing meaning
    - Ensure proper grammar and spelling
    - Make descriptions helpful and actionable
 
-6. **Tool Description Content Rules**
-
-   These rules apply to the tool description paragraph(s) that appear below each tool H2 heading.
-
-   **Convert CLI switch names to natural language:**
-   - Replace `--switch-name` style references with their natural language equivalents (e.g., `--resource-group` → "resource group", `--vm-name` → "VM name", `--subscription` → "subscription")
-   - **Exception**: If a switch name exactly matches a keyword that appears as a parameter name in the tool's parameter table, keep it as-is in the parameter table but still use natural language in the description text
-   - Do NOT leave any `--switch-name` syntax in tool description prose
-
-   **Remove LLM-specific usage guidance:**
-   The documentation is for **people** using the Azure MCP Server from their IDE, not for LLMs calling tools programmatically. Remove or rewrite any content that is LLM tool-calling guidance rather than human-facing documentation:
-   - Remove "Use this tool when..." / "Use this tool to..." phrasing that instructs an AI agent on tool selection
-   - Remove "Do not use this tool to..." / "Not for..." negative instructions meant to steer LLM tool routing
-   - Remove "This command is equivalent to `az ...`" CLI equivalence hints (these help LLM routing, not humans)
-   - Remove instructions about how to pass parameters programmatically (e.g., "read the user's public key file and pass its content")
-   - Remove tool disambiguation hints aimed at LLMs (e.g., "use `VMSS create` instead", "use `vm update` instead")
-   - **Keep**: Factual descriptions of what the tool does, its capabilities, prerequisites, and what it returns — these help human readers
-   - **Rewrite** rather than just delete where possible: If removing LLM guidance leaves the description too sparse, rewrite the content to focus on what a human user can accomplish with the tool
-
-   **Backtick formatting consistency:**
-   If a term in the tool description also appears in the parameter descriptions table enclosed in single backticks (inline code format), apply the same backtick formatting to that term in the description text. This ensures visual consistency between description prose and the parameter table.
-   - Example: If the parameter table uses `resource-group` in backticks, the description must also use `resource-group` (with backticks), not "resource group" or resource-group without backticks
-   - Scan the parameter table's Description column for backtick-wrapped terms, then check the tool description for the same terms and apply matching backtick formatting
-
-7. **Parameter Descriptions**
+5. **Parameter Descriptions**
    - Keep all parameter descriptions inside the parameter table only
    - Do NOT add any parameter narrative or "Valid values" text after the table
 


### PR DESCRIPTION
## Summary

Completes remaining P2/P3 work from issue #294 (PR #323 handled P0/P1).

### Changes

**Step 3 prompt scope narrowed (P2)** — Removed 35 lines of formatting/style rules from \DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt\ (102 → 67 lines):
- Removed backtick formatting rules (section 3)
- Removed CLI switch name conversion rules (\--switch-name\ → natural language)
- Removed LLM guidance removal rules (\Use this tool when...\ removal)
- Removed backtick formatting consistency rules
- These rules are **duplicated in Step 4** and belong there exclusively
- Step 3 now focuses purely on content quality: voice/tone, technical accuracy, Azure guidelines, content quality, parameter descriptions

**Legacy prompt files (P1)** — Already deleted by PR #323. Regression tests added.

**Step 6 Acrolinx (P2)** — Already references \{{ACROLINX_RULES}}\ at line 280 (added by PR #323). Regression test added.

### Tests (14 new in PromptHygieneTests.cs)

| Category | Count | Purpose |
|----------|-------|---------|
| Legacy file guards | 6 | Prevents re-introduction of duplicate prompts in \docs-generation/prompts/\ |
| Acrolinx token coverage | 4 | Verifies all AI steps (2, 3, 4, 6) reference \{{ACROLINX_RULES}}\ |
| Step 3 scope boundaries | 3 | Ensures Step 3 does NOT contain formatting rules belonging to Step 4 |
| Step 3 content guard | 1 | Ensures Step 3 still contains content quality rules |

### Line count: +184 −38

Closes #294