### PR TITLE
feat: add CI workflow for prompt regression tests

### DIFF
--- a/.github/workflows/prompt-regression.yml
+++ b/.github/workflows/prompt-regression.yml
@@ -1,0 +1,38 @@
+name: Prompt Regression Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs-generation/**/prompts/**'
+      - 'prompt-regression.sh'
+      - 'docs-generation/DocGeneration.PromptRegression.Tests/**'
+  workflow_dispatch:
+
+jobs:
+  prompt-regression:
+    name: Prompt Regression Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore docs-generation/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj
+
+      - name: Build regression test project
+        run: dotnet build docs-generation/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj --no-restore --configuration Release
+
+      - name: Run prompt regression tests
+        run: dotnet test docs-generation/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj --no-build --configuration Release --logger "console;verbosity=detailed"
+        env:
+          FOUNDRY_API_KEY: ${{ secrets.FOUNDRY_API_KEY }}
+          FOUNDRY_ENDPOINT: ${{ secrets.FOUNDRY_ENDPOINT }}
+          FOUNDRY_MODEL_NAME: ${{ secrets.FOUNDRY_MODEL_NAME }}
+          FOUNDRY_MODEL_API_VERSION: ${{ secrets.FOUNDRY_MODEL_API_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **CI workflow for prompt regression testing** — New GitHub Actions workflow (`.github/workflows/prompt-regression.yml`) triggers on PRs modifying prompt files or regression test infrastructure. Supports manual dispatch. Runs prompt content and regression comparison tests against committed baselines. (#350)
+
 ### Changed
 
 - **Consolidated FindProjectRoot() into shared test utility** — Created `DocGeneration.TestInfrastructure` project with canonical `ProjectRootFinder` class (`FindSolutionRoot()`, `FindDocsGenerationRoot()`). Replaced 7 duplicate implementations across 5 test projects. (Issue #334)


### PR DESCRIPTION
Closes #350

## Changes
- New GitHub Actions workflow \.github/workflows/prompt-regression.yml\
- Triggers on PRs modifying prompt files (\docs-generation/**/prompts/**\) or regression test infrastructure
- Supports manual trigger via \workflow_dispatch\
- Runs prompt regression comparison tests against committed baselines
- Updated CHANGELOG.md

## Notes
- Does NOT run on every PR — only when prompt files change
- Uses existing \FOUNDRY_*\ secrets for AI credentials (same pattern as existing workflows)
- Bounded scope: only builds and tests the regression test project, not the full solution
- Tests gracefully skip when no candidates exist (baseline-only CI runs verify prompt content tests)