### PR TITLE
feat: add token usage tracking models and schema (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Token usage tracking models** — `TokenUsageRecord` and `TokenUsageSummary` types in `DocGeneration.Core.Shared` for tracking Azure OpenAI token consumption per AI call. `StepResultFile` v3 schema adds nullable `tokenUsage` field. Backward-compatible with v1/v2 results. 12 new tests. (Issue #212)
+
 - **Prompt versioning documentation** — `docs/prompt-versioning.md` covering `PromptHasher`, `PromptSnapshot`, `PromptTokenResolver`, `StepResultFile` v2 schema, usage examples, and future pipeline integration notes. Added to README navigation. (Issue #333)
 - **Prompt versioning system** — `PromptHasher` utility (SHA256) + `PromptSnapshot` record + `StepResultFile` v2 schema with `promptSnapshots` field. Backward-compatible: v1 results still deserialize. 16 new tests. (Issue #211)
 - **Prompt regression testing framework** — Runner script (`prompt-regression.sh`) + 5 regression comparison tests + baselines for 5 representative namespaces. Detects quality regressions when prompts change. (PR #329, Issue #214)

--- a/docs-generation/DocGeneration.Core.Shared.Tests/TokenUsageTests.cs
+++ b/docs-generation/DocGeneration.Core.Shared.Tests/TokenUsageTests.cs
@@ -1,0 +1,374 @@
+using System.Text.Json;
+using Xunit;
+using Shared;
+
+namespace Shared.Tests;
+
+public class TokenUsageRecordTests
+{
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var record = new TokenUsageRecord();
+
+        Assert.Equal(0, record.PromptTokens);
+        Assert.Equal(0, record.CompletionTokens);
+        Assert.Equal(0, record.TotalTokens);
+        Assert.Equal("", record.Model);
+        Assert.Equal("", record.ToolName);
+    }
+
+    [Fact]
+    public void Serialization_RoundTrips_AllFields()
+    {
+        var original = new TokenUsageRecord
+        {
+            PromptTokens = 150,
+            CompletionTokens = 80,
+            TotalTokens = 230,
+            Model = "gpt-4o-mini",
+            ToolName = "deploy_get"
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<TokenUsageRecord>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(original.PromptTokens, deserialized!.PromptTokens);
+        Assert.Equal(original.CompletionTokens, deserialized.CompletionTokens);
+        Assert.Equal(original.TotalTokens, deserialized.TotalTokens);
+        Assert.Equal(original.Model, deserialized.Model);
+        Assert.Equal(original.ToolName, deserialized.ToolName);
+    }
+
+    [Fact]
+    public void Serialization_UsesExpectedPropertyNames()
+    {
+        var record = new TokenUsageRecord
+        {
+            PromptTokens = 10,
+            CompletionTokens = 20,
+            TotalTokens = 30,
+            Model = "gpt-4o",
+            ToolName = "storage_list"
+        };
+
+        var json = JsonSerializer.Serialize(record);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("promptTokens", out _));
+        Assert.True(root.TryGetProperty("completionTokens", out _));
+        Assert.True(root.TryGetProperty("totalTokens", out _));
+        Assert.True(root.TryGetProperty("model", out _));
+        Assert.True(root.TryGetProperty("toolName", out _));
+    }
+}
+
+public class TokenUsageSummaryTests
+{
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var summary = new TokenUsageSummary();
+
+        Assert.Equal(0, summary.TotalPromptTokens);
+        Assert.Equal(0, summary.TotalCompletionTokens);
+        Assert.Equal(0, summary.TotalTokens);
+        Assert.Equal(0, summary.CallCount);
+        Assert.NotNull(summary.Calls);
+        Assert.Empty(summary.Calls);
+    }
+
+    [Fact]
+    public void AddCall_SingleCall_AccumulatesTotals()
+    {
+        var summary = new TokenUsageSummary();
+        var record = new TokenUsageRecord
+        {
+            PromptTokens = 100,
+            CompletionTokens = 50,
+            TotalTokens = 150,
+            Model = "gpt-4o-mini",
+            ToolName = "cosmos_query"
+        };
+
+        summary.AddCall(record);
+
+        Assert.Equal(100, summary.TotalPromptTokens);
+        Assert.Equal(50, summary.TotalCompletionTokens);
+        Assert.Equal(150, summary.TotalTokens);
+        Assert.Equal(1, summary.CallCount);
+        Assert.Single(summary.Calls);
+        Assert.Same(record, summary.Calls[0]);
+    }
+
+    [Fact]
+    public void AddCall_MultipleCalls_AccumulatesTotals()
+    {
+        var summary = new TokenUsageSummary();
+
+        summary.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 100,
+            CompletionTokens = 50,
+            TotalTokens = 150,
+            Model = "gpt-4o-mini",
+            ToolName = "storage_list"
+        });
+
+        summary.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 200,
+            CompletionTokens = 120,
+            TotalTokens = 320,
+            Model = "gpt-4o-mini",
+            ToolName = "keyvault_get"
+        });
+
+        summary.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 80,
+            CompletionTokens = 40,
+            TotalTokens = 120,
+            Model = "gpt-4o",
+            ToolName = "monitor_query"
+        });
+
+        Assert.Equal(380, summary.TotalPromptTokens);   // 100 + 200 + 80
+        Assert.Equal(210, summary.TotalCompletionTokens); // 50 + 120 + 40
+        Assert.Equal(590, summary.TotalTokens);           // 150 + 320 + 120
+        Assert.Equal(3, summary.CallCount);
+        Assert.Equal(3, summary.Calls.Count);
+    }
+
+    [Fact]
+    public void Serialization_EmptySummary_RoundTripsCorrectly()
+    {
+        var original = new TokenUsageSummary();
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<TokenUsageSummary>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(0, deserialized!.TotalPromptTokens);
+        Assert.Equal(0, deserialized.TotalCompletionTokens);
+        Assert.Equal(0, deserialized.TotalTokens);
+        Assert.Equal(0, deserialized.CallCount);
+        Assert.Empty(deserialized.Calls);
+    }
+
+    [Fact]
+    public void Serialization_WithMultipleCalls_RoundTripsCorrectly()
+    {
+        var original = new TokenUsageSummary();
+        original.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 100,
+            CompletionTokens = 50,
+            TotalTokens = 150,
+            Model = "gpt-4o-mini",
+            ToolName = "deploy_create"
+        });
+        original.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 200,
+            CompletionTokens = 80,
+            TotalTokens = 280,
+            Model = "gpt-4o",
+            ToolName = "speech_recognize"
+        });
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<TokenUsageSummary>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(original.TotalPromptTokens, deserialized!.TotalPromptTokens);
+        Assert.Equal(original.TotalCompletionTokens, deserialized.TotalCompletionTokens);
+        Assert.Equal(original.TotalTokens, deserialized.TotalTokens);
+        Assert.Equal(original.CallCount, deserialized.CallCount);
+        Assert.Equal(2, deserialized.Calls.Count);
+
+        // Verify individual call records survived round-trip
+        Assert.Equal("deploy_create", deserialized.Calls[0].ToolName);
+        Assert.Equal(100, deserialized.Calls[0].PromptTokens);
+        Assert.Equal("speech_recognize", deserialized.Calls[1].ToolName);
+        Assert.Equal(200, deserialized.Calls[1].PromptTokens);
+    }
+
+    [Fact]
+    public void Serialization_UsesExpectedPropertyNames()
+    {
+        var summary = new TokenUsageSummary();
+        summary.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 10,
+            CompletionTokens = 5,
+            TotalTokens = 15,
+            Model = "gpt-4o",
+            ToolName = "test"
+        });
+
+        var json = JsonSerializer.Serialize(summary);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("totalPromptTokens", out _));
+        Assert.True(root.TryGetProperty("totalCompletionTokens", out _));
+        Assert.True(root.TryGetProperty("totalTokens", out _));
+        Assert.True(root.TryGetProperty("callCount", out _));
+        Assert.True(root.TryGetProperty("calls", out _));
+    }
+}
+
+public class StepResultFileTokenUsageTests
+{
+    [Fact]
+    public void StepResultFile_WithTokenUsage_RoundTripsCorrectly()
+    {
+        var original = new StepResultFile
+        {
+            Version = 3,
+            Status = StepResultStatus.Success,
+            Step = "Step 3 - Tool Generation",
+            Namespace = "deploy",
+            OutputFileCount = 5,
+            Duration = "00:02:15.123",
+            TokenUsage = new TokenUsageSummary()
+        };
+
+        original.TokenUsage.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 500,
+            CompletionTokens = 200,
+            TotalTokens = 700,
+            Model = "gpt-4o-mini",
+            ToolName = "deploy_create"
+        });
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<StepResultFile>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized!.TokenUsage);
+        Assert.Equal(500, deserialized.TokenUsage!.TotalPromptTokens);
+        Assert.Equal(200, deserialized.TokenUsage.TotalCompletionTokens);
+        Assert.Equal(700, deserialized.TokenUsage.TotalTokens);
+        Assert.Equal(1, deserialized.TokenUsage.CallCount);
+        Assert.Equal("deploy_create", deserialized.TokenUsage.Calls[0].ToolName);
+    }
+
+    [Fact]
+    public void StepResultFile_WithoutTokenUsage_BackwardCompatible()
+    {
+        // v1/v2 JSON without tokenUsage field — must deserialize cleanly
+        var json = """
+        {
+          "version": 2,
+          "status": "success",
+          "step": "Step 3 - Tool Generation",
+          "namespace": "deploy",
+          "outputFileCount": 5,
+          "warnings": [],
+          "errors": [],
+          "duration": "00:02:15.123",
+          "promptSnapshots": [
+            { "fileName": "system-prompt.txt", "contentHash": "abc123", "sizeBytes": 1024 }
+          ]
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<StepResultFile>(json);
+
+        Assert.NotNull(result);
+        Assert.Null(result!.TokenUsage);
+        Assert.Equal(2, result.Version);
+        Assert.Equal(StepResultStatus.Success, result.Status);
+        Assert.NotNull(result.PromptSnapshots);
+        Assert.Single(result.PromptSnapshots!);
+    }
+
+    [Fact]
+    public void StepResultFile_V1_WithoutTokenUsage_StillWorks()
+    {
+        // Bare v1 JSON — no promptSnapshots, no tokenUsage
+        var json = """
+        {
+          "version": 1,
+          "status": "failure",
+          "step": "Step 2 - Example Prompts",
+          "namespace": "storage",
+          "outputFileCount": 0,
+          "warnings": ["warning 1"],
+          "errors": ["error 1"],
+          "duration": "00:00:30.000"
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<StepResultFile>(json);
+
+        Assert.NotNull(result);
+        Assert.Null(result!.TokenUsage);
+        Assert.Null(result.PromptSnapshots);
+        Assert.Equal(1, result.Version);
+        Assert.Equal(StepResultStatus.Failure, result.Status);
+    }
+
+    [Fact]
+    public void StepResultFile_TokenUsage_AppearsInJsonSchema()
+    {
+        var result = new StepResultFile
+        {
+            Version = 3,
+            Status = StepResultStatus.Success,
+            Step = "Step 6 - Horizontal Articles",
+            Namespace = "advisor",
+            OutputFileCount = 1,
+            Duration = "00:01:00.000",
+            TokenUsage = new TokenUsageSummary()
+        };
+
+        result.TokenUsage.AddCall(new TokenUsageRecord
+        {
+            PromptTokens = 300,
+            CompletionTokens = 150,
+            TotalTokens = 450,
+            Model = "gpt-4o",
+            ToolName = "advisor_get"
+        });
+
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("tokenUsage", out var tokenUsageElement));
+        Assert.True(tokenUsageElement.TryGetProperty("totalPromptTokens", out _));
+        Assert.True(tokenUsageElement.TryGetProperty("totalCompletionTokens", out _));
+        Assert.True(tokenUsageElement.TryGetProperty("totalTokens", out _));
+        Assert.True(tokenUsageElement.TryGetProperty("callCount", out _));
+        Assert.True(tokenUsageElement.TryGetProperty("calls", out var callsElement));
+        Assert.Equal(JsonValueKind.Array, callsElement.ValueKind);
+        Assert.Equal(1, callsElement.GetArrayLength());
+    }
+
+    [Fact]
+    public void StepResultFile_NullTokenUsage_OmittedOrNullInJson()
+    {
+        var result = new StepResultFile
+        {
+            Version = 2,
+            Status = StepResultStatus.Success,
+            Step = "Step 1 - Annotations",
+            Namespace = "compute",
+            OutputFileCount = 10,
+            Duration = "00:00:05.000",
+            TokenUsage = null
+        };
+
+        var json = JsonSerializer.Serialize(result);
+        var deserialized = JsonSerializer.Deserialize<StepResultFile>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Null(deserialized!.TokenUsage);
+    }
+}

