### PR TITLE
chore: remove unused files and migrate NUnit to xUnit (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 - Deleted unused `test_coverage.cs` and `test_coverage.csx` from repository root (#349)
+- Removed unused NUnit and NUnit3TestAdapter from central package management (#349)
 
 ### Changed
 
-- **Consolidated FindProjectRoot() into shared test utility** — Created `DocGeneration.TestInfrastructure` project with canonical `ProjectRootFinder` class (`FindSolutionRoot()`, `FindDocsGenerationRoot()`). Replaced 7 duplicate implementations across 5 test projects. (Issue #334)
+- Migrated 3 NUnit test projects (SkillsRelevance, TextTransformation, HorizontalArticles) to xUnit for framework consistency (#349)
+- **Consolidated FindProjectRoot() into shared test utility**— Created `DocGeneration.TestInfrastructure` project with canonical `ProjectRootFinder` class (`FindSolutionRoot()`, `FindDocsGenerationRoot()`). Replaced 7 duplicate implementations across 5 test projects. (Issue #334)
 
 ### Fixed
 

--- a/docs-generation/Directory.Packages.props
+++ b/docs-generation/Directory.Packages.props
@@ -4,8 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Testing packages -->
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/docs-generation/DocGeneration.Core.TextTransformation.Tests/ConfigLoaderTests.cs
+++ b/docs-generation/DocGeneration.Core.TextTransformation.Tests/ConfigLoaderTests.cs
@@ -1,21 +1,18 @@
-using NUnit.Framework;
+using Xunit;
 using Azure.Mcp.TextTransformation.Models;
 
 namespace Azure.Mcp.TextTransformation.Tests;
 
-[TestFixture]
-public class ConfigLoaderTests
+public class ConfigLoaderTests : IDisposable
 {
-    private string _testConfigPath = null!;
+    private readonly string _testConfigPath;
 
-    [SetUp]
-    public void Setup()
+    public ConfigLoaderTests()
     {
         _testConfigPath = Path.Combine(Path.GetTempPath(), "test-transformation-config.json");
     }
 
-    [TearDown]
-    public void Teardown()
+    public void Dispose()
     {
         if (File.Exists(_testConfigPath))
         {
@@ -23,7 +20,7 @@ public class ConfigLoaderTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task LoadAsync_WithValidConfig_LoadsSuccessfully()
     {
         // Arrange
@@ -48,23 +45,23 @@ public class ConfigLoaderTests
         var config = await loader.LoadAsync();
 
         // Assert
-        Assert.That(config, Is.Not.Null);
-        Assert.That(config.Lexicon.Acronyms.ContainsKey("id"), Is.True);
-        Assert.That(config.Lexicon.Acronyms["id"].Canonical, Is.EqualTo("ID"));
-        Assert.That(config.Lexicon.StopWords.Count, Is.EqualTo(2));
+        Assert.NotNull(config);
+        Assert.True(config.Lexicon.Acronyms.ContainsKey("id"));
+        Assert.Equal("ID", config.Lexicon.Acronyms["id"].Canonical);
+        Assert.Equal(2, config.Lexicon.StopWords.Count);
     }
 
-    [Test]
-    public void LoadAsync_WithMissingFile_ThrowsFileNotFoundException()
+    [Fact]
+    public async Task LoadAsync_WithMissingFile_ThrowsFileNotFoundException()
     {
         // Arrange
         var loader = new ConfigLoader("/nonexistent/path/config.json");
 
         // Act & Assert
-        Assert.ThrowsAsync<FileNotFoundException>(async () => await loader.LoadAsync());
+        await Assert.ThrowsAsync<FileNotFoundException>(async () => await loader.LoadAsync());
     }
 
-    [Test]
+    [Fact]
     public async Task LoadAsync_ResolvesLexiconReferences()
     {
         // Arrange
@@ -93,10 +90,10 @@ public class ConfigLoaderTests
         var config = await loader.LoadAsync();
 
         // Assert
-        Assert.That(config.Services.Mappings[0].ShortName, Is.EqualTo("AKS"));
+        Assert.Equal("AKS", config.Services.Mappings[0].ShortName);
     }
 
-    [Test]
+    [Fact]
     public async Task LoadAsync_CachesConfiguration()
     {
         // Arrange
@@ -109,6 +106,6 @@ public class ConfigLoaderTests
         var config2 = await loader.LoadAsync();
 
         // Assert
-        Assert.That(config1, Is.SameAs(config2));
+        Assert.Same(config1, config2);
     }
 }

--- a/docs-generation/DocGeneration.Core.TextTransformation.Tests/DocGeneration.Core.TextTransformation.Tests.csproj
+++ b/docs-generation/DocGeneration.Core.TextTransformation.Tests/DocGeneration.Core.TextTransformation.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.Core.TextTransformation\DocGeneration.Core.TextTransformation.csproj" />

--- a/docs-generation/DocGeneration.Core.TextTransformation.Tests/FilenameGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Core.TextTransformation.Tests/FilenameGeneratorTests.cs
@@ -1,17 +1,15 @@
-using NUnit.Framework;
+using Xunit;
 using Azure.Mcp.TextTransformation.Models;
 using Azure.Mcp.TextTransformation.Services;
 
 namespace Azure.Mcp.TextTransformation.Tests;
 
-[TestFixture]
 public class FilenameGeneratorTests
 {
-    private TransformationConfig _config = null!;
-    private FilenameGenerator _generator = null!;
+    private readonly TransformationConfig _config;
+    private readonly FilenameGenerator _generator;
 
-    [SetUp]
-    public void Setup()
+    public FilenameGeneratorTests()
     {
         _config = new TransformationConfig
         {
@@ -32,9 +30,9 @@ public class FilenameGeneratorTests
             {
                 Mappings = new List<ServiceMapping>
                 {
-                    new ServiceMapping 
-                    { 
-                        McpName = "aks", 
+                    new ServiceMapping
+                    {
+                        McpName = "aks",
                         ShortName = "aks",
                         Filename = "azure-kubernetes-service"
                     },
@@ -57,103 +55,73 @@ public class FilenameGeneratorTests
         _generator = new FilenameGenerator(_config);
     }
 
-    [Test]
+    [Fact]
     public void GenerateFilename_Tier1_UsesBrandMapping()
     {
-        // Act
         var filename = _generator.GenerateFilename("aks", "get-cluster", "annotations");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("azure-kubernetes-service-get-cluster-annotations.md"));
+        Assert.Equal("azure-kubernetes-service-get-cluster-annotations.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void GenerateFilename_Tier2_UsesCompoundWords()
     {
-        // Act
         var filename = _generator.GenerateFilename("nodepool", "list", "parameters");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("node-pool-list-parameters.md"));
+        Assert.Equal("node-pool-list-parameters.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void GenerateFilename_Tier3_UsesOriginalName()
     {
-        // Act
         var filename = _generator.GenerateFilename("unknown", "operation", "type");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("unknown-operation-type.md"));
+        Assert.Equal("unknown-operation-type.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void CleanFilename_RemovesStopWords()
     {
-        // Act
         var cleaned = _generator.CleanFilename("get-a-list-of-the-items");
-
-        // Assert
-        Assert.That(cleaned, Is.EqualTo("get-list-items"));
+        Assert.Equal("get-list-items", cleaned);
     }
 
-    [Test]
+    [Fact]
     public void CleanFilename_LowercasesAcronyms_WhenCategoryDefaultApplies()
     {
-        // Act
         var cleaned = _generator.CleanFilename("AKS-cluster-VM");
-
-        // Assert
-        Assert.That(cleaned, Is.EqualTo("aks-cluster-vm"));
+        Assert.Equal("aks-cluster-vm", cleaned);
     }
 
-    [Test]
+    [Fact]
     public void GenerateMainServiceFilename_UsesBrandMappingFilename()
     {
-        // Act
         var filename = _generator.GenerateMainServiceFilename("aks");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("azure-kubernetes-service.md"));
+        Assert.Equal("azure-kubernetes-service.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void GenerateMainServiceFilename_UsesShortName_WhenFilenameNotSet()
     {
-        // Act
         var filename = _generator.GenerateMainServiceFilename("storage");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("storage.md"));
+        Assert.Equal("storage.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void GenerateMainServiceFilename_UsesOriginalName_WhenNoMapping()
     {
-        // Act
         var filename = _generator.GenerateMainServiceFilename("unknown");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo("unknown.md"));
+        Assert.Equal("unknown.md", filename);
     }
 
-    [Test]
+    [Fact]
     public void GenerateFilename_WithEmptyAreaName_ReturnsEmpty()
     {
-        // Act
         var filename = _generator.GenerateFilename("");
-
-        // Assert
-        Assert.That(filename, Is.EqualTo(string.Empty));
+        Assert.Equal(string.Empty, filename);
     }
 
-    [Test]
+    [Fact]
     public void CleanFilename_HandlesMultipleSeparators()
     {
-        // Act
         var cleaned = _generator.CleanFilename("some_mixed-name with spaces");
-
-        // Assert
-        Assert.That(cleaned, Is.EqualTo("some-mixed-name-with-spaces"));
+        Assert.Equal("some-mixed-name-with-spaces", cleaned);
     }
 }

--- a/docs-generation/DocGeneration.Core.TextTransformation.Tests/TransformationEngineTests.cs
+++ b/docs-generation/DocGeneration.Core.TextTransformation.Tests/TransformationEngineTests.cs
@@ -1,17 +1,15 @@
-using NUnit.Framework;
+using Xunit;
 using Azure.Mcp.TextTransformation.Models;
 using Azure.Mcp.TextTransformation.Services;
 
 namespace Azure.Mcp.TextTransformation.Tests;
 
-[TestFixture]
 public class TransformationEngineTests
 {
-    private TransformationConfig _config = null!;
-    private TransformationEngine _engine = null!;
+    private readonly TransformationConfig _config;
+    private readonly TransformationEngine _engine;
 
-    [SetUp]
-    public void Setup()
+    public TransformationEngineTests()
     {
         _config = new TransformationConfig
         {
@@ -32,9 +30,9 @@ public class TransformationEngineTests
             {
                 Mappings = new List<ServiceMapping>
                 {
-                    new ServiceMapping 
-                    { 
-                        McpName = "aks", 
+                    new ServiceMapping
+                    {
+                        McpName = "aks",
                         ShortName = "AKS",
                         BrandName = "Azure Kubernetes Service"
                     }
@@ -55,162 +53,97 @@ public class TransformationEngineTests
         _engine = new TransformationEngine(_config);
     }
 
-    [Test]
+    [Fact]
     public void GetServiceDisplayName_WithMapping_ReturnsBrandName()
     {
-        // Act
-        var displayName = _engine.GetServiceDisplayName("aks");
-
-        // Assert
-        Assert.That(displayName, Is.EqualTo("Azure Kubernetes Service"));
+        Assert.Equal("Azure Kubernetes Service", _engine.GetServiceDisplayName("aks"));
     }
 
-    [Test]
+    [Fact]
     public void GetServiceDisplayName_WithoutMapping_ReturnsTitleCase()
     {
-        // Act
-        var displayName = _engine.GetServiceDisplayName("storage");
-
-        // Assert
-        Assert.That(displayName, Is.EqualTo("Storage"));
+        Assert.Equal("Storage", _engine.GetServiceDisplayName("storage"));
     }
 
-    [Test]
+    [Fact]
     public void GetServiceShortName_WithMapping_ReturnsShortName()
     {
-        // Act
-        var shortName = _engine.GetServiceShortName("aks");
-
-        // Assert
-        Assert.That(shortName, Is.EqualTo("AKS"));
+        Assert.Equal("AKS", _engine.GetServiceShortName("aks"));
     }
 
-    [Test]
+    [Fact]
     public void GetServiceShortName_WithoutMapping_ReturnsMcpName()
     {
-        // Act
-        var shortName = _engine.GetServiceShortName("storage");
-
-        // Assert
-        Assert.That(shortName, Is.EqualTo("storage"));
+        Assert.Equal("storage", _engine.GetServiceShortName("storage"));
     }
 
-    [Test]
+    [Fact]
     public void TransformDescription_ReplacesAbbreviations()
     {
-        // Arrange
-        var description = "This is an example eg a test";
-
-        // Act
-        var transformed = _engine.TransformDescription(description);
-
-        // Assert
-        Assert.That(transformed, Does.Contain("e.g."));
+        var transformed = _engine.TransformDescription("This is an example eg a test");
+        Assert.Contains("e.g.", transformed);
     }
 
-    [Test]
+    [Fact]
     public void TransformDescription_EnsuresEndsPeriod()
     {
-        // Arrange
-        var description = "This is a test";
-
-        // Act
-        var transformed = _engine.TransformDescription(description);
-
-        // Assert
-        Assert.That(transformed, Does.EndWith("."));
+        var transformed = _engine.TransformDescription("This is a test");
+        Assert.EndsWith(".", transformed);
     }
 
-    [Test]
+    [Fact]
     public void TransformDescription_DoesNotAddPeriod_WhenAlreadyPresent()
     {
-        // Arrange
-        var description = "This is a test.";
-
-        // Act
-        var transformed = _engine.TransformDescription(description);
-
-        // Assert
-        Assert.That(transformed, Is.EqualTo("This is a test."));
+        var transformed = _engine.TransformDescription("This is a test.");
+        Assert.Equal("This is a test.", transformed);
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_NormalizeParameter_UsesMappingWhenAvailable()
     {
-        // Act
-        var normalized = _engine.TextNormalizer.NormalizeParameter("subscriptionId");
-
-        // Assert
-        Assert.That(normalized, Is.EqualTo("subscription ID"));
+        Assert.Equal("subscription ID", _engine.TextNormalizer.NormalizeParameter("subscriptionId"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_SplitAndTransformProgrammaticName_SplitsCamelCase()
     {
-        // Act
-        var transformed = _engine.TextNormalizer.SplitAndTransformProgrammaticName("resourceGroupName");
-
-        // Assert
-        Assert.That(transformed, Is.EqualTo("resource group name"));
+        Assert.Equal("resource group name", _engine.TextNormalizer.SplitAndTransformProgrammaticName("resourceGroupName"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_SplitAndTransformProgrammaticName_HandlesAcronyms()
     {
-        // Act
-        var transformed = _engine.TextNormalizer.SplitAndTransformProgrammaticName("vmId");
-
-        // Assert
-        Assert.That(transformed, Is.EqualTo("VM ID"));
+        Assert.Equal("VM ID", _engine.TextNormalizer.SplitAndTransformProgrammaticName("vmId"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_ToTitleCase_PreservesAcronyms()
     {
-        // Act
-        var titleCase = _engine.TextNormalizer.ToTitleCase("get vm id");
-
-        // Assert
-        Assert.That(titleCase, Is.EqualTo("Get VM ID"));
+        Assert.Equal("Get VM ID", _engine.TextNormalizer.ToTitleCase("get vm id"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_ToTitleCase_LowercasesStopWords()
     {
-        // Act
-        var titleCase = _engine.TextNormalizer.ToTitleCase("get a list of the items", "titleCase");
-
-        // Assert
-        Assert.That(titleCase, Is.EqualTo("Get a List of the Items"));
+        Assert.Equal("Get a List of the Items", _engine.TextNormalizer.ToTitleCase("get a list of the items", "titleCase"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_ToTitleCase_CapitalizesFirstStopWord()
     {
-        // Act
-        var titleCase = _engine.TextNormalizer.ToTitleCase("a list of items", "titleCase");
-
-        // Assert
-        Assert.That(titleCase, Is.EqualTo("A List of Items"));
+        Assert.Equal("A List of Items", _engine.TextNormalizer.ToTitleCase("a list of items", "titleCase"));
     }
 
-    [Test]
+    [Fact]
     public void TextNormalizer_ReplaceStaticText_HandlesMultipleReplacements()
     {
-        // Arrange
-        var text = "Use eg for examples";
-
-        // Act
-        var replaced = _engine.TextNormalizer.ReplaceStaticText(text);
-
-        // Assert
-        Assert.That(replaced, Does.Contain("e.g."));
+        var replaced = _engine.TextNormalizer.ReplaceStaticText("Use eg for examples");
+        Assert.Contains("e.g.", replaced);
     }
 
-    [Test]
+    [Fact]
     public void Config_IsAccessible()
     {
-        // Assert
-        Assert.That(_engine.Config, Is.SameAs(_config));
+        Assert.Same(_config, _engine.Config);
     }
 }

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorTransformationTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorTransformationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
+using Xunit;
 using Azure.Mcp.TextTransformation.Models;
 using Azure.Mcp.TextTransformation.Services;
 using HorizontalArticleGenerator.Generators;
@@ -9,14 +9,12 @@ using HorizontalArticleGenerator.Models;
 
 namespace HorizontalArticleGenerator.Tests;
 
-[TestFixture]
 public class ArticleContentProcessorTransformationTests
 {
-    private TransformationEngine _engine = null!;
-    private ArticleContentProcessor _processor = null!;
+    private readonly TransformationEngine _engine;
+    private readonly ArticleContentProcessor _processor;
 
-    [SetUp]
-    public void Setup()
+    public ArticleContentProcessorTransformationTests()
     {
         var config = new TransformationConfig
         {
@@ -41,7 +39,7 @@ public class ArticleContentProcessorTransformationTests
 
     // ===== Core bug: TransformDescription adds periods, TransformText does not =====
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_ServiceShortDescription_DoesNotGetTrailingPeriod()
     {
         var data = CreateMinimalData();
@@ -49,11 +47,11 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.ServiceShortDescription, Does.Not.EndWith("."));
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("web applications and database connections"));
+        Assert.False(data.ServiceShortDescription.EndsWith("."));
+        Assert.Equal("web applications and database connections", data.ServiceShortDescription);
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_ServiceOverview_GetsTrailingPeriod()
     {
         var data = CreateMinimalData();
@@ -61,10 +59,10 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.ServiceOverview, Does.EndWith("."));
+        Assert.EndsWith(".", data.ServiceOverview);
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_Capabilities_DoNotGetTrailingPeriods()
     {
         var data = CreateMinimalData();
@@ -79,11 +77,11 @@ public class ArticleContentProcessorTransformationTests
 
         foreach (var cap in data.Capabilities)
         {
-            Assert.That(cap, Does.Not.EndWith("."), $"Capability should not end with period: '{cap}'");
+            Assert.False(cap.EndsWith("."), $"Capability should not end with period: '{cap}'");
         }
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_BestPracticeTitles_DoNotGetTrailingPeriods()
     {
         var data = CreateMinimalData();
@@ -99,12 +97,12 @@ public class ArticleContentProcessorTransformationTests
 
         foreach (var bp in data.BestPractices)
         {
-            Assert.That(bp.Title, Does.Not.EndWith("."), $"Best practice title should not end with period: '{bp.Title}'");
-            Assert.That(bp.Description, Does.EndWith("."), $"Best practice description should end with period: '{bp.Description}'");
+            Assert.False(bp.Title.EndsWith("."), $"Best practice title should not end with period: '{bp.Title}'");
+            Assert.True(bp.Description.EndsWith("."), $"Best practice description should end with period: '{bp.Description}'");
         }
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_ScenarioTitles_DoNotGetTrailingPeriods()
     {
         var data = CreateMinimalData();
@@ -121,12 +119,12 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.Scenarios[0].Title, Does.Not.EndWith("."));
-        Assert.That(data.Scenarios[0].Description, Does.EndWith("."));
-        Assert.That(data.Scenarios[0].ExpectedOutcome, Does.EndWith("."));
+        Assert.False(data.Scenarios[0].Title.EndsWith("."));
+        Assert.EndsWith(".", data.Scenarios[0].Description);
+        Assert.EndsWith(".", data.Scenarios[0].ExpectedOutcome);
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_PrerequisiteDescriptions_GetTrailingPeriods()
     {
         var data = CreateMinimalData();
@@ -137,10 +135,10 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.ServiceSpecificPrerequisites[0].Description, Does.EndWith("."));
+        Assert.EndsWith(".", data.ServiceSpecificPrerequisites[0].Description);
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_RolePurposes_GetTrailingPeriods()
     {
         var data = CreateMinimalData();
@@ -151,12 +149,12 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.RequiredRoles[0].Purpose, Does.EndWith("."));
+        Assert.EndsWith(".", data.RequiredRoles[0].Purpose);
     }
 
     // ===== Static text replacement integration =====
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_ReplacesAzureActiveDirectory_WithEntraID()
     {
         var data = CreateMinimalData();
@@ -170,12 +168,12 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.BestPractices[0].Title, Is.EqualTo("Use Microsoft Entra ID"));
-        Assert.That(data.BestPractices[0].Description, Does.Contain("Microsoft Entra ID"));
-        Assert.That(data.BestPractices[0].Description, Does.Not.Contain("Azure Active Directory"));
+        Assert.Equal("Use Microsoft Entra ID", data.BestPractices[0].Title);
+        Assert.Contains("Microsoft Entra ID", data.BestPractices[0].Description);
+        Assert.DoesNotContain("Azure Active Directory", data.BestPractices[0].Description);
     }
 
-    [Test]
+    [Fact]
     public void ApplyTransformations_ReplacesAzureActiveDirectory_InServiceOverview()
     {
         var data = CreateMinimalData();
@@ -183,13 +181,13 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.ApplyTransformations(data);
 
-        Assert.That(data.ServiceOverview, Does.Contain("Microsoft Entra ID"));
-        Assert.That(data.ServiceOverview, Does.Not.Contain("Azure Active Directory"));
+        Assert.Contains("Microsoft Entra ID", data.ServiceOverview);
+        Assert.DoesNotContain("Azure Active Directory", data.ServiceOverview);
     }
 
     // ===== Full pipeline: Validate + Transform =====
 
-    [Test]
+    [Fact]
     public void Process_FullPipeline_ServiceShortDescription_NeverEndsWithPeriod()
     {
         // This is THE critical test — simulates the exact bug:
@@ -199,12 +197,12 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.Process(data, "TestService");
 
-        Assert.That(data.ServiceShortDescription, Does.Not.EndWith("."),
+        Assert.False(data.ServiceShortDescription.EndsWith("."),
             "After full pipeline, serviceShortDescription must NEVER end with a period");
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("web applications and APIs"));
+        Assert.Equal("web applications and APIs", data.ServiceShortDescription);
     }
 
-    [Test]
+    [Fact]
     public void Process_FullPipeline_Capabilities_NeverEndWithPeriods()
     {
         var data = CreateMinimalData();
@@ -219,12 +217,12 @@ public class ArticleContentProcessorTransformationTests
 
         foreach (var cap in data.Capabilities)
         {
-            Assert.That(cap, Does.Not.EndWith("."),
+            Assert.False(cap.EndsWith("."),
                 $"After full pipeline, capability must NOT end with period: '{cap}'");
         }
     }
 
-    [Test]
+    [Fact]
     public void Process_FullPipeline_BestPracticeTitles_NeverEndWithPeriods()
     {
         var data = CreateMinimalData();
@@ -240,12 +238,12 @@ public class ArticleContentProcessorTransformationTests
 
         foreach (var bp in data.BestPractices)
         {
-            Assert.That(bp.Title, Does.Not.EndWith("."),
+            Assert.False(bp.Title.EndsWith("."),
                 $"After full pipeline, best practice title must NOT end with period: '{bp.Title}'");
         }
     }
 
-    [Test]
+    [Fact]
     public void Process_FullPipeline_RenderedFrontmatter_HasNoBreak()
     {
         // End-to-end: simulate the template interpolation that was producing broken text
@@ -256,18 +254,18 @@ public class ArticleContentProcessorTransformationTests
 
         // Simulate template: description: Learn how to ... manage {{genai-serviceShortDescription}} through AI-powered ...
         var frontmatter = $"description: Learn how to use the Azure MCP Server to manage {data.ServiceShortDescription} through AI-powered natural language interactions.";
-        Assert.That(frontmatter, Does.Not.Contain(". through"));
+        Assert.DoesNotContain(". through", frontmatter);
 
         // Simulate template: Manage {{genai-serviceShortDescription}} using natural language ...
         var intro = $"Manage {data.ServiceShortDescription} using natural language conversations.";
-        Assert.That(intro, Does.Not.Contain(". using"));
+        Assert.DoesNotContain(". using", intro);
 
         // Simulate template: I want to manage {{genai-serviceShortDescription}} using natural language ...
         var customerIntent = $"I want to manage {data.ServiceShortDescription} using natural language conversations.";
-        Assert.That(customerIntent, Does.Not.Contain(". using"));
+        Assert.DoesNotContain(". using", customerIntent);
     }
 
-    [Test]
+    [Fact]
     public void Process_FullPipeline_OverviewStillGetsPeriod()
     {
         var data = CreateMinimalData();
@@ -275,8 +273,7 @@ public class ArticleContentProcessorTransformationTests
 
         _processor.Process(data, "TestService");
 
-        Assert.That(data.ServiceOverview, Does.EndWith("."),
-            "ServiceOverview is a full sentence and should end with a period");
+        Assert.EndsWith(".", data.ServiceOverview);
     }
 
     // ===== Helper =====

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorValidationTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorValidationTests.cs
@@ -1,19 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
+using Xunit;
 using HorizontalArticleGenerator.Generators;
 using HorizontalArticleGenerator.Models;
 
 namespace HorizontalArticleGenerator.Tests;
 
-[TestFixture]
 public class ArticleContentProcessorValidationTests
 {
-    private ArticleContentProcessor _processor = null!;
+    private readonly ArticleContentProcessor _processor;
 
-    [SetUp]
-    public void Setup()
+    public ArticleContentProcessorValidationTests()
     {
         // No transformation engine — tests pure validation logic
         _processor = new ArticleContentProcessor();
@@ -21,7 +19,7 @@ public class ArticleContentProcessorValidationTests
 
     // ===== Trailing Period Stripping =====
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriod_FromServiceShortDescription()
     {
         var data = CreateMinimalData();
@@ -29,11 +27,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("web applications and APIs"));
-        Assert.That(result.Corrections, Has.Some.Contains("serviceShortDescription"));
+        Assert.Equal("web applications and APIs", data.ServiceShortDescription);
+        Assert.Contains(result.Corrections, c => c.Contains("serviceShortDescription"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriodAndSpace_FromServiceShortDescription()
     {
         var data = CreateMinimalData();
@@ -41,10 +39,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("web applications and APIs"));
+        Assert.Equal("web applications and APIs", data.ServiceShortDescription);
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoChange_WhenServiceShortDescriptionHasNoPeriod()
     {
         var data = CreateMinimalData();
@@ -52,11 +50,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("keys, secrets, and certificates"));
-        Assert.That(result.Corrections, Has.None.Contains("serviceShortDescription"));
+        Assert.Equal("keys, secrets, and certificates", data.ServiceShortDescription);
+        Assert.DoesNotContain(result.Corrections, c => c.Contains("serviceShortDescription"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriods_FromAllCapabilities()
     {
         var data = CreateMinimalData();
@@ -69,12 +67,12 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.Capabilities[0], Is.EqualTo("Create and manage virtual machines"));
-        Assert.That(data.Capabilities[1], Is.EqualTo("Configure network security groups"));
-        Assert.That(data.Capabilities[2], Is.EqualTo("Monitor resource utilization metrics"));
+        Assert.Equal("Create and manage virtual machines", data.Capabilities[0]);
+        Assert.Equal("Configure network security groups", data.Capabilities[1]);
+        Assert.Equal("Monitor resource utilization metrics", data.Capabilities[2]);
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriods_FromBestPracticeTitles()
     {
         var data = CreateMinimalData();
@@ -88,13 +86,13 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.BestPractices[0].Title, Is.EqualTo("Use managed identities"));
-        Assert.That(data.BestPractices[1].Title, Is.EqualTo("Monitor performance"));
+        Assert.Equal("Use managed identities", data.BestPractices[0].Title);
+        Assert.Equal("Monitor performance", data.BestPractices[1].Title);
         // Descriptions should NOT be stripped (they are full sentences)
-        Assert.That(data.BestPractices[0].Description, Is.EqualTo("Desc."));
+        Assert.Equal("Desc.", data.BestPractices[0].Description);
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriods_FromPrerequisiteTitles()
     {
         var data = CreateMinimalData();
@@ -105,11 +103,11 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceSpecificPrerequisites[0].Title, Is.EqualTo("Existing Storage Account"));
-        Assert.That(data.ServiceSpecificPrerequisites[0].Description, Is.EqualTo("Required."));
+        Assert.Equal("Existing Storage Account", data.ServiceSpecificPrerequisites[0].Title);
+        Assert.Equal("Required.", data.ServiceSpecificPrerequisites[0].Description);
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsTrailingPeriods_FromScenarioTitles()
     {
         var data = CreateMinimalData();
@@ -126,12 +124,12 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.Scenarios[0].Title, Is.EqualTo("Add a database connection"));
+        Assert.Equal("Add a database connection", data.Scenarios[0].Title);
     }
 
     // ===== Broken Sentence Fix =====
 
-    [Test]
+    [Fact]
     public void Validate_FixesBrokenSentence_InServiceShortDescription()
     {
         var data = CreateMinimalData();
@@ -139,10 +137,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceShortDescription, Is.EqualTo("web applications and APIs"));
+        Assert.Equal("web applications and APIs", data.ServiceShortDescription);
     }
 
-    [Test]
+    [Fact]
     public void Validate_FixesBrokenSentence_InServiceOverview()
     {
         var data = CreateMinimalData();
@@ -150,10 +148,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceOverview, Is.EqualTo("is a platform for building apps"));
+        Assert.Equal("is a platform for building apps", data.ServiceOverview);
     }
 
-    [Test]
+    [Fact]
     public void Validate_PreservesLegitimateAbbreviations_InServiceOverview()
     {
         var data = CreateMinimalData();
@@ -162,12 +160,12 @@ public class ArticleContentProcessorValidationTests
         _processor.Validate(data, "Test");
 
         // "period + uppercase I" should NOT be modified
-        Assert.That(data.ServiceOverview, Is.EqualTo("is a platform. It provides scaling."));
+        Assert.Equal("is a platform. It provides scaling.", data.ServiceOverview);
     }
 
     // ===== Redundant Words =====
 
-    [Test]
+    [Fact]
     public void Validate_RemovesRedundantWord_AtStartOfOverview()
     {
         var data = CreateMinimalData();
@@ -175,10 +173,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceOverview, Is.EqualTo("Search enables full-text searching."));
+        Assert.Equal("Search enables full-text searching.", data.ServiceOverview);
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoChange_WhenNoRedundantWord()
     {
         var data = CreateMinimalData();
@@ -186,12 +184,12 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceOverview, Is.EqualTo("is a cloud search service."));
+        Assert.Equal("is a cloud search service.", data.ServiceOverview);
     }
 
     // ===== RBAC Role Validation =====
 
-    [Test]
+    [Fact]
     public void Validate_BlocksInventedRbacRoles()
     {
         var data = CreateMinimalData();
@@ -202,11 +200,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.True);
-        Assert.That(result.CriticalErrors, Has.Some.Contains("INVENTED RBAC ROLE"));
+        Assert.True(result.HasCriticalErrors);
+        Assert.Contains(result.CriticalErrors, e => e.Contains("INVENTED RBAC ROLE"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_AllowsOfficialRbacRoles()
     {
         var data = CreateMinimalData();
@@ -219,10 +217,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.False);
+        Assert.False(result.HasCriticalErrors);
     }
 
-    [Test]
+    [Fact]
     public void Validate_AllowsContributorReaderRoles()
     {
         var data = CreateMinimalData();
@@ -234,10 +232,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.False);
+        Assert.False(result.HasCriticalErrors);
     }
 
-    [Test]
+    [Fact]
     public void Validate_BlocksAdministratorSuffix()
     {
         // "Administrator" is never used in Azure built-in RBAC roles
@@ -249,11 +247,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.True);
-        Assert.That(result.CriticalErrors, Has.Some.Contains("Administrator"));
+        Assert.True(result.HasCriticalErrors);
+        Assert.Contains(result.CriticalErrors, e => e.Contains("Administrator"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_BlocksGenericPrefixRoles()
     {
         // "Database Contributor" is too generic — real role would be "SQL DB Contributor"
@@ -265,13 +263,14 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.True);
-        Assert.That(result.CriticalErrors, Has.Some.Contains("too generic"));
+        Assert.True(result.HasCriticalErrors);
+        Assert.Contains(result.CriticalErrors, e => e.Contains("too generic"));
     }
 
-    [TestCase("Database Reader")]
-    [TestCase("Application Contributor")]
-    [TestCase("Resource Contributor")]
+    [Theory]
+    [InlineData("Database Reader")]
+    [InlineData("Application Contributor")]
+    [InlineData("Resource Contributor")]
     public void Validate_BlocksVariousGenericPrefixRoles(string roleName)
     {
         var data = CreateMinimalData();
@@ -282,15 +281,16 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.True);
+        Assert.True(result.HasCriticalErrors);
     }
 
-    [TestCase("SQL DB Contributor")]
-    [TestCase("SQL Server Contributor")]
-    [TestCase("Website Contributor")]
-    [TestCase("Web Plan Contributor")]
-    [TestCase("Storage Account Contributor")]
-    [TestCase("Key Vault Contributor")]
+    [Theory]
+    [InlineData("SQL DB Contributor")]
+    [InlineData("SQL Server Contributor")]
+    [InlineData("Website Contributor")]
+    [InlineData("Web Plan Contributor")]
+    [InlineData("Storage Account Contributor")]
+    [InlineData("Key Vault Contributor")]
     public void Validate_AllowsOfficialServiceSpecificRoles(string roleName)
     {
         var data = CreateMinimalData();
@@ -301,12 +301,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.False);
+        Assert.False(result.HasCriticalErrors);
     }
 
     // ===== Tool Description Quality =====
 
-    [Test]
+    [Fact]
     public void Validate_WarnsOnShortToolDescription()
     {
         var data = CreateMinimalData();
@@ -317,10 +317,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.Some.Contains("too short"));
+        Assert.Contains(result.Warnings, w => w.Contains("too short"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_WarnsOnGenericToolDescription()
     {
         var data = CreateMinimalData();
@@ -331,10 +331,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.Some.Contains("generic description"));
+        Assert.Contains(result.Warnings, w => w.Contains("generic description"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoWarning_WhenToolDescriptionIsGoodQuality()
     {
         var data = CreateMinimalData();
@@ -345,13 +345,13 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.None.Contains("too short"));
-        Assert.That(result.Warnings, Has.None.Contains("generic description"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("too short"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("generic description"));
     }
 
     // ===== Best Practice Count =====
 
-    [Test]
+    [Fact]
     public void Validate_WarnsWhenFewerThanThreeBestPractices()
     {
         var data = CreateMinimalData();
@@ -363,10 +363,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.Some.Contains("best practices"));
+        Assert.Contains(result.Warnings, w => w.Contains("best practices"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoWarning_WhenThreeOrMoreBestPractices()
     {
         var data = CreateMinimalData();
@@ -380,12 +380,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.None.Contains("best practices"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("best practices"));
     }
 
     // ===== Combined: trailing period on serviceShortDescription mid-sentence =====
 
-    [Test]
+    [Fact]
     public void Validate_PreventsBrokenFrontmatter_WhenDescriptionHasTrailingPeriod()
     {
         // Simulates the exact bug: "manage web applications and APIs. through AI-powered"
@@ -396,11 +396,11 @@ public class ArticleContentProcessorValidationTests
 
         // After validation, the period should be gone
         var rendered = $"Learn how to manage {data.ServiceShortDescription} through AI-powered interactions.";
-        Assert.That(rendered, Does.Not.Contain(". through"));
-        Assert.That(rendered, Is.EqualTo("Learn how to manage web applications and APIs through AI-powered interactions."));
+        Assert.DoesNotContain(". through", rendered);
+        Assert.Equal("Learn how to manage web applications and APIs through AI-powered interactions.", rendered);
     }
 
-    [Test]
+    [Fact]
     public void Validate_PreventsBrokenIntro_WhenDescriptionHasTrailingPeriod()
     {
         // Simulates: "Manage web applications and APIs. using natural language"
@@ -410,13 +410,13 @@ public class ArticleContentProcessorValidationTests
         _processor.Validate(data, "Test");
 
         var rendered = $"Manage {data.ServiceShortDescription} using natural language conversations.";
-        Assert.That(rendered, Does.Not.Contain(". using"));
-        Assert.That(rendered, Is.EqualTo("Manage web applications and APIs using natural language conversations."));
+        Assert.DoesNotContain(". using", rendered);
+        Assert.Equal("Manage web applications and APIs using natural language conversations.", rendered);
     }
 
     // ===== Link URL Validation =====
 
-    [Test]
+    [Fact]
     public void Validate_StripsLearnPrefixFromServiceDocLink()
     {
         var data = CreateMinimalData();
@@ -424,11 +424,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.ServiceDocLink, Is.EqualTo("/azure/storage/blobs/overview"));
-        Assert.That(result.Corrections, Has.Some.Contains("Stripped learn.microsoft.com prefix from serviceDocLink"));
+        Assert.Equal("/azure/storage/blobs/overview", data.ServiceDocLink);
+        Assert.Contains(result.Corrections, c => c.Contains("Stripped learn.microsoft.com prefix from serviceDocLink"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_StripsLearnPrefixFromAdditionalLinks()
     {
         var data = CreateMinimalData();
@@ -440,11 +440,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks[0].Url, Is.EqualTo("/azure/key-vault/general/best-practices"));
-        Assert.That(result.Corrections, Has.Some.Contains("Stripped learn.microsoft.com prefix"));
+        Assert.Equal("/azure/key-vault/general/best-practices", data.AdditionalLinks[0].Url);
+        Assert.Contains(result.Corrections, c => c.Contains("Stripped learn.microsoft.com prefix"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_RemovesCatchAllServiceDocLink()
     {
         var data = CreateMinimalData();
@@ -452,11 +452,11 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Azure Extension", "extension");
 
-        Assert.That(data.ServiceDocLink, Is.Null);
-        Assert.That(result.Corrections, Has.Some.Contains("Removed invalid serviceDocLink for catch-all namespace 'extension'"));
+        Assert.Null(data.ServiceDocLink);
+        Assert.Contains(result.Corrections, c => c.Contains("Removed invalid serviceDocLink for catch-all namespace 'extension'"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_RemovesLinksWithFabricatedDocsPath()
     {
         var data = CreateMinimalData();
@@ -469,12 +469,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Partitioning Guide"));
-        Assert.That(result.Corrections, Has.Some.Contains("fabricated URL pattern"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Partitioning Guide", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("fabricated URL pattern"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_KeepsNonFabricatedLinks()
     {
         var data = CreateMinimalData();
@@ -487,10 +487,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(2));
+        Assert.Equal(2, data.AdditionalLinks.Count);
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoErrorWhenAdditionalLinksEmpty()
     {
         var data = CreateMinimalData();
@@ -499,12 +499,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.HasCriticalErrors, Is.False);
+        Assert.False(result.HasCriticalErrors);
     }
 
     // ===== Deduplicate Additional Links =====
 
-    [Test]
+    [Fact]
     public void Validate_RemovesDuplicateExactUrlMatch()
     {
         var data = CreateMinimalData();
@@ -517,12 +517,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Quickstart"));
-        Assert.That(result.Corrections, Has.Some.Contains("Removed duplicate additional link"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Quickstart", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("Removed duplicate additional link"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_RemovesDuplicateDocumentationTitle()
     {
         var data = CreateMinimalData();
@@ -535,12 +535,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Best Practices"));
-        Assert.That(result.Corrections, Has.Some.Contains("Removed duplicate additional link"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Best Practices", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("Removed duplicate additional link"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_KeepsLinksFromDifferentServiceArea()
     {
         var data = CreateMinimalData();
@@ -552,10 +552,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
+        Assert.Equal(1, data.AdditionalLinks.Count);
     }
 
-    [Test]
+    [Fact]
     public void Validate_KeepsNonDocumentationLinksInSameServiceArea()
     {
         var data = CreateMinimalData();
@@ -568,10 +568,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(2));
+        Assert.Equal(2, data.AdditionalLinks.Count);
     }
 
-    [Test]
+    [Fact]
     public void Validate_RemovesFabricatedAndDuplicateLinksEndToEnd()
     {
         // Verifies fabricated /docs path removal and near-duplicate detection together
@@ -586,14 +586,14 @@ public class ArticleContentProcessorValidationTests
         var result = _processor.Validate(data, "Test");
 
         // The fabricated /docs link should be removed
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Voice Gallery"));
-        Assert.That(result.Corrections, Has.Some.Contains("fabricated URL pattern").Or.Contains("Removed duplicate"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Voice Gallery", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("fabricated URL pattern") || c.Contains("Removed duplicate"));
     }
 
     // ===== Capability-to-Tool Ratio Validation =====
 
-    [Test]
+    [Fact]
     public void Validate_WarnsWhenCapabilitiesExceedToolCount()
     {
         var data = CreateMinimalData();
@@ -609,10 +609,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.Some.Contains("Capabilities (2) exceed tool count (1)"));
+        Assert.Contains(result.Warnings, w => w.Contains("Capabilities (2) exceed tool count (1)"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoWarningWhenCapabilitiesMatchToolCount()
     {
         var data = CreateMinimalData();
@@ -631,10 +631,10 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.None.Contains("exceed tool count"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("exceed tool count"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_NoWarningWhenSingleToolHasSingleCapability()
     {
         var data = CreateMinimalData();
@@ -649,12 +649,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(result.Warnings, Has.None.Contains("exceed tool count"));
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("exceed tool count"));
     }
 
     // ===== Empty URL Link Removal =====
 
-    [Test]
+    [Fact]
     public void Validate_RemovesLinksWithEmptyUrl()
     {
         var data = CreateMinimalData();
@@ -667,12 +667,12 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Metrics Overview"));
-        Assert.That(result.Corrections, Has.Some.Contains("Removed link with empty URL"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Metrics Overview", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("Removed link with empty URL"));
     }
 
-    [Test]
+    [Fact]
     public void Validate_RemovesLinksWithWhitespaceOnlyUrl()
     {
         var data = CreateMinimalData();
@@ -685,9 +685,9 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.That(data.AdditionalLinks, Has.Count.EqualTo(1));
-        Assert.That(data.AdditionalLinks[0].Title, Is.EqualTo("Cluster Security"));
-        Assert.That(result.Corrections, Has.Some.Contains("Removed link with empty URL"));
+        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Equal("Cluster Security", data.AdditionalLinks[0].Title);
+        Assert.Contains(result.Corrections, c => c.Contains("Removed link with empty URL"));
     }
 
     // ===== Helper =====

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/CalculateMaxTokensTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/CalculateMaxTokensTests.cs
@@ -1,40 +1,40 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
+using Xunit;
 using ArticleGenerator = HorizontalArticleGenerator.Generators.HorizontalArticleGenerator;
 
 namespace HorizontalArticleGenerator.Tests;
 
-[TestFixture]
 public class CalculateMaxTokensTests
 {
-    [TestCase(1, 8000, Description = "1 tool: 4000+600=4600 → clamped to min 8000")]
-    [TestCase(0, 8000, Description = "0 tools: 4000+0=4000 → clamped to min 8000")]
-    [TestCase(7, 8200, Description = "7 tools: 4000+4200=8200 → within range")]
-    [TestCase(10, 10000, Description = "10 tools: 4000+6000=10000 → within range")]
-    [TestCase(35, 24000, Description = "35 tools: 4000+21000=25000 → clamped to max 24000")]
+    [Theory]
+    [InlineData(1, 8000)]
+    [InlineData(0, 8000)]
+    [InlineData(7, 8200)]
+    [InlineData(10, 10000)]
+    [InlineData(35, 24000)]
     public void CalculateMaxTokens_ReturnsExpectedValue(int toolCount, int expected)
     {
         var result = ArticleGenerator.CalculateMaxTokens(toolCount);
-        Assert.That(result, Is.EqualTo(expected));
+        Assert.Equal(expected, result);
     }
 
-    [Test]
+    [Fact]
     public void CalculateMaxTokens_NeverBelowMinimum()
     {
         for (var i = 0; i <= 6; i++)
         {
-            Assert.That(ArticleGenerator.CalculateMaxTokens(i), Is.GreaterThanOrEqualTo(8000));
+            Assert.True(ArticleGenerator.CalculateMaxTokens(i) >= 8000);
         }
     }
 
-    [Test]
+    [Fact]
     public void CalculateMaxTokens_NeverAboveMaximum()
     {
         for (var i = 30; i <= 100; i++)
         {
-            Assert.That(ArticleGenerator.CalculateMaxTokens(i), Is.LessThanOrEqualTo(24000));
+            Assert.True(ArticleGenerator.CalculateMaxTokens(i) <= 24000);
         }
     }
 }

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
@@ -4,50 +4,50 @@
 using CSharpGenerator.Models;
 using HorizontalArticleGenerator.Generators;
 using HorizontalArticleGenerator.Models;
-using NUnit.Framework;
+using Xunit;
 
 namespace HorizontalArticleGenerator.Tests;
 
-[TestFixture]
 public class DeterministicHorizontalHelpersTests
 {
     // ── ClassifyToolPlane ────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void ClassifyToolPlane_ReadOnlyMetadata_ReturnsData()
     {
         var tool = MakeTool("keyvault secret get", readOnly: true);
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("data"));
+        Assert.Equal("data", DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [Test]
+    [Fact]
     public void ClassifyToolPlane_DestructiveMetadata_ReturnsManagement()
     {
         var tool = MakeTool("sql database delete", destructive: true);
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("management"));
+        Assert.Equal("management", DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [TestCase("storage account create", "management")]
-    [TestCase("keyvault secret delete", "management")]
-    [TestCase("appservice webapp update", "management")]
-    [TestCase("storage account list", "data")]
-    [TestCase("cosmos container get", "data")]
+    [Theory]
+    [InlineData("storage account create", "management")]
+    [InlineData("keyvault secret delete", "management")]
+    [InlineData("appservice webapp update", "management")]
+    [InlineData("storage account list", "data")]
+    [InlineData("cosmos container get", "data")]
     public void ClassifyToolPlane_ByCommandVerb(string command, string expectedPlane)
     {
         var tool = MakeTool(command);
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo(expectedPlane));
+        Assert.Equal(expectedPlane, DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [Test]
+    [Fact]
     public void ClassifyToolPlane_NoMetadataNoVerb_DefaultsToData()
     {
         var tool = MakeTool("monitor query");
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("data"));
+        Assert.Equal("data", DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
     // ── OrderToolsByPlane ───────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void OrderToolsByPlane_ManagementBeforeData()
     {
         var tools = new List<HorizontalToolSummary>
@@ -61,13 +61,13 @@ public class DeterministicHorizontalHelpersTests
         var ordered = DeterministicHorizontalHelpers.OrderToolsByPlane(tools);
 
         // Management (create) first, then data (get)
-        Assert.That(ordered[0].Command, Does.Contain("create"));
-        Assert.That(ordered[1].Command, Does.Contain("create"));
-        Assert.That(ordered[2].Command, Does.Contain("get"));
-        Assert.That(ordered[3].Command, Does.Contain("get"));
+        Assert.Contains("create", ordered[0].Command);
+        Assert.Contains("create", ordered[1].Command);
+        Assert.Contains("get", ordered[2].Command);
+        Assert.Contains("get", ordered[3].Command);
     }
 
-    [Test]
+    [Fact]
     public void OrderToolsByPlane_AlphabeticalWithinPlane()
     {
         var tools = new List<HorizontalToolSummary>
@@ -79,12 +79,12 @@ public class DeterministicHorizontalHelpersTests
 
         var ordered = DeterministicHorizontalHelpers.OrderToolsByPlane(tools);
 
-        Assert.That(ordered[0].Command, Is.EqualTo("storage account list"));
-        Assert.That(ordered[1].Command, Is.EqualTo("storage blob list"));
-        Assert.That(ordered[2].Command, Is.EqualTo("storage table list"));
+        Assert.Equal("storage account list", ordered[0].Command);
+        Assert.Equal("storage blob list", ordered[1].Command);
+        Assert.Equal("storage table list", ordered[2].Command);
     }
 
-    [Test]
+    [Fact]
     public void OrderToolsByPlane_PreservesAllTools()
     {
         var tools = new List<HorizontalToolSummary>
@@ -95,12 +95,12 @@ public class DeterministicHorizontalHelpersTests
         };
 
         var ordered = DeterministicHorizontalHelpers.OrderToolsByPlane(tools);
-        Assert.That(ordered, Has.Count.EqualTo(3));
+        Assert.Equal(3, ordered.Count);
     }
 
     // ── ExtractCapability ───────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void ExtractCapability_FromDescription_ReturnsCleanCapability()
     {
         var tool = MakeTool("storage account list");
@@ -108,11 +108,11 @@ public class DeterministicHorizontalHelpersTests
 
         var capability = DeterministicHorizontalHelpers.ExtractCapability(tool);
 
-        Assert.That(capability, Does.Not.EndWith("."));
-        Assert.That(capability, Is.Not.Empty);
+        Assert.False(capability.EndsWith("."));
+        Assert.NotEmpty(capability);
     }
 
-    [Test]
+    [Fact]
     public void ExtractCapability_StripsTrailingPeriod()
     {
         var tool = MakeTool("keyvault secret create");
@@ -120,10 +120,10 @@ public class DeterministicHorizontalHelpersTests
 
         var capability = DeterministicHorizontalHelpers.ExtractCapability(tool);
 
-        Assert.That(capability, Does.Not.EndWith("."));
+        Assert.False(capability.EndsWith("."));
     }
 
-    [Test]
+    [Fact]
     public void ExtractCapability_TruncatesLongDescription()
     {
         var tool = MakeTool("deploy generate_plan");
@@ -132,32 +132,32 @@ public class DeterministicHorizontalHelpersTests
         var capability = DeterministicHorizontalHelpers.ExtractCapability(tool);
 
         var wordCount = capability.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-        Assert.That(wordCount, Is.LessThanOrEqualTo(15));
+        Assert.True(wordCount <= 15);
     }
 
     // ── TruncateDescription ─────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void TruncateDescription_ShortEnough_ReturnsAsIs()
     {
         var result = DeterministicHorizontalHelpers.TruncateDescription(
             "List all storage accounts", maxWords: 10);
-        Assert.That(result, Is.EqualTo("List all storage accounts"));
+        Assert.Equal("List all storage accounts", result);
     }
 
-    [Test]
+    [Fact]
     public void TruncateDescription_TooLong_TruncatesAndAddsSuffix()
     {
         var result = DeterministicHorizontalHelpers.TruncateDescription(
             "Generate a very detailed and comprehensive deployment plan for Azure resources", maxWords: 5);
 
         var wordCount = result.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-        Assert.That(wordCount, Is.LessThanOrEqualTo(6)); // 5 words + possible suffix
+        Assert.True(wordCount <= 6); // 5 words + possible suffix
     }
 
     // ── PreComputeCapabilities ──────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void PreComputeCapabilities_OnePerTool()
     {
         var tools = new List<HorizontalToolSummary>
@@ -169,13 +169,13 @@ public class DeterministicHorizontalHelpersTests
 
         var capabilities = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
 
-        Assert.That(capabilities, Has.Count.EqualTo(3));
-        Assert.That(capabilities.Values, Has.All.Not.EndsWith("."));
+        Assert.Equal(3, capabilities.Count);
+        Assert.All(capabilities.Values, v => Assert.False(v.EndsWith(".")));
     }
 
     // ── PreComputeShortDescriptions ─────────────────────────────────
 
-    [Test]
+    [Fact]
     public void PreComputeShortDescriptions_ReturnsMapByCommand()
     {
         var tools = new List<HorizontalToolSummary>
@@ -186,12 +186,12 @@ public class DeterministicHorizontalHelpersTests
 
         var descriptions = DeterministicHorizontalHelpers.PreComputeShortDescriptions(tools);
 
-        Assert.That(descriptions, Has.Count.EqualTo(2));
-        Assert.That(descriptions.ContainsKey("storage account list"), Is.True);
-        Assert.That(descriptions.ContainsKey("storage blob get"), Is.True);
+        Assert.Equal(2, descriptions.Count);
+        Assert.True(descriptions.ContainsKey("storage account list"));
+        Assert.True(descriptions.ContainsKey("storage blob get"));
     }
 
-    [Test]
+    [Fact]
     public void PreComputeShortDescriptions_MaxTenToFifteenWords()
     {
         var tools = new List<HorizontalToolSummary>
@@ -202,12 +202,12 @@ public class DeterministicHorizontalHelpersTests
         var descriptions = DeterministicHorizontalHelpers.PreComputeShortDescriptions(tools);
         var words = descriptions["deploy plan"].Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
 
-        Assert.That(words, Is.LessThanOrEqualTo(15));
+        Assert.True(words <= 15);
     }
 
     // ── Idempotent ──────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void OrderAndCapabilities_SameInput_SameOutput()
     {
         var tools = new List<HorizontalToolSummary>
@@ -221,13 +221,13 @@ public class DeterministicHorizontalHelpersTests
         var order2 = DeterministicHorizontalHelpers.OrderToolsByPlane(tools);
         var caps2 = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
 
-        Assert.That(order1.Select(t => t.Command), Is.EqualTo(order2.Select(t => t.Command)));
-        Assert.That(caps1.Values, Is.EqualTo(caps2.Values));
+        Assert.Equal(order1.Select(t => t.Command), order2.Select(t => t.Command));
+        Assert.Equal(caps1.Values, caps2.Values);
     }
 
     // ── Edge cases (review feedback) ────────────────────────────────
 
-    [Test]
+    [Fact]
     public void ClassifyToolPlane_NullMetadata_DefaultsToVerbClassification()
     {
         var tool = new HorizontalToolSummary
@@ -236,10 +236,10 @@ public class DeterministicHorizontalHelpersTests
             Description = "Create account",
             Metadata = null!
         };
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("management"));
+        Assert.Equal("management", DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [Test]
+    [Fact]
     public void ClassifyToolPlane_EmptyMetadata_DefaultsToVerbClassification()
     {
         var tool = new HorizontalToolSummary
@@ -248,26 +248,27 @@ public class DeterministicHorizontalHelpersTests
             Description = "Get container",
             Metadata = new Dictionary<string, MetadataValue>()
         };
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo("data"));
+        Assert.Equal("data", DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [TestCase("appconfig createorupdate", "management")]
-    [TestCase("compute deploy", "management")]
-    [TestCase("functionapp publish", "management")]
+    [Theory]
+    [InlineData("appconfig createorupdate", "management")]
+    [InlineData("compute deploy", "management")]
+    [InlineData("functionapp publish", "management")]
     public void ClassifyToolPlane_CompoundVerbs_CorrectlyClassified(string command, string expected)
     {
         var tool = MakeTool(command);
-        Assert.That(DeterministicHorizontalHelpers.ClassifyToolPlane(tool), Is.EqualTo(expected));
+        Assert.Equal(expected, DeterministicHorizontalHelpers.ClassifyToolPlane(tool));
     }
 
-    [Test]
+    [Fact]
     public void OrderToolsByPlane_EmptyList_ReturnsEmpty()
     {
         var result = DeterministicHorizontalHelpers.OrderToolsByPlane(new List<HorizontalToolSummary>());
-        Assert.That(result, Is.Empty);
+        Assert.Empty(result);
     }
 
-    [Test]
+    [Fact]
     public void PreComputeCapabilities_DuplicateCommands_FirstWins()
     {
         var tools = new List<HorizontalToolSummary>
@@ -277,22 +278,22 @@ public class DeterministicHorizontalHelpersTests
         };
 
         var caps = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
-        Assert.That(caps, Has.Count.EqualTo(1));
-        Assert.That(caps["storage list"], Is.EqualTo("First description"));
+        Assert.Equal(1, caps.Count);
+        Assert.Equal("First description", caps["storage list"]);
     }
 
-    [Test]
+    [Fact]
     public void TruncateDescription_EmptyString_ReturnsEmpty()
     {
         var result = DeterministicHorizontalHelpers.TruncateDescription("", maxWords: 10);
-        Assert.That(result, Is.EqualTo(""));
+        Assert.Equal("", result);
     }
 
-    [Test]
+    [Fact]
     public void TruncateDescription_SingleWord_ReturnsTrimmed()
     {
         var result = DeterministicHorizontalHelpers.TruncateDescription("List.", maxWords: 10);
-        Assert.That(result, Is.EqualTo("List"));
+        Assert.Equal("List", result);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.Steps.HorizontalArticles\DocGeneration.Steps.HorizontalArticles.csproj" />

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/HorizontalArticleGeneratorTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/HorizontalArticleGeneratorTests.cs
@@ -6,18 +6,16 @@ using System.Text.Json;
 using CSharpGenerator.Models;
 using GenerativeAI;
 using HorizontalArticleGenerator.Models;
-using NUnit.Framework;
+using Xunit;
 using ArticleGenerator = HorizontalArticleGenerator.Generators.HorizontalArticleGenerator;
 
 namespace HorizontalArticleGenerator.Tests;
 
-[TestFixture]
-public class HorizontalArticleGeneratorTests
+public class HorizontalArticleGeneratorTests : IDisposable
 {
-    private string _outputBasePath = null!;
+    private readonly string _outputBasePath;
 
-    [SetUp]
-    public void SetUp()
+    public HorizontalArticleGeneratorTests()
     {
         _outputBasePath = Path.Combine(Path.GetTempPath(), "horizontal-article-generator-tests", Guid.NewGuid().ToString("N"));
         var cliDirectory = Path.Combine(_outputBasePath, "cli");
@@ -25,8 +23,7 @@ public class HorizontalArticleGeneratorTests
         File.WriteAllText(Path.Combine(cliDirectory, "cli-version.json"), "{\"version\":\"test-version\"}");
     }
 
-    [TearDown]
-    public void TearDown()
+    public void Dispose()
     {
         if (Directory.Exists(_outputBasePath))
         {
@@ -34,7 +31,7 @@ public class HorizontalArticleGeneratorTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task ExtractStaticData_UsesToolFamilyReferenceLink()
     {
         await WriteCliOutputAsync(new CliOutput
@@ -56,8 +53,8 @@ public class HorizontalArticleGeneratorTests
 
         var staticData = await InvokeExtractStaticDataAsync(generator);
 
-        Assert.That(staticData, Has.Count.EqualTo(1));
-        Assert.That(staticData[0].ToolsReferenceLink, Is.EqualTo("../tool-family/compute.md"));
+        Assert.Equal(1, staticData.Count);
+        Assert.Equal("../tool-family/compute.md", staticData[0].ToolsReferenceLink);
     }
 
     private ArticleGenerator CreateGenerator()
@@ -83,10 +80,10 @@ public class HorizontalArticleGeneratorTests
     private static async Task<List<StaticArticleData>> InvokeExtractStaticDataAsync(ArticleGenerator generator)
     {
         var method = typeof(ArticleGenerator).GetMethod("ExtractStaticData", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.That(method, Is.Not.Null);
+        Assert.NotNull(method);
 
         var task = method!.Invoke(generator, null) as Task<List<StaticArticleData>>;
-        Assert.That(task, Is.Not.Null);
+        Assert.NotNull(task);
 
         return await task!;
     }

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/DocGeneration.Steps.SkillsRelevance.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/DocGeneration.Steps.SkillsRelevance.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.Steps.SkillsRelevance\DocGeneration.Steps.SkillsRelevance.csproj" />

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillContentParserTests.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillContentParserTests.cs
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
+using Xunit;
 using SkillsRelevance.Services;
 
 namespace SkillsRelevance.Tests;
 
-[TestFixture]
 public class SkillContentParserTests
 {
     // ── Markdown with YAML frontmatter ────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownWithFrontmatter_ExtractsName()
     {
         var content = """
@@ -25,10 +24,10 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("storage-helper.md", content, "https://github.com/org/repo/storage-helper.md", "https://raw.githubusercontent.com/org/repo/main/storage-helper.md", "Test Source");
 
-        Assert.That(skill.Name, Is.EqualTo("Azure Storage Helper"));
+        Assert.Equal("Azure Storage Helper", skill.Name);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownWithFrontmatter_ExtractsDescription()
     {
         var content = """
@@ -40,10 +39,10 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("kv.md", content, "https://example.com/kv.md", "https://raw.example.com/kv.md", "Test Source");
 
-        Assert.That(skill.Description, Is.EqualTo("Manages Azure Key Vault secrets"));
+        Assert.Equal("Manages Azure Key Vault secrets", skill.Description);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownWithFrontmatter_ExtractsTags()
     {
         var content = """
@@ -58,12 +57,12 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("tags-test.md", content, "https://example.com/tags-test.md", "https://raw.example.com/tags-test.md", "Test Source");
 
-        Assert.That(skill.Tags, Contains.Item("azure"));
-        Assert.That(skill.Tags, Contains.Item("storage"));
-        Assert.That(skill.Tags, Contains.Item("blob"));
+        Assert.Contains("azure", skill.Tags);
+        Assert.Contains("storage", skill.Tags);
+        Assert.Contains("blob", skill.Tags);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownWithFrontmatter_ExtractsAuthorAndVersion()
     {
         var content = """
@@ -76,11 +75,11 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("versioned.md", content, "https://example.com/versioned.md", "https://raw.example.com/versioned.md", "Test Source");
 
-        Assert.That(skill.Author, Is.EqualTo("Jane Doe"));
-        Assert.That(skill.Version, Is.EqualTo("1.2.0"));
+        Assert.Equal("Jane Doe", skill.Author);
+        Assert.Equal("1.2.0", skill.Version);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownWithFrontmatter_ExtractsLastUpdated()
     {
         var content = """
@@ -92,12 +91,12 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("dated.md", content, "https://example.com/dated.md", "https://raw.example.com/dated.md", "Test Source");
 
-        Assert.That(skill.LastUpdated, Is.Not.Null);
-        Assert.That(skill.LastUpdated!.Value.Year, Is.EqualTo(2024));
-        Assert.That(skill.LastUpdated.Value.Month, Is.EqualTo(3));
+        Assert.NotNull(skill.LastUpdated);
+        Assert.Equal(2024, skill.LastUpdated!.Value.Year);
+        Assert.Equal(3, skill.LastUpdated.Value.Month);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownNoFrontmatter_FallsBackToH1ForName()
     {
         var content = """
@@ -108,28 +107,28 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("my-skill.md", content, "https://example.com/my-skill.md", "https://raw.example.com/my-skill.md", "Test Source");
 
-        Assert.That(skill.Name, Is.EqualTo("My Skill Title"));
+        Assert.Equal("My Skill Title", skill.Name);
     }
 
-    [Test]
+    [Fact]
     public void Parse_MarkdownNoFrontmatterNoH1_DeriveNameFromFilename()
     {
         var content = "Just some plain text with no headings.";
 
         var skill = SkillContentParser.Parse("my-skill-name.md", content, "https://example.com/my-skill-name.md", "https://raw.example.com/my-skill-name.md", "Test Source");
 
-        Assert.That(skill.Name, Is.EqualTo("my skill name"));
+        Assert.Equal("my skill name", skill.Name);
     }
 
-    [Test]
+    [Fact]
     public void Parse_SetsRawContent()
     {
         var content = "# Title\nSome content here.";
         var skill = SkillContentParser.Parse("skill.md", content, "https://example.com/skill.md", "https://raw.example.com/skill.md", "Source");
-        Assert.That(skill.RawContent, Is.EqualTo(content));
+        Assert.Equal(content, skill.RawContent);
     }
 
-    [Test]
+    [Fact]
     public void Parse_SetsSourceFields()
     {
         var skill = SkillContentParser.Parse(
@@ -139,15 +138,15 @@ public class SkillContentParserTests
             "https://raw.example.com/raw",
             "My Source");
 
-        Assert.That(skill.FileName, Is.EqualTo("skill.md"));
-        Assert.That(skill.SourceUrl, Is.EqualTo("https://example.com/html"));
-        Assert.That(skill.RawContentUrl, Is.EqualTo("https://raw.example.com/raw"));
-        Assert.That(skill.SourceRepository, Is.EqualTo("My Source"));
+        Assert.Equal("skill.md", skill.FileName);
+        Assert.Equal("https://example.com/html", skill.SourceUrl);
+        Assert.Equal("https://raw.example.com/raw", skill.RawContentUrl);
+        Assert.Equal("My Source", skill.SourceRepository);
     }
 
     // ── Plain YAML ────────────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void Parse_YamlFile_ExtractsFields()
     {
         var content = """
@@ -158,12 +157,12 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("cosmos.yml", content, "https://example.com/cosmos.yml", "https://raw.example.com/cosmos.yml", "Source");
 
-        Assert.That(skill.Name, Is.EqualTo("Cosmos DB Skill"));
-        Assert.That(skill.Description, Is.EqualTo("Helps with Azure Cosmos DB NoSQL queries"));
-        Assert.That(skill.Category, Is.EqualTo("database"));
+        Assert.Equal("Cosmos DB Skill", skill.Name);
+        Assert.Equal("Helps with Azure Cosmos DB NoSQL queries", skill.Description);
+        Assert.Equal("database", skill.Category);
     }
 
-    [Test]
+    [Fact]
     public void Parse_YamlFile_ExtractsServicesList()
     {
         var content = """
@@ -175,13 +174,13 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("multi.yaml", content, "https://example.com/multi.yaml", "https://raw.example.com/multi.yaml", "Source");
 
-        Assert.That(skill.AzureServices, Contains.Item("Azure Monitor"));
-        Assert.That(skill.AzureServices, Contains.Item("Azure Log Analytics"));
+        Assert.Contains("Azure Monitor", skill.AzureServices);
+        Assert.Contains("Azure Log Analytics", skill.AzureServices);
     }
 
     // ── JSON ─────────────────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void Parse_JsonFile_ExtractsFields()
     {
         var content = """
@@ -196,14 +195,14 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("kv.json", content, "https://example.com/kv.json", "https://raw.example.com/kv.json", "Source");
 
-        Assert.That(skill.Name, Is.EqualTo("Key Vault JSON Skill"));
-        Assert.That(skill.Description, Is.EqualTo("Manages secrets in Azure Key Vault"));
-        Assert.That(skill.Author, Is.EqualTo("DevOps Team"));
-        Assert.That(skill.Version, Is.EqualTo("2.0"));
-        Assert.That(skill.Category, Is.EqualTo("security"));
+        Assert.Equal("Key Vault JSON Skill", skill.Name);
+        Assert.Equal("Manages secrets in Azure Key Vault", skill.Description);
+        Assert.Equal("DevOps Team", skill.Author);
+        Assert.Equal("2.0", skill.Version);
+        Assert.Equal("security", skill.Category);
     }
 
-    [Test]
+    [Fact]
     public void Parse_JsonFile_ExtractsTags()
     {
         var content = """
@@ -215,66 +214,66 @@ public class SkillContentParserTests
 
         var skill = SkillContentParser.Parse("tagged.json", content, "https://example.com/tagged.json", "https://raw.example.com/tagged.json", "Source");
 
-        Assert.That(skill.Tags, Contains.Item("azure"));
-        Assert.That(skill.Tags, Contains.Item("devops"));
-        Assert.That(skill.Tags, Contains.Item("pipelines"));
+        Assert.Contains("azure", skill.Tags);
+        Assert.Contains("devops", skill.Tags);
+        Assert.Contains("pipelines", skill.Tags);
     }
 
-    [Test]
+    [Fact]
     public void Parse_InvalidJson_FallsBackToPlainText()
     {
         var content = "not valid json {{ }}";
         var skill = SkillContentParser.Parse("bad.json", content, "https://example.com/bad.json", "https://raw.example.com/bad.json", "Source");
         // Should not throw; description should be populated with some content
-        Assert.That(skill.Description, Is.Not.Empty);
+        Assert.NotEmpty(skill.Description);
     }
 
     // ── ExtractAzureServices ──────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void ExtractAzureServices_FindsKnownServices()
     {
         var content = "This skill helps you use Azure Key Vault and Azure Monitor for observability.";
         var services = SkillContentParser.ExtractAzureServices(content);
-        Assert.That(services, Contains.Item("Azure Key Vault"));
-        Assert.That(services, Contains.Item("Azure Monitor"));
+        Assert.Contains("Azure Key Vault", services);
+        Assert.Contains("Azure Monitor", services);
     }
 
-    [Test]
+    [Fact]
     public void ExtractAzureServices_IsCaseInsensitive()
     {
         var content = "Connect to azure storage and AZURE SQL databases.";
         var services = SkillContentParser.ExtractAzureServices(content);
-        Assert.That(services, Contains.Item("Azure Storage"));
-        Assert.That(services, Contains.Item("Azure SQL"));
+        Assert.Contains("Azure Storage", services);
+        Assert.Contains("Azure SQL", services);
     }
 
-    [Test]
+    [Fact]
     public void ExtractAzureServices_NoDuplicates()
     {
         var content = "Azure Storage is great. Use Azure Storage for blobs. Azure Storage is fast.";
         var services = SkillContentParser.ExtractAzureServices(content);
-        Assert.That(services.Count(s => s.Equals("Azure Storage", StringComparison.OrdinalIgnoreCase)), Is.EqualTo(1));
+        Assert.Equal(1, services.Count(s => s.Equals("Azure Storage", StringComparison.OrdinalIgnoreCase)));
     }
 
-    [Test]
+    [Fact]
     public void ExtractAzureServices_EmptyContent_ReturnsEmptyList()
     {
         var services = SkillContentParser.ExtractAzureServices(string.Empty);
-        Assert.That(services, Is.Empty);
+        Assert.Empty(services);
     }
 
-    [Test]
+    [Fact]
     public void ExtractAzureServices_NoKnownServices_ReturnsEmptyList()
     {
         var content = "This is about JavaScript and Node.js with no Azure services.";
         var services = SkillContentParser.ExtractAzureServices(content);
-        Assert.That(services, Is.Empty);
+        Assert.Empty(services);
     }
 
     // ── ExtractSection ────────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void ExtractSection_ReturnsContentUnderMatchingHeading()
     {
         var content = """
@@ -290,11 +289,11 @@ public class SkillContentParserTests
             """;
 
         var section = SkillContentParser.ExtractSection(content, "best practice");
-        Assert.That(section, Does.Contain("managed identities"));
-        Assert.That(section, Does.Contain("RBAC"));
+        Assert.Contains("managed identities", section);
+        Assert.Contains("RBAC", section);
     }
 
-    [Test]
+    [Fact]
     public void ExtractSection_StopsAtNextHeading()
     {
         var content = """
@@ -306,10 +305,10 @@ public class SkillContentParserTests
             """;
 
         var section = SkillContentParser.ExtractSection(content, "best practice");
-        Assert.That(section, Does.Not.Contain("should not be included"));
+        Assert.DoesNotContain("should not be included", section);
     }
 
-    [Test]
+    [Fact]
     public void ExtractSection_HeadingNotFound_ReturnsEmpty()
     {
         var content = """
@@ -318,10 +317,10 @@ public class SkillContentParserTests
             """;
 
         var section = SkillContentParser.ExtractSection(content, "troubleshoot");
-        Assert.That(section, Is.Empty);
+        Assert.Empty(section);
     }
 
-    [Test]
+    [Fact]
     public void ExtractSection_IsCaseInsensitive()
     {
         var content = """
@@ -330,6 +329,6 @@ public class SkillContentParserTests
             """;
 
         var section = SkillContentParser.ExtractSection(content, "troubleshoot");
-        Assert.That(section, Does.Contain("Azure Monitor"));
+        Assert.Contains("Azure Monitor", section);
     }
 }

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillRelevanceAnalyzerTests.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillRelevanceAnalyzerTests.cs
@@ -1,78 +1,77 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
+using Xunit;
 using SkillsRelevance.Models;
 using SkillsRelevance.Services;
 
 namespace SkillsRelevance.Tests;
 
-[TestFixture]
 public class SkillRelevanceAnalyzerTests
 {
     // ── BuildSearchTerms ────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_ReturnsRawInput()
     {
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("storage");
-        Assert.That(terms, Contains.Item("storage"));
+        Assert.Contains("storage", terms);
     }
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_AksExpandsToKubernetesAndK8s()
     {
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("aks");
-        Assert.That(terms, Contains.Item("kubernetes"));
-        Assert.That(terms, Contains.Item("k8s"));
+        Assert.Contains("kubernetes", terms);
+        Assert.Contains("k8s", terms);
     }
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_KeyvaultExpandsToSecretAndCertificate()
     {
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("keyvault");
-        Assert.That(terms, Contains.Item("key vault"));
-        Assert.That(terms, Contains.Item("secret"));
-        Assert.That(terms, Contains.Item("certificate"));
+        Assert.Contains("key vault", terms);
+        Assert.Contains("secret", terms);
+        Assert.Contains("certificate", terms);
     }
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_SplitsHyphenatedInput()
     {
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("azure-storage");
-        Assert.That(terms, Contains.Item("azure"));
-        Assert.That(terms, Contains.Item("storage"));
+        Assert.Contains("azure", terms);
+        Assert.Contains("storage", terms);
     }
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_FiltersShortParts()
     {
         // Parts of length ≤ 2 should not be added as separate terms
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("vm");
         // "vm" is the raw input so it stays; no additional split items since it's only one part
-        Assert.That(terms, Contains.Item("vm"));
+        Assert.Contains("vm", terms);
     }
 
-    [Test]
+    [Fact]
     public void BuildSearchTerms_NoDuplicates()
     {
         var terms = SkillRelevanceAnalyzer.BuildSearchTerms("storage");
         // "storage" should appear exactly once
-        Assert.That(terms.Count(t => string.Equals(t, "storage", StringComparison.OrdinalIgnoreCase)), Is.EqualTo(1));
+        Assert.Equal(1, terms.Count(t => string.Equals(t, "storage", StringComparison.OrdinalIgnoreCase)));
     }
 
     // ── Score ────────────────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void Score_NameMatch_ReturnsHighScore()
     {
         var analyzer = new SkillRelevanceAnalyzer("keyvault");
         var skill = new SkillInfo { Name = "Azure Key Vault Best Practices", FileName = "keyvault-tips.md" };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.GreaterThanOrEqualTo(0.4));
+        Assert.True(score >= 0.4);
     }
 
-    [Test]
+    [Fact]
     public void Score_NoMatch_ReturnsZero()
     {
         var analyzer = new SkillRelevanceAnalyzer("cosmosdb");
@@ -85,10 +84,10 @@ public class SkillRelevanceAnalyzerTests
             Tags = new List<string> { "github", "pr" }
         };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.EqualTo(0.0));
+        Assert.Equal(0.0, score);
     }
 
-    [Test]
+    [Fact]
     public void Score_DescriptionMatch_AddsScore()
     {
         var analyzer = new SkillRelevanceAnalyzer("storage");
@@ -99,11 +98,11 @@ public class SkillRelevanceAnalyzerTests
             Description = "Use Azure Storage blobs for large file uploads."
         };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.GreaterThan(0.0));
-        Assert.That(skill.RelevanceReasons, Has.Some.Contains("Description mentions"));
+        Assert.True(score > 0.0);
+        Assert.Contains(skill.RelevanceReasons, r => r.Contains("Description mentions"));
     }
 
-    [Test]
+    [Fact]
     public void Score_TagMatch_AddsScore()
     {
         var analyzer = new SkillRelevanceAnalyzer("sql");
@@ -114,11 +113,11 @@ public class SkillRelevanceAnalyzerTests
             Tags = new List<string> { "azure sql", "relational" }
         };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.GreaterThan(0.0));
-        Assert.That(skill.RelevanceReasons, Has.Some.Contains("Tag"));
+        Assert.True(score > 0.0);
+        Assert.Contains(skill.RelevanceReasons, r => r.Contains("Tag"));
     }
 
-    [Test]
+    [Fact]
     public void Score_ContentMatches_AddsScore()
     {
         var analyzer = new SkillRelevanceAnalyzer("monitor");
@@ -129,10 +128,10 @@ public class SkillRelevanceAnalyzerTests
             RawContent = "Use Azure Monitor to collect metrics. Azure Monitor alerts help you."
         };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.GreaterThan(0.0));
+        Assert.True(score > 0.0);
     }
 
-    [Test]
+    [Fact]
     public void Score_CapsAt1()
     {
         var analyzer = new SkillRelevanceAnalyzer("aks");
@@ -147,10 +146,10 @@ public class SkillRelevanceAnalyzerTests
             RawContent = string.Concat(Enumerable.Repeat("aks kubernetes k8s ", 20))
         };
         var score = analyzer.Score(skill);
-        Assert.That(score, Is.LessThanOrEqualTo(1.0));
+        Assert.True(score <= 1.0);
     }
 
-    [Test]
+    [Fact]
     public void Score_PopulatesRelevanceReasons()
     {
         var analyzer = new SkillRelevanceAnalyzer("storage");
@@ -161,12 +160,12 @@ public class SkillRelevanceAnalyzerTests
             RawContent = "storage"
         };
         analyzer.Score(skill);
-        Assert.That(skill.RelevanceReasons, Is.Not.Empty);
+        Assert.NotEmpty(skill.RelevanceReasons);
     }
 
     // ── FilterAndSort ────────────────────────────────────────────────────
 
-    [Test]
+    [Fact]
     public void FilterAndSort_ExcludesBelowMinScore()
     {
         var analyzer = new SkillRelevanceAnalyzer("cosmosdb");
@@ -177,10 +176,10 @@ public class SkillRelevanceAnalyzerTests
         };
 
         var results = analyzer.FilterAndSort(skills, minScore: 0.1);
-        Assert.That(results, Has.All.Matches<SkillInfo>(s => s.RelevanceScore >= 0.1));
+        Assert.All(results, s => Assert.True(s.RelevanceScore >= 0.1));
     }
 
-    [Test]
+    [Fact]
     public void FilterAndSort_OrdersByScoreDescending()
     {
         var analyzer = new SkillRelevanceAnalyzer("sql");
@@ -192,14 +191,14 @@ public class SkillRelevanceAnalyzerTests
         };
 
         var results = analyzer.FilterAndSort(skills, minScore: 0.0);
-        Assert.That(results.Count, Is.GreaterThan(0));
+        Assert.True(results.Count > 0);
         for (int i = 1; i < results.Count; i++)
         {
-            Assert.That(results[i - 1].RelevanceScore, Is.GreaterThanOrEqualTo(results[i].RelevanceScore));
+            Assert.True(results[i - 1].RelevanceScore >= results[i].RelevanceScore);
         }
     }
 
-    [Test]
+    [Fact]
     public void FilterAndSort_AllSkillsMode_ReturnsAllWhenMinScoreIsZero()
     {
         var analyzer = new SkillRelevanceAnalyzer("openai");
@@ -210,6 +209,6 @@ public class SkillRelevanceAnalyzerTests
         };
 
         var results = analyzer.FilterAndSort(skills, minScore: 0.0);
-        Assert.That(results.Count, Is.EqualTo(2));
+        Assert.Equal(2, results.Count);
     }
 }


### PR DESCRIPTION
Closes #349

## Changes
- Deleted `test_coverage.cs` and `test_coverage.csx` from repo root (unused artifacts)
- Removed NUnit (3.13.3) and NUnit3TestAdapter (4.5.0) from `Directory.Packages.props`
- Migrated 3 test projects from NUnit to xUnit (168 tests):
  - `DocGeneration.Steps.SkillsRelevance.Tests` (39 tests)
  - `DocGeneration.Core.TextTransformation.Tests` (29 tests)
  - `DocGeneration.Steps.HorizontalArticles.Tests` (100 tests)
- Updated `.csproj` files to reference xunit/xunit.runner.visualstudio instead of NUnit/NUnit3TestAdapter

## Verification
- Confirmed zero `.csproj` files reference NUnit
- Zero `using NUnit` or `[TestFixture]` remain in any `.cs` file
- Build passes (0 errors)
- All 1,772+ tests pass (including 168 migrated tests)