### PR TITLE
migrate skills source to microsoft/azure-skills repo

### DIFF
--- a/skills-generation/SkillsGen.Cli/Program.cs
+++ b/skills-generation/SkillsGen.Cli/Program.cs
@@ -21,7 +21,7 @@ var allOption = new Option<bool>("--all", "Generate all skills from inventory");
 var noLlmOption = new Option<bool>("--no-llm", "Disable LLM rewriting");
 var dryRunOption = new Option<bool>("--dry-run", "Parse and validate only");
 var sourceOption = new Option<string>("--source", () => "local", "Source: github or local");
-var outOption = new Option<string>("--out", () => "./generated-skills/", "Output directory");
+var outOption = new Option<string>("--out", () => "../generated-skills/", "Output directory");
 var forceOption = new Option<bool>("--force", "Write even if validation fails");
 var verboseOption = new Option<bool>("--verbose", "Verbose output");
 var sourcePathOption = new Option<string>("--source-path", () => "./skills-source/", "Path to local skills source directory");

--- a/skills-generation/SkillsGen.Core.Tests/Fixtures/minimal-skill.md
+++ b/skills-generation/SkillsGen.Core.Tests/Fixtures/minimal-skill.md
@@ -4,6 +4,6 @@ display_name: Azure Quotas
 description: "Check and manage Azure subscription quotas and usage limits."
 ---
 
-# Azure Quotas
+# Azure skill for Azure Quotas
 
 Check Azure subscription quotas.

--- a/skills-generation/SkillsGen.Core.Tests/Fixtures/sample-skill.md
+++ b/skills-generation/SkillsGen.Core.Tests/Fixtures/sample-skill.md
@@ -4,7 +4,7 @@ display_name: Azure Storage
 description: "Work with Azure Storage accounts, blobs, queues, tables, and file shares. USE FOR: creating storage accounts, managing blobs, configuring access policies, monitoring storage metrics, troubleshooting connectivity. DO NOT USE FOR: Azure Cosmos DB operations, Azure SQL Database queries, non-Azure storage providers."
 ---
 
