### PR TITLE
ci: wire prompt regression tests into CI (#350)

### DIFF
--- a/.github/workflows/prompt-regression-ci.yml
+++ b/.github/workflows/prompt-regression-ci.yml
@@ -1,0 +1,53 @@
+name: Prompt Regression Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs-generation/**/prompts/**'
+      - 'prompt-regression.sh'
+      - 'docs-generation/DocGeneration.PromptRegression.Tests/**'
+      - '.github/workflows/prompt-regression-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  prompt-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore docs-generation.sln
+
+      - name: Build solution
+        run: dotnet build docs-generation.sln --no-restore --configuration Release
+
+      - name: Run prompt regression tests
+        run: >
+          dotnet test
+          docs-generation/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj
+          --no-build
+          --configuration Release
+          --verbosity normal
+          --logger "trx;LogFileName=prompt-regression-results.trx"
+        env:
+          FOUNDRY_API_KEY: ${{ secrets.FOUNDRY_API_KEY }}
+          FOUNDRY_ENDPOINT: ${{ secrets.FOUNDRY_ENDPOINT }}
+          FOUNDRY_MODEL_NAME: ${{ secrets.FOUNDRY_MODEL_NAME }}
+          FOUNDRY_MODEL_API_VERSION: ${{ secrets.FOUNDRY_MODEL_API_VERSION }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: prompt-regression-results
+          path: '**/prompt-regression-results.trx'
+          retention-days: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Prompt regression CI workflow** — New `.github/workflows/prompt-regression-ci.yml` runs prompt content validation and regression infrastructure tests on PRs touching `docs-generation/**/prompts/**` or `prompt-regression.sh`. Includes baseline management documentation. (#350)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)
 - `start-azure-skills.sh` entry point script
 - 77 xUnit tests with 81.6% line coverage

--- a/docs-generation/DocGeneration.PromptRegression.Tests/README.md
+++ b/docs-generation/DocGeneration.PromptRegression.Tests/README.md
@@ -130,3 +130,94 @@ DocGeneration.PromptRegression.Tests/
 - **➖ No change**: Metrics identical (prompt change had no measurable effect)
 
 When a regression is detected, investigate before merging — the prompt change may have unintended side effects.
+
+## CI Integration
+
+The **Prompt Regression Tests** workflow (`.github/workflows/prompt-regression-ci.yml`) runs automatically on PRs that modify prompt files or regression test infrastructure.
+
+### Trigger paths
+
+The CI job runs when a PR changes any of:
+
+- `docs-generation/**/prompts/**` — AI system/user prompt files
+- `prompt-regression.sh` — Regression runner script
+- `docs-generation/DocGeneration.PromptRegression.Tests/**` — Test code or baselines
+- `.github/workflows/prompt-regression-ci.yml` — The workflow itself
+
+PRs that don't touch these paths skip the job entirely.
+
+### What CI runs
+
+The CI job executes `dotnet test` on the `DocGeneration.PromptRegression.Tests` project. This runs:
+
+| Test class | Runs in CI? | What it checks |
+|---|---|---|
+| **PromptContentTests** | ✅ Always | Prompt files exist and contain expected rules |
+| **QualityMetricsTests** | ✅ Always | Metric calculation accuracy |
+| **BaselineManagerTests** | ✅ Always | Baseline file storage and retrieval |
+| **MetricsComparisonTests** | ✅ Always | Regression/improvement detection logic |
+| **DiffReporterTests** | ✅ Always | Report generation |
+| **RegressionComparisonTests** | ⏭️ Skips | Requires candidates (populated by `prompt-regression.sh compare`) |
+
+The `RegressionComparisonTests` gracefully skip when no candidates directory is populated — this is by design. Full regression comparison requires AI regeneration and is performed locally via `prompt-regression.sh test`.
+
+### Manual trigger
+
+You can also trigger the workflow manually from the Actions tab using **workflow_dispatch**.
+
+### AI credentials
+
+The workflow has access to `FOUNDRY_*` repository secrets for future expansion of AI-powered regression tests in CI.
+
+## Baseline Management
+
+### When to update baselines
+
+Update baselines after **intentional** prompt improvements that result in better output quality. Never update baselines to mask a regression.
+
+### How to update baselines
+
+```bash
+# 1. Make your prompt changes
+
+# 2. Regenerate output for representative namespaces
+./start.sh applens 4,6 --skip-deps
+./start.sh cloudarchitect 4,6 --skip-deps
+./start.sh deploy 4,6 --skip-deps
+./start.sh compute 4,6 --skip-deps
+./start.sh fileshares 4,6 --skip-deps
+
+# 3. Compare against current baselines
+./prompt-regression.sh compare
+
+# 4. Review the regression report
+./prompt-regression.sh report
+
+# 5. If output improved, re-seed baselines
+./prompt-regression.sh seed
+
+# 6. Commit updated baselines alongside your prompt changes
+git add docs-generation/DocGeneration.PromptRegression.Tests/Baselines/
+git commit -m "chore: update regression baselines for prompt improvements"
+```
+
+### Baseline files
+
+Baselines live in `Baselines/{namespace}/` with two articles per namespace:
+
+- `tool-family.md` — Step 4 output (tool-family assembly)
+- `horizontal-article.md` — Step 6 output (horizontal overview article)
+
+These are committed to git and serve as the golden reference for quality comparison.
+
+### Representative namespaces
+
+The 5 namespaces cover a range of service sizes and complexity:
+
+| Namespace | Size | Why selected |
+|---|---|---|
+| `applens` | Small (1 tool) | Minimum viable article |
+| `cloudarchitect` | Small (2 tools) | Simple multi-tool service |
+| `deploy` | Medium (5 tools) | Moderate complexity |
+| `compute` | Large (10+ tools) | High tool count |
+| `fileshares` | Medium (4 tools) | File-oriented operations |


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs prompt regression tests on PRs touching prompt files.

## Changes

- **New workflow**: `prompt-regression-ci.yml` triggers on PRs modifying `docs-generation/**/prompts/**`, `prompt-regression.sh`, or the test project itself
- **Documentation**: Added CI integration and baseline management sections to PromptRegression.Tests README
- **CHANGELOG**: Added entry under Unreleased

## Workflow details

- **Trigger**: PRs modifying prompt files + workflow_dispatch
- **Runner**: ubuntu-latest
- **Timeout**: 20 minutes
- **Tests run**: PromptContentTests, QualityMetricsTests, BaselineManagerTests, MetricsComparisonTests, DiffReporterTests
- **Skipped in CI**: RegressionComparisonTests (require AI-generated candidates)
- **Secrets**: FOUNDRY_* env vars available for future AI-powered CI tests
- **Artifacts**: TRX test results uploaded, retained 10 days

## Path filters

PRs that do NOT touch these paths skip the job entirely:
- `docs-generation/**/prompts/**`
- `prompt-regression.sh`
- `docs-generation/DocGeneration.PromptRegression.Tests/**`
- `.github/workflows/prompt-regression-ci.yml`

Closes #350