--- a/docs-generation/DocGeneration.Core.Shared/StepResultFile.cs
+++ b/docs-generation/DocGeneration.Core.Shared/StepResultFile.cs
@@ -28,9 +28,9 @@ public enum StepResultStatus
 /// Structured result written by generator processes as step-result.json.
 /// Replaces regex-based subprocess error detection with a typed contract.
 ///
-/// Schema v2 (added promptSnapshots):
+/// Schema v3 (added tokenUsage):
 /// {
-///   "version": 2,
+///   "version": 3,
 ///   "status": "success|failure|partial",
 ///   "step": "Step 3 - Tool Generation",
 ///   "namespace": "deploy",
@@ -38,12 +38,13 @@ public enum StepResultStatus
 ///   "warnings": ["warning 1"],
 ///   "errors": ["error 1"],
 ///   "duration": "00:02:15.123",
-///   "promptSnapshots": [{ "fileName": "...", "contentHash": "...", "sizeBytes": 1024 }]
+///   "promptSnapshots": [{ "fileName": "...", "contentHash": "...", "sizeBytes": 1024 }],
+///   "tokenUsage": { "totalPromptTokens": 500, "totalCompletionTokens": 200, ... }
 /// }
 /// </summary>
 public class StepResultFile
 {
-    /// <summary>Schema version for forward compatibility. v2: added promptSnapshots.</summary>
+    /// <summary>Schema version for forward compatibility. v2: added promptSnapshots. v3: added tokenUsage.</summary>
     [JsonPropertyName("version")]
     public int Version { get; set; } = 1;
 
@@ -81,6 +82,13 @@ public class StepResultFile
     /// </summary>
     [JsonPropertyName("promptSnapshots")]
     public List<PromptSnapshotRecord>? PromptSnapshots { get; set; }
+
+    /// <summary>
+    /// v3: Aggregated token usage from Azure OpenAI calls during step execution.
+    /// Nullable for backward compatibility - non-AI steps and v1/v2 results omit this field.
+    /// </summary>
+    [JsonPropertyName("tokenUsage")]
+    public TokenUsageSummary? TokenUsage { get; set; }
 
     /// <summary>
     /// Serialization-friendly record for prompt file metadata.

--- a/docs-generation/DocGeneration.Core.Shared/TokenUsage.cs
+++ b/docs-generation/DocGeneration.Core.Shared/TokenUsage.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Shared;
+
+/// <summary>
+/// Records token usage from a single Azure OpenAI API call.
+/// Captured per-tool so cost and consumption can be attributed.
+/// </summary>
+public sealed class TokenUsageRecord
+{
+    /// <summary>Number of tokens in the prompt (input).</summary>
+    [JsonPropertyName("promptTokens")]
+    public int PromptTokens { get; set; }
+
+    /// <summary>Number of tokens in the completion (output).</summary>
+    [JsonPropertyName("completionTokens")]
+    public int CompletionTokens { get; set; }
+
+    /// <summary>Total tokens consumed (prompt + completion).</summary>
+    [JsonPropertyName("totalTokens")]
+    public int TotalTokens { get; set; }
+
+    /// <summary>Model deployment name (e.g., "gpt-4o-mini").</summary>
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = "";
+
+    /// <summary>Which tool or namespace this call was for (e.g., "deploy_create").</summary>
+    [JsonPropertyName("toolName")]
+    public string ToolName { get; set; } = "";
+}
+
+/// <summary>
+/// Aggregated token usage across all AI calls within a pipeline step.
+/// Attached to <see cref="StepResultFile.TokenUsage"/> for observability.
+/// </summary>
+public sealed class TokenUsageSummary
+{
+    /// <summary>Sum of prompt tokens across all calls.</summary>
+    [JsonPropertyName("totalPromptTokens")]
+    public int TotalPromptTokens { get; set; }
+
+    /// <summary>Sum of completion tokens across all calls.</summary>
+    [JsonPropertyName("totalCompletionTokens")]
+    public int TotalCompletionTokens { get; set; }
+
+    /// <summary>Sum of total tokens across all calls.</summary>
+    [JsonPropertyName("totalTokens")]
+    public int TotalTokens { get; set; }
+
+    /// <summary>Number of AI API calls made.</summary>
+    [JsonPropertyName("callCount")]
+    public int CallCount { get; set; }
+
+    /// <summary>Individual call records for per-tool attribution.</summary>
+    [JsonPropertyName("calls")]
+    public List<TokenUsageRecord> Calls { get; set; } = new();
+
+    /// <summary>
+    /// Records a single AI call and updates running totals.
+    /// </summary>
+    public void AddCall(TokenUsageRecord record)
+    {
+        Calls.Add(record);
+        TotalPromptTokens += record.PromptTokens;
+        TotalCompletionTokens += record.CompletionTokens;
+        TotalTokens += record.TotalTokens;
+        CallCount++;
+    }
+}

--- a/docs/token-tracking.md
+++ b/docs/token-tracking.md
@@ -1,0 +1,134 @@
+# Token Usage Tracking
+
+Track Azure OpenAI token consumption per pipeline step for cost observability and optimization.
+
+## Overview
+
+AI-enhanced pipeline steps (2, 3, 4, 6) call Azure OpenAI for each tool they process. Token usage tracking captures prompt tokens, completion tokens, and model information for every API call, then aggregates them per step in `step-result.json`.
+
+## Data Model
+
+### TokenUsageRecord
+
+Captures a single Azure OpenAI API call:
+
+```json
+{
+  "promptTokens": 500,
+  "completionTokens": 200,
+  "totalTokens": 700,
+  "model": "gpt-4o-mini",
+  "toolName": "deploy_create"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `promptTokens` | int | Tokens in the input prompt |
+| `completionTokens` | int | Tokens in the AI response |
+| `totalTokens` | int | Sum of prompt + completion |
+| `model` | string | Model deployment name |
+| `toolName` | string | Tool/namespace the call was for |
+
+### TokenUsageSummary
+
+Aggregates all AI calls within a step:
+
+```json
+{
+  "totalPromptTokens": 1500,
+  "totalCompletionTokens": 800,
+  "totalTokens": 2300,
+  "callCount": 5,
+  "calls": [ ... ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalPromptTokens` | int | Sum of prompt tokens across all calls |
+| `totalCompletionTokens` | int | Sum of completion tokens across all calls |
+| `totalTokens` | int | Sum of total tokens across all calls |
+| `callCount` | int | Number of AI API calls made |
+| `calls` | array | Individual `TokenUsageRecord` entries |
+
+## StepResultFile v3 Schema
+
+`StepResultFile` gained a nullable `TokenUsage` property in schema version 3.
+
+```json
+{
+  "version": 3,
+  "status": "success",
+  "step": "Step 3 - Tool Generation",
+  "namespace": "deploy",
+  "outputFileCount": 5,
+  "warnings": [],
+  "errors": [],
+  "duration": "00:02:15.123",
+  "promptSnapshots": [ ... ],
+  "tokenUsage": {
+    "totalPromptTokens": 1500,
+    "totalCompletionTokens": 800,
+    "totalTokens": 2300,
+    "callCount": 5,
+    "calls": [
+      {
+        "promptTokens": 500,
+        "completionTokens": 200,
+        "totalTokens": 700,
+        "model": "gpt-4o-mini",
+        "toolName": "deploy_create"
+      }
+    ]
+  }
+}
+```
+
+### Backward Compatibility
+
+- **v1/v2 → v3 reading**: The `TokenUsage` property is `TokenUsageSummary?` (nullable). Files without `tokenUsage` deserialize cleanly — the property stays `null`.
+- **v3 → v1/v2 reading**: Consumers that don't know about `tokenUsage` ignore the unknown JSON property (default `System.Text.Json` behavior).
+- Non-AI steps (Step 0, Step 1, Step 5) won't populate `tokenUsage` — it remains `null`.
+
+## Usage
+
+```csharp
+// Create a summary and record calls
+var usage = new TokenUsageSummary();
+
+usage.AddCall(new TokenUsageRecord
+{
+    PromptTokens = 500,
+    CompletionTokens = 200,
+    TotalTokens = 700,
+    Model = "gpt-4o-mini",
+    ToolName = "deploy_create"
+});
+
+// Attach to step result
+var result = new StepResultFile
+{
+    Version = 3,
+    Status = StepResultStatus.Success,
+    Step = "Step 3 - Tool Generation",
+    Namespace = "deploy",
+    OutputFileCount = 5,
+    TokenUsage = usage
+};
+```
+
+## Future: AI Client Integration
+
+The token usage infrastructure is in place but **AI clients don't yet record usage at runtime**. Wiring `GenerativeAIClient` to capture token counts from Azure OpenAI SDK responses is follow-up work. When implemented:
+
+- Each AI step (2, 3, 4, 6) will record token usage in `step-result.json`.
+- The pipeline runner can aggregate usage across all steps for a full run summary.
+- Teams can monitor cost trends per namespace and per step.
+
+## Related
+
+- [Prompt versioning](prompt-versioning.md) — Prompt hash tracking (v2 schema)
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Pipeline step details and data flow
+- Source: `docs-generation/DocGeneration.Core.Shared/TokenUsage.cs`
+- Source: `docs-generation/DocGeneration.Core.Shared/StepResultFile.cs`


### PR DESCRIPTION
## Summary

Adds token usage tracking infrastructure (models + schema) for Azure OpenAI observability. **Does not wire into AI clients** — that's follow-up work.

### Changes

- **\TokenUsageRecord\** — Per-call record: promptTokens, completionTokens, totalTokens, model, toolName
- **\TokenUsageSummary\** — Aggregated totals with \AddCall()\ accumulator and individual call list
- **\StepResultFile.TokenUsage\** — Nullable \TokenUsageSummary?\ (v3 schema). Backward-compatible with v1/v2.
- **12 new tests** (TDD): defaults, accumulation, round-trip serialization, JSON property names, backward compatibility with v1/v2 JSON
- **\docs/token-tracking.md\** — Data model, schema, usage examples, future integration notes
- **CHANGELOG.md** updated

### Schema Evolution

| Version | Added |
|---------|-------|
| v1 | Base schema |
| v2 | \promptSnapshots\ (Issue #211) |
| v3 | \	okenUsage\ (Issue #212) |

### Testing

- All 222 Shared tests pass
- Full solution builds clean (\dotnet build --configuration Release\)
- Pre-existing GenerativeAI test crash is unrelated (tries to call real Azure OpenAI)

Closes #212