### PR TITLE
feat: add AI response archival infrastructure (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **AI response archival infrastructure** — `AiResponseArchiveEntry` model and `AiResponseArchiveWriter` in `DocGeneration.Core.Shared`. Writes raw AI responses to `{outputDir}/ai-responses/{step}-{toolName}.json` for audit trail. Enabled by default; set `ARCHIVE_AI_RESPONSES=false` to disable. 15 new tests. (Issue #340)
 - **Token usage tracking models** — `TokenUsageRecord` and `TokenUsageSummary` types in `DocGeneration.Core.Shared` for tracking Azure OpenAI token consumption per AI call. `StepResultFile` v3 schema adds nullable `tokenUsage` field. Backward-compatible with v1/v2 results. 12 new tests. (Issue #212)
 
 - **Prompt versioning documentation** — `docs/prompt-versioning.md` covering `PromptHasher`, `PromptSnapshot`, `PromptTokenResolver`, `StepResultFile` v2 schema, usage examples, and future pipeline integration notes. Added to README navigation. (Issue #333)

--- a/docs-generation/DocGeneration.Core.Shared.Tests/AiResponseArchiveEntryTests.cs
+++ b/docs-generation/DocGeneration.Core.Shared.Tests/AiResponseArchiveEntryTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+using Shared;
+
+namespace Shared.Tests;
+
+public class AiResponseArchiveEntryTests
+{
+    [Fact]
+    public void Defaults_AreEmptyAndZero()
+    {
+        var entry = new AiResponseArchiveEntry();
+
+        Assert.Equal("", entry.Step);
+        Assert.Equal("", entry.ToolName);
+        Assert.Equal("", entry.PromptHash);
+        Assert.Equal("", entry.RawResponse);
+        Assert.Equal("", entry.Model);
+        Assert.Equal(default, entry.Timestamp);
+        Assert.Equal(0, entry.PromptTokens);
+        Assert.Equal(0, entry.CompletionTokens);
+    }
+
+    [Fact]
+    public void Serialization_RoundTrip_PreservesAllFields()
+    {
+        var timestamp = new DateTimeOffset(2025, 7, 15, 10, 30, 0, TimeSpan.Zero);
+        var entry = new AiResponseArchiveEntry
+        {
+            Step = "Step 2 - Example Prompts",
+            ToolName = "storage_blob_list",
+            PromptHash = "abc123def456",
+            RawResponse = "{\"prompts\":[\"List all blobs\"]}",
+            Model = "gpt-4o-mini",
+            Timestamp = timestamp,
+            PromptTokens = 150,
+            CompletionTokens = 300
+        };
+
+        var json = JsonSerializer.Serialize(entry);
+        var deserialized = JsonSerializer.Deserialize<AiResponseArchiveEntry>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("Step 2 - Example Prompts", deserialized!.Step);
+        Assert.Equal("storage_blob_list", deserialized.ToolName);
+        Assert.Equal("abc123def456", deserialized.PromptHash);
+        Assert.Equal("{\"prompts\":[\"List all blobs\"]}", deserialized.RawResponse);
+        Assert.Equal("gpt-4o-mini", deserialized.Model);
+        Assert.Equal(timestamp, deserialized.Timestamp);
+        Assert.Equal(150, deserialized.PromptTokens);
+        Assert.Equal(300, deserialized.CompletionTokens);
+    }
+
+    [Fact]
+    public void Serialization_UsesJsonPropertyNames()
+    {
+        var entry = new AiResponseArchiveEntry
+        {
+            Step = "Step 3",
+            ToolName = "keyvault_secret_get",
+            PromptHash = "hash123",
+            RawResponse = "raw",
+            Model = "gpt-4o",
+            Timestamp = DateTimeOffset.UtcNow,
+            PromptTokens = 100,
+            CompletionTokens = 200
+        };
+
+        var json = JsonSerializer.Serialize(entry);
+
+        Assert.Contains("\"step\"", json);
+        Assert.Contains("\"toolName\"", json);
+        Assert.Contains("\"promptHash\"", json);
+        Assert.Contains("\"rawResponse\"", json);
+        Assert.Contains("\"model\"", json);
+        Assert.Contains("\"timestamp\"", json);
+        Assert.Contains("\"promptTokens\"", json);
+        Assert.Contains("\"completionTokens\"", json);
+    }
+
+    [Fact]
+    public void Deserialization_FromJsonString_Works()
+    {
+        var json = """
+        {
+            "step": "Step 6",
+            "toolName": "cosmos_query",
+            "promptHash": "deadbeef",
+            "rawResponse": "some response",
+            "model": "gpt-4o-mini",
+            "timestamp": "2025-07-15T12:00:00+00:00",
+            "promptTokens": 50,
+            "completionTokens": 75
+        }
+        """;
+
+        var entry = JsonSerializer.Deserialize<AiResponseArchiveEntry>(json);
+
+        Assert.NotNull(entry);
+        Assert.Equal("Step 6", entry!.Step);
+        Assert.Equal("cosmos_query", entry.ToolName);
+        Assert.Equal("deadbeef", entry.PromptHash);
+        Assert.Equal("some response", entry.RawResponse);
+        Assert.Equal("gpt-4o-mini", entry.Model);
+        Assert.Equal(50, entry.PromptTokens);
+        Assert.Equal(75, entry.CompletionTokens);
+    }
+}

--- a/docs-generation/DocGeneration.Core.Shared.Tests/AiResponseArchiveWriterTests.cs
+++ b/docs-generation/DocGeneration.Core.Shared.Tests/AiResponseArchiveWriterTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+using Shared;
+
+namespace Shared.Tests;
+
+public class AiResponseArchiveWriterTests : IDisposable
+{
+    private readonly string _testDir;
+    private const string EnvVar = "ARCHIVE_AI_RESPONSES";
+
+    public AiResponseArchiveWriterTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"ai-archive-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        // Ensure env var is unset at test start (default = enabled)
+        Environment.SetEnvironmentVariable(EnvVar, null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, null);
+        if (Directory.Exists(_testDir))
+            Directory.Delete(_testDir, recursive: true);
+    }
+
+    private static AiResponseArchiveEntry MakeEntry(string step = "step2", string toolName = "storage_blob_list") =>
+        new()
+        {
+            Step = step,
+            ToolName = toolName,
+            PromptHash = "abc123",
+            RawResponse = "{\"result\":\"ok\"}",
+            Model = "gpt-4o-mini",
+            Timestamp = new DateTimeOffset(2025, 7, 15, 10, 0, 0, TimeSpan.Zero),
+            PromptTokens = 100,
+            CompletionTokens = 200
+        };
+
+    [Fact]
+    public async Task WriteAsync_CreatesFileAtExpectedPath()
+    {
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "storage", entry);
+
+        var expected = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        Assert.True(File.Exists(expected), $"Expected file at {expected}");
+    }
+
+    [Fact]
+    public async Task WriteAsync_CreatesDirectoryIfMissing()
+    {
+        var nested = Path.Combine(_testDir, "deep", "output");
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(nested, "advisor", entry);
+
+        var dir = Path.Combine(nested, "ai-responses");
+        Assert.True(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public async Task WriteAsync_ProducesValidDeserializableJson()
+    {
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "keyvault", entry);
+
+        var filePath = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<AiResponseArchiveEntry>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("step2", deserialized!.Step);
+        Assert.Equal("storage_blob_list", deserialized.ToolName);
+        Assert.Equal("{\"result\":\"ok\"}", deserialized.RawResponse);
+        Assert.Equal("gpt-4o-mini", deserialized.Model);
+        Assert.Equal(100, deserialized.PromptTokens);
+        Assert.Equal(200, deserialized.CompletionTokens);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ProducesIndentedJson()
+    {
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "monitor", entry);
+
+        var filePath = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        var json = await File.ReadAllTextAsync(filePath);
+
+        Assert.Contains("\n", json);
+        Assert.Contains("\"step\"", json);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverwritesExistingFile()
+    {
+        var entry1 = MakeEntry();
+        entry1.RawResponse = "first";
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "storage", entry1);
+
+        var entry2 = MakeEntry();
+        entry2.RawResponse = "second";
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "storage", entry2);
+
+        var filePath = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var loaded = JsonSerializer.Deserialize<AiResponseArchiveEntry>(json);
+
+        Assert.Equal("second", loaded!.RawResponse);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MultipleEntries_DontInterfere()
+    {
+        var entry1 = MakeEntry(step: "step2", toolName: "storage_blob_list");
+        var entry2 = MakeEntry(step: "step3", toolName: "keyvault_secret_get");
+        entry2.RawResponse = "keyvault response";
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "storage", entry1);
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "keyvault", entry2);
+
+        var file1 = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        var file2 = Path.Combine(_testDir, "ai-responses", "step3-keyvault_secret_get.json");
+
+        Assert.True(File.Exists(file1));
+        Assert.True(File.Exists(file2));
+
+        var loaded1 = JsonSerializer.Deserialize<AiResponseArchiveEntry>(
+            await File.ReadAllTextAsync(file1));
+        var loaded2 = JsonSerializer.Deserialize<AiResponseArchiveEntry>(
+            await File.ReadAllTextAsync(file2));
+
+        Assert.Equal("{\"result\":\"ok\"}", loaded1!.RawResponse);
+        Assert.Equal("keyvault response", loaded2!.RawResponse);
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsNoOp_WhenEnvVarSetToFalse()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "false");
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "storage", entry);
+
+        var dir = Path.Combine(_testDir, "ai-responses");
+        Assert.False(Directory.Exists(dir), "ai-responses dir should not be created when disabled");
+    }
+
+    [Fact]
+    public async Task WriteAsync_Writes_WhenEnvVarSetToTrue()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "true");
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "cosmos", entry);
+
+        var expected = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        Assert.True(File.Exists(expected));
+    }
+
+    [Fact]
+    public async Task WriteAsync_Writes_WhenEnvVarNotSet()
+    {
+        // Default behavior: archival is enabled
+        Environment.SetEnvironmentVariable(EnvVar, null);
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "speech", entry);
+
+        var expected = Path.Combine(_testDir, "ai-responses", "step2-storage_blob_list.json");
+        Assert.True(File.Exists(expected));
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsNoOp_WhenEnvVarSetTo0()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "0");
+        var entry = MakeEntry();
+
+        await AiResponseArchiveWriter.WriteAsync(_testDir, "sql", entry);
+
+        var dir = Path.Combine(_testDir, "ai-responses");
+        Assert.False(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsTrueByDefault()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, null);
+        Assert.True(AiResponseArchiveWriter.IsEnabled());
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenSetToFalse()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "false");
+        Assert.False(AiResponseArchiveWriter.IsEnabled());
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenSetTo0()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "0");
+        Assert.False(AiResponseArchiveWriter.IsEnabled());
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsTrue_WhenSetToTrue()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "true");
+        Assert.True(AiResponseArchiveWriter.IsEnabled());
+    }
+}

