### PR TITLE
docs: add configuration registry and JSON schemas (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `start-azure-skills.sh` entry point script
 - 77 xUnit tests with 81.6% line coverage
 - Skills Generation CI workflow (`.github/workflows/skills-generation-ci.yml`)
+- JSON schemas for core configuration files in `docs-generation/data/schemas/` (#355)
+- Configuration registry document (`docs/configuration-registry.md`) (#355)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ To modify AI-generated content quality or style:
 | Document | Description |
 |----------|-------------|
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture, data flow, pipeline step details |
+| [docs/configuration-registry.md](docs/configuration-registry.md) | Configuration files inventory, load order, schemas, duplication analysis |
 | [docs/PRD-PipelineRunner.md](docs/PRD-PipelineRunner.md) | Product requirements for the typed .NET pipeline |
 | [docs-generation/README.md](docs-generation/README.md) | Generator implementation details |
 

--- a/docs-generation/data/schemas/brand-to-server-mapping.schema.json
+++ b/docs-generation/data/schemas/brand-to-server-mapping.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "brand-to-server-mapping.schema.json",
+  "title": "Brand-to-Server Mapping",
+  "description": "Maps MCP server namespace identifiers to Azure brand names, short names, filenames, and optional merge-group configuration for multi-namespace services.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["brandName", "mcpServerName", "shortName", "fileName"],
+    "properties": {
+      "brandName": {
+        "type": "string",
+        "description": "Official Azure product brand name (e.g. 'Azure Cosmos DB')."
+      },
+      "mcpServerName": {
+        "type": "string",
+        "description": "MCP CLI namespace identifier (e.g. 'cosmos'). Must be unique across the array.",
+        "pattern": "^[a-z][a-z0-9_]*$"
+      },
+      "shortName": {
+        "type": "string",
+        "description": "Abbreviated display name used in generated docs (e.g. 'Cosmos DB')."
+      },
+      "fileName": {
+        "type": "string",
+        "description": "Base filename for generated markdown (e.g. 'azure-cosmos-db'). No extension.",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "mergeGroup": {
+        "type": "string",
+        "description": "Group identifier for multi-namespace merge (e.g. 'azure-monitor'). All entries sharing a mergeGroup are merged into a single article.",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "mergeOrder": {
+        "type": "integer",
+        "description": "Position within the merge group. 1 = primary namespace.",
+        "minimum": 1
+      },
+      "mergeRole": {
+        "type": "string",
+        "description": "Role in the merge group. 'primary' owns frontmatter/overview; 'secondary' contributes tool sections only.",
+        "enum": ["primary", "secondary"]
+      }
+    },
+    "additionalProperties": false,
+    "dependencies": {
+      "mergeGroup": ["mergeOrder", "mergeRole"],
+      "mergeOrder": ["mergeGroup", "mergeRole"],
+      "mergeRole": ["mergeGroup", "mergeOrder"]
+    }
+  },
+  "minItems": 1,
+  "uniqueItems": true
+}

--- a/docs-generation/data/schemas/common-parameters.schema.json
+++ b/docs-generation/data/schemas/common-parameters.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "common-parameters.schema.json",
+  "title": "Common Parameters",
+  "description": "Parameters shared across most MCP tools (authentication, retry, subscription, resource-group). Optional common parameters are filtered from per-tool documentation tables; required ones are kept.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "type", "description", "isRequired"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "CLI parameter name including leading dashes (e.g. '--tenant').",
+        "pattern": "^--[a-z][a-z0-9-]*$"
+      },
+      "type": {
+        "type": "string",
+        "description": "JSON-Schema-style type of the parameter value.",
+        "enum": ["string", "number", "integer", "boolean"]
+      },
+      "description": {
+        "type": "string",
+        "description": "Human-readable description of the parameter.",
+        "minLength": 10
+      },
+      "isRequired": {
+        "type": "boolean",
+        "description": "Whether the parameter is required. Common parameters are usually optional (false)."
+      }
+    },
+    "additionalProperties": false
+  },
+  "minItems": 1
+}

