### PR TITLE
feat: E2E integration test harness for single namespace pipeline

### DIFF
--- a/docs-generation.sln
+++ b/docs-generation.sln
@@ -108,6 +108,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocGeneration.Tools.Fingerp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocGeneration.TestInfrastructure", "docs-generation\DocGeneration.TestInfrastructure\DocGeneration.TestInfrastructure.csproj", "{F2AD7AFC-92BC-438A-AAD4-9C339425A522}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocGeneration.E2E.Tests", "docs-generation\DocGeneration.E2E.Tests\DocGeneration.E2E.Tests.csproj", "{2E9DD663-0E87-422B-9ECB-72F745A6F578}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -646,6 +648,18 @@ Global
 		{F2AD7AFC-92BC-438A-AAD4-9C339425A522}.Release|x64.Build.0 = Release|Any CPU
 		{F2AD7AFC-92BC-438A-AAD4-9C339425A522}.Release|x86.ActiveCfg = Release|Any CPU
 		{F2AD7AFC-92BC-438A-AAD4-9C339425A522}.Release|x86.Build.0 = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|x64.Build.0 = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -678,5 +692,6 @@ Global
 		{858DB81C-6634-4E95-9BF0-8DB411F61595} = {DF01CBFE-2A46-B04D-C9C1-3B401942EB66}
 		{8F464DF9-1EF0-450D-92D1-2A6B9F90F422} = {DF01CBFE-2A46-B04D-C9C1-3B401942EB66}
 		{F2AD7AFC-92BC-438A-AAD4-9C339425A522} = {DF01CBFE-2A46-B04D-C9C1-3B401942EB66}
+		{2E9DD663-0E87-422B-9ECB-72F745A6F578} = {DF01CBFE-2A46-B04D-C9C1-3B401942EB66}
 	EndGlobalSection
 EndGlobal

--- a/docs-generation/DocGeneration.E2E.Tests/CrossStepConsistencyTests.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/CrossStepConsistencyTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DocGeneration.E2E.Tests.Fixtures;
+using DocGeneration.E2E.Tests.Helpers;
+
+namespace DocGeneration.E2E.Tests;
+
+/// <summary>
+/// Validates cross-step consistency: annotations, parameters, and raw tools
+/// should all reference the same set of tools for the "advisor" namespace.
+/// </summary>
+[Collection(E2ETestCollection.Name)]
+[Trait("Category", "E2E")]
+public sealed class CrossStepConsistencyTests : E2ETestBase
+{
+    public CrossStepConsistencyTests(PipelineOutputFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public void EveryAnnotationFileHasMatchingParameterFile()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationBaseNames = OutputValidator.GetToolBaseNames(
+            Fixture.OutputPath, "annotations", "-annotations");
+        var parameterBaseNames = OutputValidator.GetToolBaseNames(
+            Fixture.OutputPath, "parameters", "-parameters");
+
+        var missingInParameters = annotationBaseNames.Except(parameterBaseNames).ToList();
+        Assert.True(
+            missingInParameters.Count == 0,
+            $"Annotations exist without matching parameters: {string.Join(", ", missingInParameters)}");
+    }
+
+    [Fact]
+    public void EveryParameterFileHasMatchingAnnotationFile()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationBaseNames = OutputValidator.GetToolBaseNames(
+            Fixture.OutputPath, "annotations", "-annotations");
+        var parameterBaseNames = OutputValidator.GetToolBaseNames(
+            Fixture.OutputPath, "parameters", "-parameters");
+
+        var missingInAnnotations = parameterBaseNames.Except(annotationBaseNames).ToList();
+        Assert.True(
+            missingInAnnotations.Count == 0,
+            $"Parameters exist without matching annotations: {string.Join(", ", missingInAnnotations)}");
+    }
+
+    [Fact]
+    public void RawToolBaseNamesMatchAnnotationBaseNames()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationBaseNames = OutputValidator.GetToolBaseNames(
+            Fixture.OutputPath, "annotations", "-annotations");
+
+        var rawToolFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw");
+        var rawToolBaseNames = rawToolFiles
+            .Select(f => Path.GetFileNameWithoutExtension(f))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var missingRawTools = annotationBaseNames.Except(rawToolBaseNames).ToList();
+        var extraRawTools = rawToolBaseNames.Except(annotationBaseNames).ToList();
+
+        Assert.True(
+            missingRawTools.Count == 0,
+            $"Annotations without matching raw tools: {string.Join(", ", missingRawTools)}");
+        Assert.True(
+            extraRawTools.Count == 0,
+            $"Raw tools without matching annotations: {string.Join(", ", extraRawTools)}");
+    }
+
+    [Fact]
+    public void RawToolFilesContainCommandComment()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var rawToolFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw");
+        Assert.NotEmpty(rawToolFiles);
+
+        foreach (var file in rawToolFiles)
+        {
+            var content = File.ReadAllText(file);
+            Assert.True(
+                content.Contains("azmcp", StringComparison.OrdinalIgnoreCase),
+                $"Raw tool file should reference azmcp command: {Path.GetFileName(file)}");
+        }
+    }
+
+    [Fact]
+    public void ParameterFilesHaveSubstantialContent()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var parameterFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters");
+        Assert.NotEmpty(parameterFiles);
+
+        foreach (var file in parameterFiles)
+        {
+            var content = File.ReadAllText(file);
+            // Parameter files should have more than just frontmatter (at minimum a table or content)
+            Assert.True(
+                content.Length > 100,
+                $"Parameter file suspiciously short ({content.Length} chars): {Path.GetFileName(file)}");
+        }
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/DocGeneration.E2E.Tests.csproj
+++ b/docs-generation/DocGeneration.E2E.Tests/DocGeneration.E2E.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>DocGeneration.E2E.Tests</AssemblyName>
+    <RootNamespace>DocGeneration.E2E.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DocGeneration.PipelineRunner\DocGeneration.PipelineRunner.csproj" />
+    <ProjectReference Include="..\DocGeneration.TestInfrastructure\DocGeneration.TestInfrastructure.csproj" />
+    <ProjectReference Include="..\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>