--- a/docs-generation/DocGeneration.Core.Shared/AiResponseArchiveEntry.cs
+++ b/docs-generation/DocGeneration.Core.Shared/AiResponseArchiveEntry.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Shared;
+
+/// <summary>
+/// Represents a single archived AI response for audit trail purposes.
+/// Captures the raw response, prompt hash, token usage, and metadata
+/// so that AI interactions can be reviewed and debugged after generation.
+/// </summary>
+public sealed class AiResponseArchiveEntry
+{
+    /// <summary>Pipeline step that produced this response (e.g., "step2", "step3").</summary>
+    [JsonPropertyName("step")]
+    public string Step { get; set; } = "";
+
+    /// <summary>Tool name the AI call was made for (e.g., "storage_blob_list").</summary>
+    [JsonPropertyName("toolName")]
+    public string ToolName { get; set; } = "";
+
+    /// <summary>SHA256 hash of the prompt sent to the AI model.</summary>
+    [JsonPropertyName("promptHash")]
+    public string PromptHash { get; set; } = "";
+
+    /// <summary>Raw response text from the AI model, before any parsing or transformation.</summary>
+    [JsonPropertyName("rawResponse")]
+    public string RawResponse { get; set; } = "";
+
+    /// <summary>AI model deployment name (e.g., "gpt-4o-mini").</summary>
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = "";
+
+    /// <summary>UTC timestamp when the AI response was received.</summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Number of tokens in the prompt sent to the model.</summary>
+    [JsonPropertyName("promptTokens")]
+    public int PromptTokens { get; set; }
+
+    /// <summary>Number of tokens in the model's completion response.</summary>
+    [JsonPropertyName("completionTokens")]
+    public int CompletionTokens { get; set; }
+}