--- a/docs-generation/data/schemas/compound-words.schema.json
+++ b/docs-generation/data/schemas/compound-words.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "compound-words.schema.json",
+  "title": "Compound Words",
+  "description": "Maps concatenated CLI token fragments to their hyphenated or expanded forms for include-file filename generation. Keys are the source token (lowercase); values are the replacement.",
+  "type": "object",
+  "patternProperties": {
+    "^[a-z][a-z0-9-]*$": {
+      "type": "string",
+      "description": "Hyphenated or expanded replacement (e.g. 'activitylog' → 'activity-log').",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false,
+  "minProperties": 1
+}

--- a/docs-generation/data/schemas/nl-parameters.schema.json
+++ b/docs-generation/data/schemas/nl-parameters.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "nl-parameters.schema.json",
+  "title": "Natural Language Parameters",
+  "description": "Maps CLI parameter names to human-readable natural-language equivalents used in generated documentation text.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["Parameter", "NaturalLanguage"],
+    "properties": {
+      "Parameter": {
+        "type": "string",
+        "description": "CLI parameter name or identifier (without leading dashes).",
+        "minLength": 1
+      },
+      "NaturalLanguage": {
+        "type": "string",
+        "description": "Human-readable replacement text.",
+        "minLength": 1
+      }
+    },
+    "additionalProperties": false
+  },
+  "minItems": 1
+}

--- a/docs-generation/data/schemas/static-text-replacement.schema.json
+++ b/docs-generation/data/schemas/static-text-replacement.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "static-text-replacement.schema.json",
+  "title": "Static Text Replacement",
+  "description": "Find-and-replace pairs applied to generated documentation text. Used for terminology standardization (e.g. 'Azure AD' → 'Microsoft Entra ID'), style corrections, and acronym normalization. The 'Parameter' field is the search string; 'NaturalLanguage' is the replacement.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["Parameter", "NaturalLanguage"],
+    "properties": {
+      "Parameter": {
+        "type": "string",
+        "description": "Text to find (case-sensitive match).",
+        "minLength": 1
+      },
+      "NaturalLanguage": {
+        "type": "string",
+        "description": "Replacement text.",
+        "minLength": 1
+      }
+    },
+    "additionalProperties": false
+  },
+  "minItems": 1
+}

--- a/docs-generation/data/schemas/stop-words.schema.json
+++ b/docs-generation/data/schemas/stop-words.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "stop-words.schema.json",
+  "title": "Stop Words",
+  "description": "Lowercase words removed from include-file filenames during filename generation (e.g. 'a', 'the', 'and').",
+  "type": "array",
+  "items": {
+    "type": "string",
+    "description": "A stop word to strip from filenames.",
+    "minLength": 1,
+    "pattern": "^[a-z]+$"
+  },
+  "minItems": 1,
+  "uniqueItems": true
+}