--- a/docs-generation/DocGeneration.E2E.Tests/E2ETestBase.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/E2ETestBase.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DocGeneration.E2E.Tests.Fixtures;
+
+namespace DocGeneration.E2E.Tests;
+
+/// <summary>
+/// Base class for E2E tests that depend on the shared pipeline output fixture.
+/// Provides guard logic and common assertions.
+/// </summary>
+public abstract class E2ETestBase
+{
+    protected readonly PipelineOutputFixture Fixture;
+
+    protected E2ETestBase(PipelineOutputFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    /// <summary>
+    /// Ensures the pipeline ran successfully. Returns false if E2E tests are disabled
+    /// (caller should return early). Asserts pipeline success when enabled.
+    /// </summary>
+    protected bool EnsurePipelineRan()
+    {
+        if (!Fixture.PipelineRan)
+            return false;
+
+        Assert.Equal(0, Fixture.ExitCode);
+        return true;
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/Fixtures/E2ETestCollection.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/Fixtures/E2ETestCollection.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DocGeneration.E2E.Tests.Fixtures;
+
+/// <summary>
+/// xUnit collection definition that ensures all E2E test classes
+/// share a single pipeline run via PipelineOutputFixture.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class E2ETestCollection : ICollectionFixture<PipelineOutputFixture>
+{
+    public const string Name = "E2E Pipeline Tests";
+}

--- a/docs-generation/DocGeneration.E2E.Tests/Fixtures/PipelineOutputFixture.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/Fixtures/PipelineOutputFixture.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PipelineRunner.Cli;
+using DocGeneration.TestInfrastructure;
+
+namespace DocGeneration.E2E.Tests.Fixtures;
+
+/// <summary>
+/// Shared fixture that runs the pipeline once for the "advisor" namespace (Step 1 only).
+/// All E2E test classes in the same collection share this single pipeline run.
+/// Requires RUN_E2E_TESTS=true environment variable to actually execute the pipeline.
+/// </summary>
+public sealed class PipelineOutputFixture : IAsyncLifetime
+{
+    public const string TestNamespace = "advisor";
+
+    public string OutputPath { get; private set; } = string.Empty;
+    public int ExitCode { get; private set; } = -1;
+    public bool PipelineRan { get; private set; }
+    public string? SkipReason { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        if (!IsE2EEnabled())
+        {
+            SkipReason = "E2E tests are opt-in. Set RUN_E2E_TESTS=true to run.";
+            return;
+        }
+
+        var repoRoot = ProjectRootFinder.FindSolutionRoot();
+        OutputPath = Path.Combine(repoRoot, $"generated-e2e-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(OutputPath);
+
+        var request = new PipelineRequest(
+            Namespace: TestNamespace,
+            Steps: [1],
+            OutputPath: OutputPath,
+            SkipBuild: false,
+            SkipValidation: false,
+            DryRun: false,
+            SkipEnvValidation: true,
+            SkipDependencyValidation: true);
+
+        var runner = PipelineRunner.PipelineRunner.CreateDefault(repoRoot);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        ExitCode = await runner.RunAsync(request, cts.Token);
+        PipelineRan = true;
+    }
+
+    public Task DisposeAsync()
+    {
+        if (PipelineRan && Directory.Exists(OutputPath))
+        {
+            try { Directory.Delete(OutputPath, recursive: true); }
+            catch { /* best effort cleanup */ }
+        }
+        return Task.CompletedTask;
+    }
+
+    private static bool IsE2EEnabled()
+    {
+        var value = Environment.GetEnvironmentVariable("RUN_E2E_TESTS");
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "1", StringComparison.Ordinal);
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/FrontmatterParserTests.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/FrontmatterParserTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DocGeneration.E2E.Tests.Helpers;
+
+namespace DocGeneration.E2E.Tests;
+
+/// <summary>
+/// Unit tests for the FrontmatterParser helper.
+/// These run independently of the pipeline (no E2E fixture needed).
+/// </summary>
+[Trait("Category", "E2E")]
+public sealed class FrontmatterParserTests
+{
+    [Fact]
+    public void Parse_ValidFrontmatter_ReturnsFields()
+    {
+        var content = "---\nms.topic: include\nms.date: 2025-07-01\nmcp-cli.version: 1.0.0\n---\n\n# Content";
+        var result = FrontmatterParser.Parse(content);
+
+        Assert.NotNull(result);
+        Assert.Equal("include", result["ms.topic"]);
+        Assert.Equal("2025-07-01", result["ms.date"]);
+        Assert.Equal("1.0.0", result["mcp-cli.version"]);
+    }
+
+    [Fact]
+    public void Parse_FrontmatterWithComments_SkipsComments()
+    {
+        var content = "---\nms.topic: include\n# This is a comment\nms.date: 2025-07-01\n---\n";
+        var result = FrontmatterParser.Parse(content);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("include", result["ms.topic"]);
+    }
+
+    [Fact]
+    public void Parse_NoFrontmatter_ReturnsNull()
+    {
+        var content = "# Just a markdown file\nWith some content.";
+        var result = FrontmatterParser.Parse(content);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Parse_EmptyContent_ReturnsNull()
+    {
+        Assert.Null(FrontmatterParser.Parse(""));
+        Assert.Null(FrontmatterParser.Parse(null!));
+    }
+
+    [Fact]
+    public void Parse_MissingClosingDelimiter_ReturnsNull()
+    {
+        var content = "---\nms.topic: include\nms.date: 2025-07-01\n";
+        var result = FrontmatterParser.Parse(content);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HasFrontmatter_ValidBlock_ReturnsTrue()
+    {
+        var content = "---\nms.topic: include\n---\n# Content";
+        Assert.True(FrontmatterParser.HasFrontmatter(content));
+    }
+
+    [Fact]
+    public void HasFrontmatter_NoBlock_ReturnsFalse()
+    {
+        var content = "# Just markdown\nNo frontmatter here.";
+        Assert.False(FrontmatterParser.HasFrontmatter(content));
+    }
+
+    [Fact]
+    public void Parse_FrontmatterWithGeneratedTimestamp_ParsesCorrectly()
+    {
+        var content = "---\nms.topic: include\nms.date: 2025-07-01\nmcp-cli.version: 1.2.3\ngenerated: 2025-07-01 12:00:00 UTC\n---\n";
+        var result = FrontmatterParser.Parse(content);
+
+        Assert.NotNull(result);
+        Assert.Equal("2025-07-01 12:00:00 UTC", result["generated"]);
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/FrontmatterValidationTests.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/FrontmatterValidationTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DocGeneration.E2E.Tests.Fixtures;
+using DocGeneration.E2E.Tests.Helpers;
+
+namespace DocGeneration.E2E.Tests;
+
+/// <summary>
+/// Validates YAML frontmatter in all generated .md files from Step 1.
+/// Checks that annotations use ms.topic: include, raw tools use ms.topic: reference,
+/// and all files contain required metadata fields.
+/// </summary>
+[Collection(E2ETestCollection.Name)]
+[Trait("Category", "E2E")]
+public sealed class FrontmatterValidationTests : E2ETestBase
+{
+    public FrontmatterValidationTests(PipelineOutputFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public void AnnotationFiles_HaveValidFrontmatter()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var files = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        Assert.NotEmpty(files);
+
+        foreach (var file in files)
+        {
+            var content = File.ReadAllText(file);
+            var frontmatter = FrontmatterParser.Parse(content);
+            Assert.True(frontmatter is not null, $"Missing frontmatter in {Path.GetFileName(file)}");
+        }
+    }
+
+    [Fact]
+    public void AnnotationFiles_HaveMsTopicInclude()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var files = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        foreach (var file in files)
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.TryGetValue("ms.topic", out var topic),
+                $"Missing ms.topic in {Path.GetFileName(file)}");
+            Assert.Equal("include", topic);
+        }
+    }
+
+    [Fact]
+    public void ParameterFiles_HaveMsTopicInclude()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var files = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters");
+        foreach (var file in files)
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.TryGetValue("ms.topic", out var topic),
+                $"Missing ms.topic in {Path.GetFileName(file)}");
+            Assert.Equal("include", topic);
+        }
+    }
+
+    [Fact]
+    public void RawToolFiles_HaveMsTopicReference()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var files = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw");
+        foreach (var file in files)
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.TryGetValue("ms.topic", out var topic),
+                $"Missing ms.topic in {Path.GetFileName(file)}");
+            Assert.Equal("reference", topic);
+        }
+    }
+
+    [Fact]
+    public void AllFiles_HaveMcpCliVersion()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var allFiles = GetAllStep1MarkdownFiles();
+        foreach (var file in allFiles)
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.ContainsKey("mcp-cli.version"),
+                $"Missing mcp-cli.version in {Path.GetFileName(file)}");
+        }
+    }
+
+    [Fact]
+    public void AllFiles_HaveMsDate()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var allFiles = GetAllStep1MarkdownFiles();
+        foreach (var file in allFiles)
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.ContainsKey("ms.date"),
+                $"Missing ms.date in {Path.GetFileName(file)}");
+
+            var msDate = frontmatter["ms.date"];
+            Assert.False(
+                string.IsNullOrWhiteSpace(msDate),
+                $"ms.date is empty in {Path.GetFileName(file)}");
+        }
+    }
+
+    [Fact]
+    public void AnnotationAndParameterFiles_HaveGeneratedField()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        var parameterFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters");
+
+        foreach (var file in annotationFiles.Concat(parameterFiles))
+        {
+            var frontmatter = FrontmatterParser.ParseFile(file);
+            Assert.NotNull(frontmatter);
+            Assert.True(
+                frontmatter.ContainsKey("generated"),
+                $"Missing 'generated' field in {Path.GetFileName(file)}");
+        }
+    }
+
+    private IEnumerable<string> GetAllStep1MarkdownFiles()
+    {
+        return OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations")
+            .Concat(OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters"))
+            .Concat(OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw"));
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/GlobalUsings.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+global using Xunit;

--- a/docs-generation/DocGeneration.E2E.Tests/Helpers/FrontmatterParser.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/Helpers/FrontmatterParser.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DocGeneration.E2E.Tests.Helpers;
+
+/// <summary>
+/// Parses YAML frontmatter from generated markdown files.
+/// Extracts the key-value pairs between the opening and closing "---" markers.
+/// </summary>
+public static class FrontmatterParser
+{
+    /// <summary>
+    /// Attempts to parse YAML frontmatter from markdown content.
+    /// Returns null if no valid frontmatter block is found.
+    /// </summary>
+    public static Dictionary<string, string>? Parse(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var lines = content.Split('\n');
+        if (lines.Length < 2)
+            return null;
+
+        // First line must be "---"
+        if (lines[0].Trim() != "---")
+            return null;
+
+        var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+
+            // Closing delimiter
+            if (line.Trim() == "---")
+                return fields;
+
+            // Skip YAML comments
+            if (line.TrimStart().StartsWith('#'))
+                continue;
+
+            // Skip multi-line continuation (indented lines)
+            if (line.StartsWith("  ") || line.StartsWith("\t"))
+                continue;
+
+            // Parse key: value
+            var colonIndex = line.IndexOf(':');
+            if (colonIndex > 0)
+            {
+                var key = line[..colonIndex].Trim();
+                var value = line[(colonIndex + 1)..].Trim();
+                fields[key] = value;
+            }
+        }
+
+        // No closing "---" found
+        return null;
+    }
+
+    /// <summary>
+    /// Reads a file and parses its frontmatter. Returns null if file doesn't exist or has no frontmatter.
+    /// </summary>
+    public static Dictionary<string, string>? ParseFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return null;
+
+        var content = File.ReadAllText(filePath);
+        return Parse(content);
+    }
+
+    /// <summary>
+    /// Checks whether the content starts with a valid frontmatter block (--- ... ---).
+    /// </summary>
+    public static bool HasFrontmatter(string content)
+    {
+        return Parse(content) is not null;
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/Helpers/OutputValidator.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/Helpers/OutputValidator.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DocGeneration.E2E.Tests.Helpers;
+
+/// <summary>
+/// Validates the directory structure and file counts of pipeline output.
+/// </summary>
+public static class OutputValidator
+{
+    /// <summary>
+    /// Returns all .md files in the specified subdirectory of the output path.
+    /// </summary>
+    public static string[] GetMarkdownFiles(string outputPath, string subdirectory)
+    {
+        var dir = Path.Combine(outputPath, subdirectory);
+        if (!Directory.Exists(dir))
+            return Array.Empty<string>();
+
+        return Directory.GetFiles(dir, "*.md");
+    }
+
+    /// <summary>
+    /// Returns all files matching a pattern in the specified subdirectory.
+    /// </summary>
+    public static string[] GetFiles(string outputPath, string subdirectory, string pattern = "*")
+    {
+        var dir = Path.Combine(outputPath, subdirectory);
+        if (!Directory.Exists(dir))
+            return Array.Empty<string>();
+
+        return Directory.GetFiles(dir, pattern);
+    }
+
+    /// <summary>
+    /// Extracts the tool base name from a generated filename by removing the suffix.
+    /// Example: "azure-advisor-get-annotations.md" with suffix "-annotations" → "azure-advisor-get"
+    /// </summary>
+    public static string ExtractBaseName(string filePath, string suffix)
+    {
+        var fileName = Path.GetFileNameWithoutExtension(filePath);
+        return fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? fileName[..^suffix.Length]
+            : fileName;
+    }
+
+    /// <summary>
+    /// Gets the set of tool base names from a directory, stripping the given suffix.
+    /// </summary>
+    public static HashSet<string> GetToolBaseNames(string outputPath, string subdirectory, string suffix)
+    {
+        var files = GetMarkdownFiles(outputPath, subdirectory);
+        return files
+            .Select(f => ExtractBaseName(f, suffix))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/docs-generation/DocGeneration.E2E.Tests/Step1OutputStructureTests.cs
+++ b/docs-generation/DocGeneration.E2E.Tests/Step1OutputStructureTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DocGeneration.E2E.Tests.Fixtures;
+using DocGeneration.E2E.Tests.Helpers;
+
+namespace DocGeneration.E2E.Tests;
+
+/// <summary>
+/// Validates the output directory structure after running Step 1 (annotations, parameters, raw tools)
+/// for the "advisor" namespace. Ensures all expected directories exist with correct file counts.
+/// </summary>
+[Collection(E2ETestCollection.Name)]
+[Trait("Category", "E2E")]
+public sealed class Step1OutputStructureTests : E2ETestBase
+{
+    public Step1OutputStructureTests(PipelineOutputFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public void AnnotationsDirectoryExists_WithMarkdownFiles()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var dir = Path.Combine(Fixture.OutputPath, "annotations");
+        Assert.True(Directory.Exists(dir), $"annotations/ directory should exist at {dir}");
+
+        var mdFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        Assert.True(mdFiles.Length > 0, "annotations/ should contain at least one .md file");
+    }
+
+    [Fact]
+    public void ParametersDirectoryExists_WithMarkdownFiles()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var dir = Path.Combine(Fixture.OutputPath, "parameters");
+        Assert.True(Directory.Exists(dir), $"parameters/ directory should exist at {dir}");
+
+        var mdFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters");
+        Assert.True(mdFiles.Length > 0, "parameters/ should contain at least one .md file");
+    }
+
+    [Fact]
+    public void RawToolsDirectoryExists_WithMarkdownFiles()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var dir = Path.Combine(Fixture.OutputPath, "tools-raw");
+        Assert.True(Directory.Exists(dir), $"tools-raw/ directory should exist at {dir}");
+
+        var mdFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw");
+        Assert.True(mdFiles.Length > 0, "tools-raw/ should contain at least one .md file");
+    }
+
+    [Fact]
+    public void AnnotationsAndParametersHaveMatchingToolCounts()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        var parameterFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters");
+
+        Assert.Equal(annotationFiles.Length, parameterFiles.Length);
+    }
+
+    [Fact]
+    public void RawToolCountMatchesAnnotationCount()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var annotationFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations");
+        var rawToolFiles = OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw");
+
+        Assert.Equal(annotationFiles.Length, rawToolFiles.Length);
+    }
+
+    [Fact]
+    public void AllGeneratedFilesAreNonEmpty()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var allMdFiles = new List<string>();
+        allMdFiles.AddRange(OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "annotations"));
+        allMdFiles.AddRange(OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "parameters"));
+        allMdFiles.AddRange(OutputValidator.GetMarkdownFiles(Fixture.OutputPath, "tools-raw"));
+
+        foreach (var file in allMdFiles)
+        {
+            var info = new FileInfo(file);
+            Assert.True(info.Length > 0, $"File should not be empty: {Path.GetFileName(file)}");
+        }
+    }
+
+    [Fact]
+    public void CliMetadataDirectoryExists()
+    {
+        if (!EnsurePipelineRan()) return;
+
+        var cliDir = Path.Combine(Fixture.OutputPath, "cli");
+        Assert.True(Directory.Exists(cliDir), "cli/ directory should exist from bootstrap");
+
+        var cliOutputFile = Path.Combine(cliDir, "cli-output.json");
+        Assert.True(File.Exists(cliOutputFile), "cli/cli-output.json should exist from bootstrap");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #342

## Changes
- New DocGeneration.E2E.Tests project with 27 tests (19 pipeline + 8 parser)
- Step1OutputStructureTests: validates directory structure after Step 1
- FrontmatterValidationTests: validates YAML frontmatter contracts
- CrossStepConsistencyTests: annotations match parameters match raw tools
- Pipeline runs in-process via collection fixture (single shared run)
- Opt-in via RUN_E2E_TESTS=true env var

## Tests
- 27 new tests across 4 classes
- <5s when disabled, <60s target when enabled
- Uses Trait Category=E2E for CI filtering

## Note
CI needs a dedicated workflow job with Node.js + azmcp CLI prerequisites.