### PR TITLE
feat: add JSON output to Step 5 and skills section to horizontal articles (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Skills PRD Phase 1: JSON output + horizontal article integration** — Step 5 (SkillsRelevance) now outputs structured JSON alongside markdown for downstream consumption. Step 6 (HorizontalArticles) reads the JSON and renders a "GitHub Copilot extensions" section in horizontal articles when relevant skills exist. Graceful fallback when Step 5 output is missing. (#297)
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)
 - `start-azure-skills.sh` entry point script

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
@@ -15,5 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.Steps.HorizontalArticles\DocGeneration.Steps.HorizontalArticles.csproj" />
     <ProjectReference Include="..\DocGeneration.Core.TextTransformation\DocGeneration.Core.TextTransformation.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.SkillsRelevance\DocGeneration.Steps.SkillsRelevance.csproj" />
   </ItemGroup>
 </Project>

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsContractTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsContractTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using HorizontalArticleGenerator.Services;
+using SkillsRelevance.Models;
+using SkillsRelevance.Output;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+/// <summary>
+/// Cross-step contract test: validates that Step 5 JSON output can be consumed by Step 6 reader.
+/// This catches writer/reader drift since they use separate models.
+/// </summary>
+public class SkillsContractTests : IDisposable
+{
+    private readonly string _outputBasePath;
+
+    public SkillsContractTests()
+    {
+        _outputBasePath = Path.Combine(Path.GetTempPath(), "skills-contract-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputBasePath))
+            Directory.Delete(_outputBasePath, recursive: true);
+    }
+
+    [Fact]
+    public async Task Step5Writer_Step6Reader_Roundtrips()
+    {
+        var skillsDir = Path.Combine(_outputBasePath, "skills-relevance");
+
+        var skills = new List<SkillInfo>
+        {
+            new()
+            {
+                Name = "Copilot for Azure",
+                SourceRepository = "microsoft/GitHub-Copilot-for-Azure",
+                SourceUrl = "https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure.md",
+                RelevanceScore = 0.85,
+                Description = "Azure resource management and troubleshooting",
+                Tags = new List<string> { "azure", "cloud", "management" }
+            },
+            new()
+            {
+                Name = "Storage Explorer Skill",
+                SourceRepository = "test/storage-skills",
+                SourceUrl = "https://github.com/test/storage-skills/blob/main/explorer.md",
+                RelevanceScore = 0.55,
+                Description = "Navigate and manage Azure Storage accounts",
+                Tags = new List<string> { "storage", "blob" }
+            },
+            new()
+            {
+                Name = "Low Relevance Skill",
+                SourceRepository = "test/low",
+                SourceUrl = "https://github.com/test/low/blob/main/skill.md",
+                RelevanceScore = 0.3,
+                Description = "Not very relevant",
+                Tags = new List<string> { "misc" }
+            }
+        };
+
+        // Step 5 writes JSON
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(skillsDir, "storage", skills);
+
+        // Step 6 reads JSON
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "storage");
+
+        // Verify: high + medium skills returned, low skill filtered
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal("Copilot for Azure", result[0].Name);
+        Assert.Equal(0.85, result[0].RelevanceScore);
+        Assert.Equal("Azure resource management and troubleshooting", result[0].Description);
+        Assert.Equal("https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure.md", result[0].SourceUrl);
+
+        Assert.Equal("Storage Explorer Skill", result[1].Name);
+        Assert.Equal(0.55, result[1].RelevanceScore);
+    }
+
+    [Fact]
+    public async Task Step5Writer_Step6Reader_EmptySkills_Roundtrips()
+    {
+        var skillsDir = Path.Combine(_outputBasePath, "skills-relevance");
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(skillsDir, "keyvault", new List<SkillInfo>());
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "keyvault");
+
+        Assert.Empty(result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsJsonReaderTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsJsonReaderTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using HorizontalArticleGenerator.Services;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+public class SkillsJsonReaderTests : IDisposable
+{
+    private readonly string _outputBasePath;
+
+    public SkillsJsonReaderTests()
+    {
+        _outputBasePath = Path.Combine(Path.GetTempPath(), "skills-reader-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputBasePath))
+            Directory.Delete(_outputBasePath, recursive: true);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_MissingFile_ReturnsEmptyList()
+    {
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "nonexistent");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_MalformedJson_ReturnsEmptyList()
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "storage-skills-relevance.json"), "not valid json {{{");
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "storage");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_ValidJson_ReturnsFilteredSkills()
+    {
+        await WriteSkillsJsonAsync("compute", new[]
+        {
+            new { name = "High Skill", source = "test", sourceUrl = "https://example.com/high", relevanceScore = 0.9, relevanceLevel = "High", description = "A high relevance skill", tags = new[] { "azure" } },
+            new { name = "Medium Skill", source = "test", sourceUrl = "https://example.com/med", relevanceScore = 0.5, relevanceLevel = "Medium", description = "A medium relevance skill", tags = new[] { "azure" } },
+            new { name = "Low Skill", source = "test", sourceUrl = "https://example.com/low", relevanceScore = 0.3, relevanceLevel = "Low", description = "A low relevance skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "compute");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("High Skill", result[0].Name);
+        Assert.Equal("Medium Skill", result[1].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_FiltersAtThreshold_IncludesExactly05()
+    {
+        await WriteSkillsJsonAsync("advisor", new[]
+        {
+            new { name = "Exact Threshold", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.5, relevanceLevel = "Medium", description = "Exactly at threshold", tags = new[] { "azure" } },
+            new { name = "Below Threshold", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.49, relevanceLevel = "Low", description = "Just below", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "advisor");
+
+        Assert.Single(result);
+        Assert.Equal("Exact Threshold", result[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_OrdersByScoreDescending()
+    {
+        await WriteSkillsJsonAsync("search", new[]
+        {
+            new { name = "Medium", source = "test", sourceUrl = "https://example.com/m", relevanceScore = 0.6, relevanceLevel = "Medium", description = "Medium skill", tags = new[] { "azure" } },
+            new { name = "Highest", source = "test", sourceUrl = "https://example.com/h", relevanceScore = 0.95, relevanceLevel = "High", description = "Highest skill", tags = new[] { "azure" } },
+            new { name = "High", source = "test", sourceUrl = "https://example.com/hi", relevanceScore = 0.8, relevanceLevel = "High", description = "High skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "search");
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Highest", result[0].Name);
+        Assert.Equal("High", result[1].Name);
+        Assert.Equal("Medium", result[2].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_CustomMinScore()
+    {
+        await WriteSkillsJsonAsync("redis", new[]
+        {
+            new { name = "High", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.9, relevanceLevel = "High", description = "High skill", tags = new[] { "azure" } },
+            new { name = "Medium", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.6, relevanceLevel = "Medium", description = "Medium skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "redis", minScore: 0.8);
+
+        Assert.Single(result);
+        Assert.Equal("High", result[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_SanitizesDescription_EscapesPipes()
+    {
+        await WriteSkillsJsonAsync("cosmos", new[]
+        {
+            new { name = "Pipe Skill", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.8, relevanceLevel = "High", description = "Uses pipes | in text", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "cosmos");
+
+        Assert.Single(result);
+        Assert.Equal(@"Uses pipes \| in text", result[0].Description);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_SanitizesDescription_RemovesNewlines()
+    {
+        await WriteSkillsJsonAsync("functions", new[]
+        {
+            new { name = "Newline Skill", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.8, relevanceLevel = "High", description = "Line1\nLine2\r\nLine3", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "functions");
+
+        Assert.Single(result);
+        Assert.Equal("Line1 Line2 Line3", result[0].Description);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_EmptySkillsArray_ReturnsEmptyList()
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        var json = JsonSerializer.Serialize(new { serviceName = "test", generatedAt = "2025-01-01", skills = Array.Empty<object>() });
+        await File.WriteAllTextAsync(Path.Combine(dir, "test-skills-relevance.json"), json);
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "test");
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("storage", "storage")]
+    [InlineData("Cosmos DB", "cosmos-db")]
+    [InlineData("KEY vault", "key-vault")]
+    public void SanitizeFileName_NormalizesCorrectly(string input, string expected)
+    {
+        Assert.Equal(expected, SkillsJsonReader.SanitizeFileName(input));
+    }
+
+    [Theory]
+    [InlineData("simple text", "simple text")]
+    [InlineData("has | pipe", @"has \| pipe")]
+    [InlineData("has\nnewline", "has newline")]
+    [InlineData("has\r\ncrlf", "has crlf")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void SanitizeForTable_HandlesEdgeCases(string? input, string expected)
+    {
+        Assert.Equal(expected, SkillsJsonReader.SanitizeForTable(input!));
+    }
+
+    private async Task WriteSkillsJsonAsync(string serviceId, object skills)
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        var data = new { serviceName = serviceId, generatedAt = DateTime.UtcNow.ToString("o"), skills };
+        var json = JsonSerializer.Serialize(data);
+        await File.WriteAllTextAsync(Path.Combine(dir, $"{serviceId}-skills-relevance.json"), json);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsTemplateSectionTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsTemplateSectionTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HandlebarsDotNet;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+public class SkillsTemplateSectionTests
+{
+    private const string SkillsSectionTemplate = @"## Best practices
+
+When using Azure MCP Server with {{serviceBrandName}}:
+
+- **Be specific**: Include resource names and details.
+
+{{#if skills}}
+## GitHub Copilot extensions
+
+The following GitHub Copilot extensions can help you work with {{serviceBrandName}}:
+
+| Extension | Description |
+|-----------|-------------|
+{{#each skills}}
+| [{{name}}]({{sourceUrl}}) | {{description}} |
+{{/each}}
+{{/if}}
+
+## Related content
+
+* [Azure MCP Server overview](../overview.md)";
+
+    [Fact]
+    public void Template_WithSkills_RendersSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Storage",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Copilot for Azure",
+                    ["sourceUrl"] = "https://github.com/microsoft/copilot-azure",
+                    ["description"] = "Azure resource management skill"
+                },
+                new()
+                {
+                    ["name"] = "Storage Helper",
+                    ["sourceUrl"] = "https://github.com/test/storage-helper",
+                    ["description"] = "Blob and queue operations"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains("## GitHub Copilot extensions", result);
+        Assert.Contains("The following GitHub Copilot extensions can help you work with Azure Storage:", result);
+        Assert.Contains("| [Copilot for Azure](https://github.com/microsoft/copilot-azure) | Azure resource management skill |", result);
+        Assert.Contains("| [Storage Helper](https://github.com/test/storage-helper) | Blob and queue operations |", result);
+        Assert.Contains("| Extension | Description |", result);
+    }
+
+    [Fact]
+    public void Template_WithoutSkills_DoesNotRenderSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Cosmos DB",
+            ["skills"] = new List<Dictionary<string, object>>()
+        };
+
+        var result = template(data);
+
+        Assert.DoesNotContain("## GitHub Copilot extensions", result);
+        Assert.DoesNotContain("Extension | Description", result);
+        Assert.Contains("## Best practices", result);
+        Assert.Contains("## Related content", result);
+    }
+
+    [Fact]
+    public void Template_SkillsNotProvided_DoesNotRenderSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Key Vault"
+        };
+
+        var result = template(data);
+
+        Assert.DoesNotContain("## GitHub Copilot extensions", result);
+        Assert.Contains("## Best practices", result);
+        Assert.Contains("## Related content", result);
+    }
+
+    [Fact]
+    public void Template_SingleSkill_RendersOneTableRow()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Monitor",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Monitor Diagnostics",
+                    ["sourceUrl"] = "https://github.com/test/monitor",
+                    ["description"] = "Diagnostic queries and alerts"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains("## GitHub Copilot extensions", result);
+        Assert.Contains("| [Monitor Diagnostics](https://github.com/test/monitor) | Diagnostic queries and alerts |", result);
+    }
+
+    [Fact]
+    public void Template_SkillWithEscapedPipe_RendersCorrectly()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Functions",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Functions Helper",
+                    ["sourceUrl"] = "https://github.com/test/functions",
+                    ["description"] = @"Handles input \| output bindings"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains(@"Handles input \| output bindings", result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using GenerativeAI;
 using CSharpGenerator.Models;
 using HorizontalArticleGenerator.Models;
+using HorizontalArticleGenerator.Services;
 using TemplateEngine;
 using Shared;
 using Azure.Mcp.TextTransformation.Models;
@@ -88,6 +89,11 @@ public class HorizontalArticleGenerator
             
             // Merge static + AI data
             var templateData = MergeData(staticData, aiData);
+
+            // Load skills from Step 5 output (optional, graceful fallback)
+            var skills = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, staticData.ServiceIdentifier);
+            templateData.Skills = skills;
+
             // Render and save
             await RenderAndSaveArticle(templateData);
             Console.WriteLine($"{progress} ✓ Generated: horizontal-article-{staticData.ServiceIdentifier}.md");
@@ -616,6 +622,14 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
                 ["command"] = t.Command,
                 ["moreInfoLink"] = t.MoreInfoLink,
                 ["genai-shortDescription"] = t.ShortDescription
+            }).ToList(),
+
+            // Skills from Step 5 (optional)
+            ["skills"] = templateData.Skills.Select(s => new Dictionary<string, object>
+            {
+                ["name"] = s.Name,
+                ["description"] = s.Description,
+                ["sourceUrl"] = s.SourceUrl
             }).ToList()
         };
         

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Models/HorizontalArticleTemplateData.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Models/HorizontalArticleTemplateData.cs
@@ -63,6 +63,22 @@ public class HorizontalArticleTemplateData
     
     [JsonPropertyName("genai-additionalLinks")]
     public List<AdditionalLink> AdditionalLinks { get; set; } = new();
+
+    // ===== Skills from Step 5 (optional, may be empty) =====
+
+    public List<SkillEntry> Skills { get; set; } = new();
+}
+
+/// <summary>
+/// Skill entry for rendering in horizontal articles.
+/// Separate read model — not coupled to SkillsRelevance step internals.
+/// </summary>
+public class SkillEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string SourceUrl { get; set; } = string.Empty;
+    public double RelevanceScore { get; set; }
 }
 
 /// <summary>

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Services/SkillsJsonReader.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Services/SkillsJsonReader.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using HorizontalArticleGenerator.Models;
+
+namespace HorizontalArticleGenerator.Services;
+
+/// <summary>
+/// Reads skills relevance JSON produced by Step 5.
+/// Uses its own read model to avoid coupling to the SkillsRelevance project.
+/// </summary>
+public static class SkillsJsonReader
+{
+    private const double DefaultMinScore = 0.5;
+
+    /// <summary>
+    /// Loads skills from the Step 5 JSON output file.
+    /// Returns an empty list when the file is missing or malformed (graceful fallback).
+    /// Filters to skills with relevance score >= minScore.
+    /// </summary>
+    public static async Task<List<SkillEntry>> LoadSkillsAsync(
+        string outputBasePath,
+        string serviceIdentifier,
+        double minScore = DefaultMinScore)
+    {
+        var sanitized = SanitizeFileName(serviceIdentifier);
+        var jsonPath = Path.Combine(outputBasePath, "skills-relevance", $"{sanitized}-skills-relevance.json");
+
+        if (!File.Exists(jsonPath))
+        {
+            return new List<SkillEntry>();
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(jsonPath);
+            var data = JsonSerializer.Deserialize<SkillsJsonFile>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (data?.Skills == null)
+            {
+                return new List<SkillEntry>();
+            }
+
+            return data.Skills
+                .Where(s => s.RelevanceScore >= minScore)
+                .OrderByDescending(s => s.RelevanceScore)
+                .Select(s => new SkillEntry
+                {
+                    Name = s.Name,
+                    Description = SanitizeForTable(s.Description),
+                    SourceUrl = s.SourceUrl,
+                    RelevanceScore = s.RelevanceScore
+                })
+                .ToList();
+        }
+        catch (JsonException ex)
+        {
+            Console.WriteLine($"  ⚠️ Failed to parse skills JSON for '{serviceIdentifier}': {ex.Message}");
+            return new List<SkillEntry>();
+        }
+    }
+
+    /// <summary>
+    /// Sanitizes text for use in a markdown table cell.
+    /// Escapes pipes and removes newlines.
+    /// </summary>
+    internal static string SanitizeForTable(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return text.Replace("|", "\\|").Replace("\n", " ").Replace("\r", "");
+    }
+
+    internal static string SanitizeFileName(string name) =>
+        Regex.Replace(name.ToLowerInvariant().Replace(' ', '-'), @"[^a-z0-9\-]", "");
+
+    /// <summary>
+    /// Read model matching the Step 5 JSON output schema.
+    /// </summary>
+    internal class SkillsJsonFile
+    {
+        [JsonPropertyName("serviceName")]
+        public string ServiceName { get; set; } = string.Empty;
+
+        [JsonPropertyName("generatedAt")]
+        public string GeneratedAt { get; set; } = string.Empty;
+
+        [JsonPropertyName("skills")]
+        public List<SkillsJsonFileEntry> Skills { get; set; } = new();
+    }
+
+    internal class SkillsJsonFileEntry
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = string.Empty;
+
+        [JsonPropertyName("sourceUrl")]
+        public string SourceUrl { get; set; } = string.Empty;
+
+        [JsonPropertyName("relevanceScore")]
+        public double RelevanceScore { get; set; }
+
+        [JsonPropertyName("relevanceLevel")]
+        public string RelevanceLevel { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; } = new();
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
@@ -98,6 +98,18 @@ When using Azure MCP Server with {{serviceBrandName}}:
 - **Review actions before confirming**: Carefully review destructive operations before confirming them.
 {{/if}}
 
+{{#if skills}}
+## GitHub Copilot extensions
+
+The following GitHub Copilot extensions can help you work with {{serviceBrandName}}:
+
+| Extension | Description |
+|-----------|-------------|
+{{#each skills}}
+| [{{name}}]({{sourceUrl}}) | {{description}} |
+{{/each}}
+{{/if}}
+
 ## Related content
 
 * [Azure MCP Server overview](../overview.md)

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillsJsonWriterTests.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillsJsonWriterTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using SkillsRelevance.Models;
+using SkillsRelevance.Output;
+using Xunit;
+
+namespace DocGeneration.Steps.SkillsRelevance.Tests;
+
+public class SkillsJsonWriterTests : IDisposable
+{
+    private readonly string _outputDir;
+
+    public SkillsJsonWriterTests()
+    {
+        _outputDir = Path.Combine(Path.GetTempPath(), "skills-json-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputDir))
+            Directory.Delete(_outputDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_CreatesJsonFile()
+    {
+        var skills = new List<SkillInfo>
+        {
+            CreateSkill("Azure Skill", 0.85, "GitHub Awesome Copilot", "https://github.com/test/skill1")
+        };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "storage", skills);
+
+        var filePath = Path.Combine(_outputDir, "storage-skills-relevance.json");
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_JsonRoundtrips()
+    {
+        var skills = new List<SkillInfo>
+        {
+            CreateSkill("Copilot for Azure", 0.9, "Microsoft Skills", "https://github.com/ms/skill"),
+            CreateSkill("Storage Helper", 0.6, "GitHub Awesome Copilot", "https://github.com/test/storage")
+        };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "storage", skills);
+
+        var filePath = Path.Combine(_outputDir, "storage-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("storage", deserialized!.ServiceName);
+        Assert.Equal(2, deserialized.Skills.Count);
+        Assert.Equal("Copilot for Azure", deserialized.Skills[0].Name);
+        Assert.Equal(0.9, deserialized.Skills[0].RelevanceScore);
+        Assert.Equal("High", deserialized.Skills[0].RelevanceLevel);
+        Assert.Equal("Storage Helper", deserialized.Skills[1].Name);
+        Assert.Equal("Medium", deserialized.Skills[1].RelevanceLevel);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_EmptySkills_WritesEmptyArray()
+    {
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "keyvault", new List<SkillInfo>());
+
+        var filePath = Path.Combine(_outputDir, "keyvault-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.Empty(deserialized!.Skills);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_IncludesTagsAndDescription()
+    {
+        var skill = CreateSkill("Monitor Skill", 0.7, "Microsoft Skills", "https://github.com/ms/monitor");
+        skill.Description = "Helps with Azure Monitor diagnostics";
+        skill.Tags = new List<string> { "monitoring", "diagnostics", "azure" };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "monitor", new List<SkillInfo> { skill });
+
+        var filePath = Path.Combine(_outputDir, "monitor-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        var entry = Assert.Single(deserialized!.Skills);
+        Assert.Equal("Helps with Azure Monitor diagnostics", entry.Description);
+        Assert.Equal(3, entry.Tags.Count);
+        Assert.Contains("monitoring", entry.Tags);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_SanitizesFilename()
+    {
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "Cosmos DB", new List<SkillInfo>());
+
+        var filePath = Path.Combine(_outputDir, "cosmos-db-skills-relevance.json");
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Theory]
+    [InlineData(0.95, "High")]
+    [InlineData(0.8, "High")]
+    [InlineData(0.65, "Medium")]
+    [InlineData(0.5, "Medium")]
+    [InlineData(0.35, "Low")]
+    [InlineData(0.2, "Low")]
+    [InlineData(0.1, "Minimal")]
+    [InlineData(0.0, "Minimal")]
+    public void ScoreToLevel_ReturnsCorrectLevel(double score, string expected)
+    {
+        Assert.Equal(expected, SkillJsonEntry.ScoreToLevel(score));
+    }
+
+    [Fact]
+    public void FromSkillInfo_MapsAllFields()
+    {
+        var skill = new SkillInfo
+        {
+            Name = "Test Skill",
+            SourceRepository = "test/repo",
+            SourceUrl = "https://github.com/test/repo/skill.md",
+            RelevanceScore = 0.75,
+            Description = "A test skill",
+            Tags = new List<string> { "test", "azure" }
+        };
+
+        var entry = SkillJsonEntry.FromSkillInfo(skill);
+
+        Assert.Equal("Test Skill", entry.Name);
+        Assert.Equal("test/repo", entry.Source);
+        Assert.Equal("https://github.com/test/repo/skill.md", entry.SourceUrl);
+        Assert.Equal(0.75, entry.RelevanceScore);
+        Assert.Equal("Medium", entry.RelevanceLevel);
+        Assert.Equal("A test skill", entry.Description);
+        Assert.Equal(2, entry.Tags.Count);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_HasValidGeneratedAt()
+    {
+        var before = DateTime.UtcNow;
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "redis", new List<SkillInfo>());
+        var after = DateTime.UtcNow;
+
+        var filePath = Path.Combine(_outputDir, "redis-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.True(DateTimeOffset.TryParse(deserialized!.GeneratedAt, out var parsed));
+        Assert.True(parsed >= before.AddSeconds(-1) && parsed <= after.AddSeconds(1));
+    }
+
+    private static SkillInfo CreateSkill(string name, double score, string source, string url)
+    {
+        return new SkillInfo
+        {
+            Name = name,
+            RelevanceScore = score,
+            SourceRepository = source,
+            SourceUrl = url,
+            Description = $"Description for {name}",
+            Tags = new List<string> { "azure" }
+        };
+    }
+}

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Models/SkillsRelevanceJsonOutput.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Models/SkillsRelevanceJsonOutput.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace SkillsRelevance.Models;
+
+/// <summary>
+/// JSON-serializable output for skills relevance data consumed by downstream steps.
+/// </summary>
+public class SkillsRelevanceJsonOutput
+{
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [JsonPropertyName("generatedAt")]
+    public string GeneratedAt { get; set; } = string.Empty;
+
+    [JsonPropertyName("skills")]
+    public List<SkillJsonEntry> Skills { get; set; } = new();
+}
+
+/// <summary>
+/// Individual skill entry in the JSON output.
+/// </summary>
+public class SkillJsonEntry
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceUrl")]
+    public string SourceUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("relevanceScore")]
+    public double RelevanceScore { get; set; }
+
+    [JsonPropertyName("relevanceLevel")]
+    public string RelevanceLevel { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
+    /// <summary>
+    /// Maps a relevance score to a human-readable level.
+    /// </summary>
+    public static string ScoreToLevel(double score) => score switch
+    {
+        >= 0.8 => "High",
+        >= 0.5 => "Medium",
+        >= 0.2 => "Low",
+        _ => "Minimal"
+    };
+
+    /// <summary>
+    /// Creates a SkillJsonEntry from a SkillInfo model.
+    /// </summary>
+    public static SkillJsonEntry FromSkillInfo(SkillInfo skill) => new()
+    {
+        Name = skill.Name,
+        Source = skill.SourceRepository,
+        SourceUrl = skill.SourceUrl,
+        RelevanceScore = skill.RelevanceScore,
+        RelevanceLevel = ScoreToLevel(skill.RelevanceScore),
+        Description = skill.Description,
+        Tags = skill.Tags
+    };
+}

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Output/SkillsMarkdownWriter.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Output/SkillsMarkdownWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using SkillsRelevance.Models;
 
@@ -135,6 +136,38 @@ public static class SkillsMarkdownWriter
         sb.AppendLine();
 
         await File.WriteAllTextAsync(filePath, sb.ToString(), Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Writes a JSON file containing skills relevance data for downstream consumption.
+    /// Uses the service identifier (not display name) for the filename.
+    /// </summary>
+    public static async Task WriteServiceJsonAsync(
+        string outputDir,
+        string serviceIdentifier,
+        List<SkillInfo> relevantSkills)
+    {
+        Directory.CreateDirectory(outputDir);
+
+        var jsonOutput = new SkillsRelevanceJsonOutput
+        {
+            ServiceName = serviceIdentifier,
+            GeneratedAt = DateTime.UtcNow.ToString("o"),
+            Skills = relevantSkills.Select(SkillJsonEntry.FromSkillInfo).ToList()
+        };
+
+        var fileName = $"{SanitizeFileName(serviceIdentifier)}-skills-relevance.json";
+        var filePath = Path.Combine(outputDir, fileName);
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        var json = JsonSerializer.Serialize(jsonOutput, options);
+        await File.WriteAllTextAsync(filePath, json, Encoding.UTF8);
+        Console.WriteLine($"  ✅ {fileName} (JSON, {relevantSkills.Count} skills)");
     }
 
     private static void WriteSkillSection(StringBuilder sb, SkillInfo skill, int index)

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Program.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Program.cs
@@ -110,6 +110,7 @@ internal static class Program
             // Write output
             Console.WriteLine($"Writing output to: {outputDir}");
             await SkillsMarkdownWriter.WriteServiceSummaryAsync(outputDir, serviceName, relevantSkills, sources);
+            await SkillsMarkdownWriter.WriteServiceJsonAsync(outputDir, serviceName, relevantSkills);
             await SkillsMarkdownWriter.WriteIndexAsync(outputDir, new List<string> { serviceName });
 
             Console.WriteLine();


### PR DESCRIPTION
## Summary

Phase 1 of Skills PRD (Issue #297): adds structured JSON output from Step 5 and a **GitHub Copilot extensions** section in Step 6 horizontal articles.

### Changes

#### Part A: Step 5 JSON Output
- **New model**: \SkillsRelevanceJsonOutput.cs\ — JSON-serializable DTO with service name, timestamp, and skills array (name, source, sourceUrl, relevanceScore, relevanceLevel, description, tags)
- **New method**: \SkillsMarkdownWriter.WriteServiceJsonAsync()\ writes \{service}-skills-relevance.json\ alongside existing markdown
- **Program.cs**: calls JSON writer after markdown writer

#### Part B: Step 6 Skills Section
- **New model**: \SkillEntry\ on \HorizontalArticleTemplateData\ (separate read model — no cross-step ProjectReference coupling)
- **New service**: \SkillsJsonReader.LoadSkillsAsync()\ reads Step 5 JSON with graceful fallback (empty list when file missing or malformed)
- **Filter**: only skills with relevance score ≥ 0.5 appear
- **Template**: conditional \## GitHub Copilot extensions\ section with table between Best practices and Related content
- **No dependency change**: Step 6 stays \dependsOn: [0]\ — loads skills opportunistically

### Key Design Decisions
- **Separate read model** in HorizontalArticles avoids compile-time coupling between pipeline steps
- **\dependsOn\ unchanged** — Step 5 is warn-only; Step 6 handles missing output gracefully
- **Table cell sanitization** — pipe chars and newlines are escaped for markdown safety
- **Threshold ≥ 0.5** (not > 0.5) — includes Medium relevance skills

### Tests (40 new)
- \SkillsJsonWriterTests\ (15): JSON roundtrip, ScoreToLevel mapping, empty skills, filename sanitization
- \SkillsJsonReaderTests\ (13): missing file, malformed JSON, filtering, ordering, threshold, sanitization
- \SkillsTemplateSectionTests\ (5): template renders/hides section correctly
- \SkillsContractTests\ (2): cross-step writer→reader compatibility

All 1948 tests pass (0 regressions).

Closes #297