-# Azure Storage
+# Azure skill for Azure Storage
 
 The Azure Storage skill helps you manage Azure Storage accounts and their sub-resources including blob containers, file shares, queues, and tables.
 

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
@@ -174,7 +174,7 @@ public class AcrolinxPostProcessorTests
     [Fact]
     public void WrapBareSkillNames_PreservesUrls()
     {
-        var input = "**Skill:** `azure-storage` | [Source code](https://github.com/microsoft/GitHub-Copilot-for-Azure/tree/main/plugin/skills/azure-storage)";
+        var input = "**Skill:** `azure-storage` | [Source code](https://github.com/microsoft/azure-skills/tree/main/skills/azure-storage)";
         var result = AcrolinxPostProcessor.WrapBareSkillNames(input);
         // The URL should not have backticks injected
         result.Should().Contain("skills/azure-storage)");

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
@@ -147,9 +147,9 @@ public class NaturalizeItemsTests
 public class BuildContextDoNotUseForTests
 {
     private static readonly string SimpleTemplate = @"---
-title: {{displayName}}
+title: Azure skill for {{displayName}}
 ---
-# {{displayName}}
+# Azure skill for {{displayName}}
 {{#if hasDoNotUseFor}}
 ## When NOT to use
 {{#each doNotUseFor}}
@@ -227,10 +227,10 @@ title: {{displayName}}
 public class SkillPageGeneratorTests
 {
     private static readonly string SimpleTemplate = @"---
-title: {{displayName}}
+title: Azure skill for {{displayName}}
 description: {{description}}
 ---
-# {{displayName}}
+# Azure skill for {{displayName}}
 
 {{description}}
 
@@ -239,7 +239,7 @@ description: {{description}}
 - **GitHub Copilot** — Required.
 {{#if hasUseFor}}
 
-## When to use this skill
+### When to use this skill
 
 {{#each useFor}}
 - {{this}}
@@ -297,7 +297,7 @@ The skill provides knowledge about {{displayName}}.
         var result = generator.Generate(skill, triggers, tier, prereqs);
 
         result.Should().Contain("---");
-        result.Should().Contain("title: Azure Storage");
+        result.Should().Contain("title: Azure skill for Azure Storage");
         result.Should().Contain("description: Manage Azure Storage");
     }
 

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
@@ -18,11 +18,11 @@ public class SkillPageValidatorTests
 
     private static string CreateValidTier1Content() => """
         ---
-        title: Azure Storage
+        title: Azure skill for Azure Storage
         description: Work with Azure Storage accounts and resources.
         ---
 
-        # Azure Storage
+        # Azure skill for Azure Storage
 
         Work with Azure Storage accounts and resources for blob containers and file shares.
 
@@ -31,7 +31,7 @@ public class SkillPageValidatorTests
         - GitHub Copilot with Azure extension
         - Azure subscription
 
-        ## When to use this skill
+        ### When to use this skill
 
         Use this skill when managing storage accounts and working with blob containers and queues and tables.
 
@@ -46,11 +46,11 @@ public class SkillPageValidatorTests
 
     private static string CreateValidTier2Content() => """
         ---
-        title: Azure Quotas
+        title: Azure skill for Azure Quotas
         description: Check Azure quotas.
         ---
 
-        # Azure Quotas
+        # Azure skill for Azure Quotas
 
         Check and manage your Azure subscription quotas and usage limits effectively with GitHub Copilot assistance today.
 
@@ -58,7 +58,7 @@ public class SkillPageValidatorTests
 
         - GitHub Copilot
 
-        ## When to use this skill
+        ### When to use this skill
 
         Use this skill to check quotas.
 
@@ -95,14 +95,14 @@ public class SkillPageValidatorTests
     {
         var content = """
             ---
-            title: Test
+            title: Azure skill for Test
             description: Test
             ---
-            # Test
+            # Azure skill for Test
 
             Some content about this skill.
 
-            ## When to use this skill
+            ### When to use this skill
 
             Use it.
 
@@ -147,7 +147,7 @@ public class SkillPageValidatorTests
     {
         var content = """
             ---
-            title: Test
+            title: Azure skill for Test
             description: Test content here
             ---
 
@@ -157,7 +157,7 @@ public class SkillPageValidatorTests
 
             - Azure CLI
 
-            ## When to use this skill
+            ### When to use this skill
 
             Use it.
 
@@ -175,7 +175,7 @@ public class SkillPageValidatorTests
     {
         var content = """
             ---
-            title: Test
+            title: Azure skill for Test
             description: Test
             ---
 
@@ -185,7 +185,7 @@ public class SkillPageValidatorTests
 
             - GitHub Copilot
 
-            ## When to use this skill
+            ### When to use this skill
 
             Use it.
 

--- a/skills-generation/SkillsGen.Core/Fetchers/GitHubSkillFetcher.cs
+++ b/skills-generation/SkillsGen.Core/Fetchers/GitHubSkillFetcher.cs
@@ -21,9 +21,9 @@ public class GitHubSkillFetcher : ISkillSourceFetcher
         HttpClient httpClient,
         ILogger<GitHubSkillFetcher> logger,
         string owner = "microsoft",
-        string repo = "GitHub-Copilot-for-Azure",
+        string repo = "azure-skills",
         string branch = "main",
-        string skillsPath = "plugin/skills",
+        string skillsPath = "skills",
         string? token = null)
     {
         _httpClient = httpClient;

--- a/skills-generation/templates/skill-page-template.hbs
+++ b/skills-generation/templates/skill-page-template.hbs
@@ -12,7 +12,7 @@ ms.service: azure-mcp-server
 
 {{{description}}}
 
-**Skill:** `{{{name}}}` | [Source code](https://github.com/microsoft/GitHub-Copilot-for-Azure/tree/main/plugin/skills/{{{name}}})
+**Skill:** `{{{name}}}` | [Source code](https://github.com/microsoft/azure-skills/tree/main/skills/{{{name}}})
 
 ## Prerequisites
 

--- a/skills-generation/templates/skill-page-template.hbs
+++ b/skills-generation/templates/skill-page-template.hbs
@@ -1,5 +1,5 @@
 ---
-title: {{{displayName}}}
+title: Azure skill for {{{displayName}}}
 description: {{{description}}}
 ms.topic: reference
 ms.date: {{{generatedDate}}}
@@ -8,7 +8,7 @@ ms.author: diberry
 ms.service: azure-mcp-server
 ---
 
-# {{{displayName}}}
+# Azure skill for {{{displayName}}}
 
 {{{description}}}
 
@@ -23,6 +23,16 @@ ms.service: azure-mcp-server
 - **Azure subscription**—An active Azure subscription is required.
 {{/if}}
 - **GitHub Copilot**—GitHub Copilot with the Azure extension enabled.
+
+{{#if hasUseFor}}
+### When to use this skill
+
+Use the **{{{displayName}}}** skill when you need to:
+
+{{#each useFor}}
+- {{{this}}}
+{{/each}}
+{{/if}}
 {{#if hasRbacRoles}}
 
 ### Required roles
@@ -47,16 +57,6 @@ ms.service: azure-mcp-server
 
 {{#each prerequisites.resources}}
 - **{{{resourceType}}}**—{{{description}}}{{#if quickCreateCommand}} Quick create: `{{{quickCreateCommand}}}`{{/if}}
-{{/each}}
-{{/if}}
-
-{{#if hasUseFor}}
-## When to use this skill
-
-Use the **{{{displayName}}}** skill when you need to:
-
-{{#each useFor}}
-- {{{this}}}
 {{/each}}
 {{/if}}
 


### PR DESCRIPTION
## Summary
Skills have moved from \microsoft/GitHub-Copilot-for-Azure/plugin/skills/\ to \microsoft/azure-skills/skills/\.

### Changes
- \GitHubSkillFetcher.cs\: Updated default repo (\zure-skills\) and path (\skills\)
- \skill-page-template.hbs\: Updated source code URL to new repo
- \AcrolinxPostProcessorTests.cs\: Updated test fixture URL
- Also includes previous commit: skill template title/prereqs restructure

### Tests
All 152 tests pass.