--- a/docs-generation/DocGeneration.Core.Shared/AiResponseArchiveWriter.cs
+++ b/docs-generation/DocGeneration.Core.Shared/AiResponseArchiveWriter.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Shared;
+
+/// <summary>
+/// Writes <see cref="AiResponseArchiveEntry"/> records to disk for audit trail.
+/// Files are written to {outputDir}/ai-responses/{step}-{toolName}.json.
+///
+/// Archival is enabled by default. Set the environment variable
+/// ARCHIVE_AI_RESPONSES=false (or "0") to disable writing.
+/// </summary>
+public static class AiResponseArchiveWriter
+{
+    /// <summary>Environment variable that controls whether archival is enabled.</summary>
+    public const string EnvVarName = "ARCHIVE_AI_RESPONSES";
+
+    /// <summary>Subdirectory under the output root where archive files are written.</summary>
+    private const string ArchiveSubdir = "ai-responses";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Returns true if archival is enabled (default). Returns false only when
+    /// the ARCHIVE_AI_RESPONSES environment variable is explicitly set to "false" or "0".
+    /// </summary>
+    public static bool IsEnabled()
+    {
+        var value = Environment.GetEnvironmentVariable(EnvVarName);
+        if (string.IsNullOrEmpty(value))
+            return true;
+
+        return !value.Equals("false", StringComparison.OrdinalIgnoreCase)
+            && !value.Equals("0", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Writes an AI response archive entry to disk. The file is written to
+    /// {outputDir}/ai-responses/{step}-{toolName}.json. Creates the directory
+    /// if it does not exist. Overwrites any existing file for the same step+tool.
+    /// No-op when archival is disabled via environment variable.
+    /// </summary>
+    /// <param name="outputDir">Root output directory for the generation run.</param>
+    /// <param name="namespace">MCP namespace (for logging context; not used in file path).</param>
+    /// <param name="entry">The archive entry to write.</param>
+    public static async Task WriteAsync(string outputDir, string @namespace, AiResponseArchiveEntry entry)
+    {
+        if (!IsEnabled())
+            return;
+
+        var dir = Path.Combine(outputDir, ArchiveSubdir);
+        Directory.CreateDirectory(dir);
+
+        var fileName = $"{entry.Step}-{entry.ToolName}.json";
+        var filePath = Path.Combine(dir, fileName);
+
+        var json = JsonSerializer.Serialize(entry, SerializerOptions);
+        await File.WriteAllTextAsync(filePath, json);
+    }
+}


### PR DESCRIPTION
## Summary

Adds infrastructure for archiving raw AI responses as an audit trail (issue #340).

### What's included

**AiResponseArchiveEntry** (model) — Typed record capturing:
- Pipeline step and tool name
- SHA256 prompt hash
- Raw AI response text (pre-parsing)
- Model name, timestamp, token usage (prompt + completion)

**AiResponseArchiveWriter** (writer) — Async file writer:
- Writes to \{outputDir}/ai-responses/{step}-{toolName}.json\
- Creates directory if missing
- Idempotent — overwrites existing file for same step+tool
- Enabled by default; set \ARCHIVE_AI_RESPONSES=false\ (or \