--- a/docs/configuration-registry.md
+++ b/docs/configuration-registry.md
@@ -1,0 +1,104 @@
+# Configuration Registry
+
+> Inventory, load order, and schema coverage for all JSON configuration files in `docs-generation/data/`.
+
+## Configuration files inventory
+
+| File | Purpose | Loader class(es) | Used by step(s) | Entry count | Has schema? |
+|------|---------|-------------------|------------------|-------------|-------------|
+| `brand-to-server-mapping.json` | Maps MCP namespace → Azure brand name, short name, filename, merge config | `DataFileLoader`, `ToolFileNameBuilder`, `CleanupGenerator`, `BootstrapStep` | 0 (Bootstrap), 1, 3, 4, 6 | ~52 entries | Yes |
+| `common-parameters.json` | Shared CLI parameters filtered from per-tool tables (auth, retry, subscription) | `DataFileLoader`, `DocumentationGenerator` | 1 (Annotations) | 9 entries | Yes |
+| `compound-words.json` | Concatenated CLI tokens → hyphenated forms for filename generation | `DataFileLoader`, `ToolFileNameBuilder` | 0, 1 | ~23 entries | Yes |
+| `stop-words.json` | Words removed from generated include filenames | `DataFileLoader`, `ToolFileNameBuilder` | 0, 1 | 5 entries | Yes |
+| `nl-parameters.json` | CLI parameter names → human-readable text | `TextCleanup`, `Config` | 1 (Annotations) | 4 entries | Yes |
+| `nl-parameter-identifiers.json` | Single-word identifiers → "X name" expansions | `TextCleanup` (auto-discovered) | 1 (Annotations) | ~19 entries | No |
+| `static-text-replacement.json` | Find/replace pairs for terminology standardization | `TextCleanup`, `Config`, `ArticleContentProcessor` | 1, 4, 6 | ~31 entries | Yes |
+| `acronym-definitions.json` | Acronym → expansion mappings with optional context patterns | `AcronymExpander` | 4 (Tool Family Cleanup) | ~10 entries | No |
+| `service-doc-links.json` | Namespace → service documentation URL, title, SEO description | `CleanupGenerator` | 4 (Tool Family Cleanup) | ~52 entries | No |
+| `transformation-config.json` | Declares required data files for horizontal article generator | `ConfigLoader` | 6 (Horizontal Articles) | 2 entries | No |
+| `config.json` | Declares required data files for annotation generator | `Config` | 1 (Annotations) | 2 entries | No |
+
+## Load order
+
+Configuration files are loaded at different pipeline stages. The table below shows the order.
+
+### Step 0 — Bootstrap (global, runs once)
+
+1. **`brand-to-server-mapping.json`** — loaded by `BootstrapStep` to validate all CLI namespaces have brand mappings and to copy the file to temp directories for downstream use.
+
+### Step 1 — Annotations, Parameters, Raw Tools (per namespace)
+
+1. **`config.json`** — loaded by `Config.Load()` to discover paths of required data files.
+2. **`brand-to-server-mapping.json`** — loaded by `DataFileLoader.LoadBrandMappingsAsync()`.
+3. **`common-parameters.json`** — loaded by `DataFileLoader.LoadCommonParametersAsync()`.
+4. **`compound-words.json`** — loaded by `DataFileLoader.LoadCompoundWordsAsync()`.
+5. **`stop-words.json`** — loaded by `DataFileLoader.LoadStopWordsAsync()`.
+6. **`nl-parameters.json`** — loaded by `TextCleanup.LoadFiles()`.
+7. **`nl-parameter-identifiers.json`** — auto-discovered from same directory as `nl-parameters.json`.
+8. **`static-text-replacement.json`** — loaded by `TextCleanup.LoadFiles()`.
+
+### Step 4 — Tool Family Cleanup (per namespace)
+
+1. **`brand-to-server-mapping.json`** — loaded by `CleanupGenerator.Initialize()`.
+2. **`service-doc-links.json`** — loaded by `CleanupGenerator.Initialize()`.
+3. **`acronym-definitions.json`** — loaded by `AcronymExpander.LoadDefinitions()` (with 3-path fallback).
+
+### Step 6 — Horizontal Articles (per namespace)
+
+1. **`transformation-config.json`** — loaded by `ConfigLoader.LoadAsync()`.
+2. **`brand-to-server-mapping.json`** — loaded for brand resolution.
+3. **`static-text-replacement.json`** — loaded for `ArticleContentProcessor` transformations.
+
+## Duplicate data analysis
+
+Several files contain overlapping data or serve similar purposes under different structures.
+
+| Data overlap | Files involved | Details |
+|-------------|---------------|---------|
+| Brand name mapping | `brand-to-server-mapping.json`, `service-doc-links.json` | Both are keyed on MCP namespace. `service-doc-links.json` duplicates the namespace→brand relationship and adds URL/SEO fields. Both files must be updated when a new namespace is added. |
+| Static text replacements | `static-text-replacement.json`, `nl-parameters.json` | Both use `{ "Parameter": "...", "NaturalLanguage": "..." }` schema. `static-text-replacement` handles broad text corrections; `nl-parameters` handles parameter-name-to-display mappings. Loaded by the same `TextCleanup` class. |
+| Identifier expansions | `nl-parameter-identifiers.json`, `nl-parameters.json` | Both map short tokens to human-readable text. `nl-parameter-identifiers` adds the suffix "name" (e.g. `account` → `Account name`). Same schema and same loader. |
+| Required-files declarations | `config.json`, `transformation-config.json` | Both declare `RequiredFiles` arrays pointing to other data files. `config.json` serves Step 1; `transformation-config.json` serves Step 6. Identical structure with different consumers. |
+| VMSS expansion | `static-text-replacement.json`, `acronym-definitions.json` | Both define VMSS → "virtual machine scale set" mappings, though in different formats and for different processing stages. |
+
+## Schema coverage
+
+| File | Schema | Status |
+|------|--------|--------|
+| `brand-to-server-mapping.json` | `schemas/brand-to-server-mapping.schema.json` | ✅ Covered |
+| `common-parameters.json` | `schemas/common-parameters.schema.json` | ✅ Covered |
+| `compound-words.json` | `schemas/compound-words.schema.json` | ✅ Covered |
+| `stop-words.json` | `schemas/stop-words.schema.json` | ✅ Covered |
+| `nl-parameters.json` | `schemas/nl-parameters.schema.json` | ✅ Covered |
+| `static-text-replacement.json` | `schemas/static-text-replacement.schema.json` | ✅ Covered |
+| `nl-parameter-identifiers.json` | — | ❌ Needs schema (same structure as `nl-parameters.json`; can `$ref` it) |
+| `acronym-definitions.json` | — | ❌ Needs schema |
+| `service-doc-links.json` | — | ❌ Needs schema |
+| `transformation-config.json` | — | ❌ Needs schema |
+| `config.json` | — | ❌ Needs schema |
+
+## Recommendations
+
+### 1. Merge `service-doc-links.json` into `brand-to-server-mapping.json`
+
+`service-doc-links.json` is keyed by namespace and adds `title`, `url`, and `seoDescription`. These fields could be added directly to each entry in `brand-to-server-mapping.json`, eliminating a 52-entry duplicate file and the need to keep both in sync when namespaces are added or renamed.
+
+### 2. Merge `nl-parameter-identifiers.json` into `nl-parameters.json`
+
+Both files share the same `{ "Parameter", "NaturalLanguage" }` schema and are loaded by `TextCleanup`. They could be a single array (or two sections within one file) to reduce the number of files and simplify discovery.
+
+### 3. Unify `config.json` and `transformation-config.json`
+
+Both files have the same `{ "RequiredFiles": [...] }` structure. A single file with step-keyed sections (e.g. `"step1": { ... }, "step6": { ... }`) would be easier to maintain.
+
+### 4. Use `$ref` for shared schemas
+
+`nl-parameters.json`, `nl-parameter-identifiers.json`, and `static-text-replacement.json` all use the same `{ "Parameter", "NaturalLanguage" }` item schema. Define a shared `parameter-nl-pair.schema.json` and use `$ref` from all three schemas to avoid structural drift.
+
+### 5. Add schemas for remaining files
+
+Priority order for the five uncovered files:
+1. `service-doc-links.json` — large file (52 entries), frequently edited
+2. `acronym-definitions.json` — has optional fields (`ContextPattern`, `ExpandedForm`) that are easy to misconfigure
+3. `nl-parameter-identifiers.json` — can reuse `nl-parameters.schema.json` via `$ref`
+4. `config.json` / `transformation-config.json` — small files, low risk


### PR DESCRIPTION
## Summary

Closes #355 — Create configuration registry with JSON schema validation.

### Changes

- **6 JSON Schema files** (`docs-generation/data/schemas/`): Draft-07 schemas for `brand-to-server-mapping.json`, `common-parameters.json`, `compound-words.json`, `stop-words.json`, `nl-parameters.json`, `static-text-replacement.json`  
- **Configuration registry** (`docs/configuration-registry.md`): Inventory of all 11 data files, loader classes, pipeline step usage, load order, duplicate data analysis, schema coverage, and consolidation recommendations  
- **CHANGELOG.md** and **README.md** updated

### Testing

Documentation-only change; no code modified. All schemas validated as parseable JSON.