### PR TITLE
fix: H2 title generation - verb-first, compound words, area prefix removal (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **H2 title generation — verb-first, compound words, area prefix removal** — `getSimpleToolName` Handlebars helper now produces verb-first headings (e.g., "List Activity Logs" instead of "Activitylog List"), splits compound CLI commands using `compound-words.json` (e.g., "loganalytics" → "Log Analytics"), maps verb aliases (show→Get, remove→Delete), pluralizes resources for list operations, and strips area prefix patterns. Added `loganalytics` to `compound-words.json`. 47 new tests. (#383)
 - **TOCTOU race condition in PromptHasher** — `HashFileAsync` now captures file metadata before reading content and verifies the file wasn't modified during read, throwing `IOException` on mismatch. Prevents inconsistent snapshots where hash comes from old content but size/timestamp from new file. 3 new tests. (Issue #332)
 - **Copyright headers** — Added missing MIT license headers to `PromptHasher.cs` and `PromptHasherTests.cs` to match project convention. (Issue #335)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Skills PRD Phase 1: JSON output + horizontal article integration** — Step 5 (SkillsRelevance) now outputs structured JSON alongside markdown for downstream consumption. Step 6 (HorizontalArticles) reads the JSON and renders a "GitHub Copilot extensions" section in horizontal articles when relevant skills exist. Graceful fallback when Step 5 output is missing. (#297)
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)
 - `start-azure-skills.sh` entry point script

--- a/docs-generation/DocGeneration.Core.TemplateEngine.Tests/McpHelpersGetSimpleToolNameTests.cs
+++ b/docs-generation/DocGeneration.Core.TemplateEngine.Tests/McpHelpersGetSimpleToolNameTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using TemplateEngine;
+using TemplateEngine.Helpers;
+using Xunit;
+
+namespace TemplateEngine.Tests;
+
+public class McpHelpersGetSimpleToolNameTests
+{
+    private static readonly Dictionary<string, string> CompoundWords = new()
+    {
+        ["activitylog"] = "activity-log",
+        ["loganalytics"] = "log-analytics",
+        ["consumergroup"] = "consumer-group",
+        ["healthmodels"] = "health-models",
+        ["bestpractices"] = "best-practices",
+        ["eventhub"] = "event-hub",
+        ["monitoredresources"] = "monitored-resources",
+        ["hostpool"] = "host-pool",
+        ["nodepool"] = "node-pool",
+        ["webtests"] = "web-tests",
+        ["subnetsize"] = "subnet-size",
+        ["testresource"] = "test-resource",
+        ["testrun"] = "test-run",
+    };
+
+    // Bug 1: H2s should start with an action verb
+    [Theory]
+    [InlineData("monitor activitylog list", "List")]
+    [InlineData("storage blob create", "Create")]
+    [InlineData("cosmos container delete", "Delete")]
+    [InlineData("monitor loganalytics query", "Query")]
+    [InlineData("compute vm show", "Get")]
+    [InlineData("compute vm describe", "Get")]
+    [InlineData("storage blob remove", "Delete")]
+    [InlineData("storage account add", "Create")]
+    public void StartsWithVerb(string command, string expectedVerb)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.StartsWith(expectedVerb, result);
+    }
+
+    // Bug 2: Compound CLI commands are split into readable words
+    [Theory]
+    [InlineData("monitor activitylog list", "Activity")]
+    [InlineData("monitor loganalytics query", "Log")]
+    [InlineData("monitor loganalytics query", "Analytics")]
+    [InlineData("eventhub consumergroup list", "Consumer")]
+    [InlineData("monitor healthmodels get", "Health")]
+    [InlineData("monitor healthmodels get", "Models")]
+    public void SplitsCompoundWords(string command, string expectedContains)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.Contains(expectedContains, result);
+    }
+
+    // Bug 3: No area prefix or colon pattern in output
+    [Theory]
+    [InlineData("workbooks workbooks list")]
+    [InlineData("monitor activitylog list")]
+    [InlineData("storage blob create")]
+    public void NoAreaPrefixOrColon(string command)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.DoesNotContain(":", result);
+    }
+
+    // Full expected output verification
+    [Theory]
+    [InlineData("monitor activitylog list", "List Activity Logs")]
+    [InlineData("monitor loganalytics query", "Query Log Analytics")]
+    [InlineData("storage blob list", "List Blobs")]
+    [InlineData("storage blob create", "Create Blob")]
+    [InlineData("compute vm show", "Get Vm")]
+    [InlineData("cosmos container delete", "Delete Container")]
+    [InlineData("eventhub consumergroup list", "List Consumer Groups")]
+    [InlineData("compute disk create", "Create Disk")]
+    [InlineData("workbooks workbooks list", "List Workbooks")]
+    public void FullExpectedOutput(string command, string expected)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.Equal(expected, result);
+    }
+
+    // Pluralization for "list" verb
+    [Theory]
+    [InlineData("storage blob list", "Blobs")]
+    [InlineData("monitor activitylog list", "Logs")]
+    [InlineData("eventhub consumergroup list", "Groups")]
+    public void ListVerbPluralizesResource(string command, string expectedEnding)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.EndsWith(expectedEnding, result);
+    }
+
+    // Non-list verbs do NOT pluralize
+    [Theory]
+    [InlineData("storage blob create", "Blob")]
+    [InlineData("cosmos container delete", "Container")]
+    [InlineData("compute vm show", "Vm")]
+    public void NonListVerbDoesNotPluralize(string command, string expectedEnding)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.EndsWith(expectedEnding, result);
+    }
+
+    // Two-part commands: area + verb
+    [Theory]
+    [InlineData("advisor list", "List")]
+    [InlineData("cosmos query", "Query")]
+    [InlineData("storage get", "Get")]
+    public void TwoPartVerbOnly(string command, string expected)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.Equal(expected, result);
+    }
+
+    // Two-part commands: area + resource (no verb)
+    [Theory]
+    [InlineData("advisor recommendations", "Recommendations")]
+    [InlineData("monitor diagnostics", "Diagnostics")]
+    public void TwoPartResourceOnly(string command, string expected)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.Equal(expected, result);
+    }
+
+    // Two-part with compound word and no verb
+    [Theory]
+    [InlineData("monitor activitylog", "Activity Log")]
+    [InlineData("monitor healthmodels", "Health Models")]
+    public void TwoPartCompoundWithoutVerb(string command, string expected)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command, CompoundWords);
+        Assert.Equal(expected, result);
+    }
+
+    // Edge cases
+    [Theory]
+    [InlineData(null, "Unknown")]
+    [InlineData("", "Unknown")]
+    [InlineData("single", "Unknown")]
+    [InlineData("  ", "Unknown")]
+    public void EdgeCases(string? command, string expected)
+    {
+        var result = McpHelpers.GenerateSimpleToolName(command!, CompoundWords);
+        Assert.Equal(expected, result);
+    }
+
+    // Without compound words, compound words stay as one token
+    [Fact]
+    public void WithoutCompoundWords_NoSplitting()
+    {
+        var result = McpHelpers.GenerateSimpleToolName("monitor activitylog list", null);
+        Assert.StartsWith("List", result);
+        Assert.Contains("Activitylog", result);
+    }
+
+    // Hyphenated resource parts are split into separate words
+    [Fact]
+    public void HyphenatedResourcePartsFormattedAsWords()
+    {
+        var result = McpHelpers.GenerateSimpleToolName("compute managed-disk create", CompoundWords);
+        Assert.Equal("Create Managed Disk", result);
+    }
+
+    // Verb-first detection when verb is the first remaining part
+    [Fact]
+    public void VerbFirstPattern_DetectsVerbInFirstPosition()
+    {
+        var result = McpHelpers.GenerateSimpleToolName("advisor list recommendations", CompoundWords);
+        Assert.StartsWith("List", result);
+    }
+
+    // Handlebars helper integration test
+    [Fact]
+    public void HandlebarsHelper_ReturnsCorrectOutput()
+    {
+        var data = new Dictionary<string, object>
+        {
+            ["command"] = "monitor activitylog list"
+        };
+        var result = HandlebarsTemplateEngine.ProcessTemplateString(
+            "{{getSimpleToolName command}}", data);
+        Assert.StartsWith("List", result);
+    }
+}

--- a/docs-generation/DocGeneration.Core.TemplateEngine/DocGeneration.Core.TemplateEngine.csproj
+++ b/docs-generation/DocGeneration.Core.TemplateEngine/DocGeneration.Core.TemplateEngine.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
+  </ItemGroup>
 </Project>

--- a/docs-generation/DocGeneration.Core.TemplateEngine/Helpers/McpHelpers.cs
+++ b/docs-generation/DocGeneration.Core.TemplateEngine/Helpers/McpHelpers.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Text.Json;
 using HandlebarsDotNet;
+using Shared;
 
 namespace TemplateEngine.Helpers;
 
@@ -12,6 +13,152 @@ namespace TemplateEngine.Helpers;
 /// </summary>
 public static class McpHelpers
 {
+    /// <summary>
+    /// Maps CLI verb tokens to display verbs for H2 headings.
+    /// </summary>
+    private static readonly Dictionary<string, string> VerbMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["list"] = "List",
+        ["show"] = "Get",
+        ["get"] = "Get",
+        ["describe"] = "Get",
+        ["create"] = "Create",
+        ["add"] = "Create",
+        ["update"] = "Update",
+        ["modify"] = "Update",
+        ["set"] = "Set",
+        ["delete"] = "Delete",
+        ["remove"] = "Delete",
+        ["query"] = "Query",
+        ["search"] = "Search",
+        ["retrieve"] = "Retrieve",
+        ["check-name-availability"] = "Check Name Availability",
+    };
+
+    /// <summary>
+    /// Generates a clean, verb-first tool name for H2 headers.
+    /// Public for testability — the Handlebars helper delegates to this method.
+    /// </summary>
+    public static string GenerateSimpleToolName(string command, Dictionary<string, string>? compoundWords = null)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+            return "Unknown";
+
+        var parts = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+            return "Unknown";
+
+        // Skip area name (first part), get remaining segments
+        var remaining = parts.Skip(1).ToArray();
+
+        string? verb = null;
+        string[] resourceParts;
+        bool isList = false;
+
+        // Detect verb: prefer last position ("area resource verb"), fallback to first ("area verb resource")
+        if (VerbMap.TryGetValue(remaining[^1], out var mappedVerbLast))
+        {
+            verb = mappedVerbLast;
+            isList = remaining[^1].Equals("list", StringComparison.OrdinalIgnoreCase);
+            resourceParts = remaining.Length > 1 ? remaining[..^1] : Array.Empty<string>();
+        }
+        else if (remaining.Length > 1 && VerbMap.TryGetValue(remaining[0], out var mappedVerbFirst))
+        {
+            verb = mappedVerbFirst;
+            isList = remaining[0].Equals("list", StringComparison.OrdinalIgnoreCase);
+            resourceParts = remaining[1..];
+        }
+        else
+        {
+            resourceParts = remaining;
+        }
+
+        var formattedResource = FormatResourceParts(resourceParts, compoundWords);
+
+        if (isList && !string.IsNullOrEmpty(formattedResource))
+        {
+            formattedResource = SimplePluralize(formattedResource);
+        }
+
+        string result;
+        if (verb != null && !string.IsNullOrEmpty(formattedResource))
+            result = $"{verb} {formattedResource}";
+        else if (verb != null)
+            result = verb;
+        else
+            result = formattedResource;
+
+        // Strip "Area:" prefix pattern (defensive)
+        var colonIdx = result.IndexOf(':');
+        if (colonIdx > 0 && colonIdx < result.Length - 1)
+        {
+            result = result[(colonIdx + 1)..].Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(result) ? "Unknown" : result;
+    }
+
+    private static string FormatResourceParts(string[] parts, Dictionary<string, string>? compoundWords)
+    {
+        var words = new List<string>();
+        foreach (var part in parts)
+        {
+            var expanded = ApplyCompoundWords(part, compoundWords);
+            foreach (var segment in expanded.Split('-', StringSplitOptions.RemoveEmptyEntries))
+            {
+                words.Add(TitleCaseWord(segment));
+            }
+        }
+        return string.Join(" ", words);
+    }
+
+    private static string ApplyCompoundWords(string part, Dictionary<string, string>? compoundWords)
+    {
+        if (compoundWords != null && compoundWords.TryGetValue(part.ToLowerInvariant(), out var expanded))
+            return expanded;
+        return part;
+    }
+
+    private static string TitleCaseWord(string word)
+    {
+        if (string.IsNullOrEmpty(word)) return word;
+        return char.ToUpper(word[0]) + word.Substring(1).ToLower();
+    }
+
+    private static string SimplePluralize(string phrase)
+    {
+        if (string.IsNullOrWhiteSpace(phrase)) return phrase;
+
+        var words = phrase.Split(' ');
+        var lastWord = words[^1];
+
+        // Already looks plural (ends with 's' but not 'ss')
+        if (lastWord.EndsWith("s", StringComparison.OrdinalIgnoreCase) &&
+            !lastWord.EndsWith("ss", StringComparison.OrdinalIgnoreCase))
+        {
+            return phrase;
+        }
+
+        if (lastWord.EndsWith("ss", StringComparison.OrdinalIgnoreCase) ||
+            lastWord.EndsWith("x", StringComparison.OrdinalIgnoreCase) ||
+            lastWord.EndsWith("sh", StringComparison.OrdinalIgnoreCase) ||
+            lastWord.EndsWith("ch", StringComparison.OrdinalIgnoreCase))
+        {
+            words[^1] = lastWord + "es";
+        }
+        else if (lastWord.EndsWith("y", StringComparison.OrdinalIgnoreCase) &&
+                 lastWord.Length > 1 &&
+                 !"aeiou".Contains(char.ToLower(lastWord[^2])))
+        {
+            words[^1] = lastWord[..^1] + "ies";
+        }
+        else
+        {
+            words[^1] = lastWord + "s";
+        }
+
+        return string.Join(" ", words);
+    }
     /// <summary>
     /// Registers all MCP-specific helpers on the given Handlebars instance.
     /// </summary>
@@ -271,38 +418,20 @@ public static class McpHelpers
             return grouped;
         });
 
-        // Generate simple, clean tool names for H2 headers
+        // Generate simple, clean tool names for H2 headers (verb-first, compound words, no area prefix)
+        var lazyCompoundWords = new Lazy<Dictionary<string, string>>(() =>
+        {
+            try { return DataFileLoader.LoadCompoundWordsAsync().GetAwaiter().GetResult(); }
+            catch { return new Dictionary<string, string>(); }
+        });
+
         handlebars.RegisterHelper("getSimpleToolName", (context, arguments) =>
         {
             if (arguments.Length == 0 || arguments[0] == null)
                 return "Unknown";
 
             var command = arguments[0].ToString() ?? string.Empty;
-            var parts = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-            if (parts.Length < 2) // Need at least "area operation"
-                return "Unknown";
-
-            // Skip area name (first part), get remaining parts
-            var remainingParts = parts.Skip(1).ToArray();
-
-            // Format each part with proper capitalization
-            var formattedParts = remainingParts.Select(part =>
-            {
-                // Handle hyphenated terms
-                if (part.Contains('-'))
-                {
-                    var hyphenParts = part.Split('-')
-                        .Where(hp => !string.IsNullOrEmpty(hp))
-                        .Select(hp => char.ToUpper(hp[0]) + hp.Substring(1).ToLower());
-                    return string.Join("-", hyphenParts);
-                }
-
-                // Regular term - capitalize first letter
-                return char.ToUpper(part[0]) + part.Substring(1).ToLower();
-            });
-
-            return string.Join(" ", formattedParts);
+            return GenerateSimpleToolName(command, lazyCompoundWords.Value);
         });
     }
 }

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
@@ -15,5 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.Steps.HorizontalArticles\DocGeneration.Steps.HorizontalArticles.csproj" />
     <ProjectReference Include="..\DocGeneration.Core.TextTransformation\DocGeneration.Core.TextTransformation.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.SkillsRelevance\DocGeneration.Steps.SkillsRelevance.csproj" />
   </ItemGroup>
 </Project>

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsContractTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsContractTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using HorizontalArticleGenerator.Services;
+using SkillsRelevance.Models;
+using SkillsRelevance.Output;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+/// <summary>
+/// Cross-step contract test: validates that Step 5 JSON output can be consumed by Step 6 reader.
+/// This catches writer/reader drift since they use separate models.
+/// </summary>
+public class SkillsContractTests : IDisposable
+{
+    private readonly string _outputBasePath;
+
+    public SkillsContractTests()
+    {
+        _outputBasePath = Path.Combine(Path.GetTempPath(), "skills-contract-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputBasePath))
+            Directory.Delete(_outputBasePath, recursive: true);
+    }
+
+    [Fact]
+    public async Task Step5Writer_Step6Reader_Roundtrips()
+    {
+        var skillsDir = Path.Combine(_outputBasePath, "skills-relevance");
+
+        var skills = new List<SkillInfo>
+        {
+            new()
+            {
+                Name = "Copilot for Azure",
+                SourceRepository = "microsoft/GitHub-Copilot-for-Azure",
+                SourceUrl = "https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure.md",
+                RelevanceScore = 0.85,
+                Description = "Azure resource management and troubleshooting",
+                Tags = new List<string> { "azure", "cloud", "management" }
+            },
+            new()
+            {
+                Name = "Storage Explorer Skill",
+                SourceRepository = "test/storage-skills",
+                SourceUrl = "https://github.com/test/storage-skills/blob/main/explorer.md",
+                RelevanceScore = 0.55,
+                Description = "Navigate and manage Azure Storage accounts",
+                Tags = new List<string> { "storage", "blob" }
+            },
+            new()
+            {
+                Name = "Low Relevance Skill",
+                SourceRepository = "test/low",
+                SourceUrl = "https://github.com/test/low/blob/main/skill.md",
+                RelevanceScore = 0.3,
+                Description = "Not very relevant",
+                Tags = new List<string> { "misc" }
+            }
+        };
+
+        // Step 5 writes JSON
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(skillsDir, "storage", skills);
+
+        // Step 6 reads JSON
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "storage");
+
+        // Verify: high + medium skills returned, low skill filtered
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal("Copilot for Azure", result[0].Name);
+        Assert.Equal(0.85, result[0].RelevanceScore);
+        Assert.Equal("Azure resource management and troubleshooting", result[0].Description);
+        Assert.Equal("https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure.md", result[0].SourceUrl);
+
+        Assert.Equal("Storage Explorer Skill", result[1].Name);
+        Assert.Equal(0.55, result[1].RelevanceScore);
+    }
+
+    [Fact]
+    public async Task Step5Writer_Step6Reader_EmptySkills_Roundtrips()
+    {
+        var skillsDir = Path.Combine(_outputBasePath, "skills-relevance");
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(skillsDir, "keyvault", new List<SkillInfo>());
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "keyvault");
+
+        Assert.Empty(result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsJsonReaderTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsJsonReaderTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using HorizontalArticleGenerator.Services;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+public class SkillsJsonReaderTests : IDisposable
+{
+    private readonly string _outputBasePath;
+
+    public SkillsJsonReaderTests()
+    {
+        _outputBasePath = Path.Combine(Path.GetTempPath(), "skills-reader-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputBasePath))
+            Directory.Delete(_outputBasePath, recursive: true);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_MissingFile_ReturnsEmptyList()
+    {
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "nonexistent");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_MalformedJson_ReturnsEmptyList()
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "storage-skills-relevance.json"), "not valid json {{{");
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "storage");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_ValidJson_ReturnsFilteredSkills()
+    {
+        await WriteSkillsJsonAsync("compute", new[]
+        {
+            new { name = "High Skill", source = "test", sourceUrl = "https://example.com/high", relevanceScore = 0.9, relevanceLevel = "High", description = "A high relevance skill", tags = new[] { "azure" } },
+            new { name = "Medium Skill", source = "test", sourceUrl = "https://example.com/med", relevanceScore = 0.5, relevanceLevel = "Medium", description = "A medium relevance skill", tags = new[] { "azure" } },
+            new { name = "Low Skill", source = "test", sourceUrl = "https://example.com/low", relevanceScore = 0.3, relevanceLevel = "Low", description = "A low relevance skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "compute");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("High Skill", result[0].Name);
+        Assert.Equal("Medium Skill", result[1].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_FiltersAtThreshold_IncludesExactly05()
+    {
+        await WriteSkillsJsonAsync("advisor", new[]
+        {
+            new { name = "Exact Threshold", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.5, relevanceLevel = "Medium", description = "Exactly at threshold", tags = new[] { "azure" } },
+            new { name = "Below Threshold", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.49, relevanceLevel = "Low", description = "Just below", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "advisor");
+
+        Assert.Single(result);
+        Assert.Equal("Exact Threshold", result[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_OrdersByScoreDescending()
+    {
+        await WriteSkillsJsonAsync("search", new[]
+        {
+            new { name = "Medium", source = "test", sourceUrl = "https://example.com/m", relevanceScore = 0.6, relevanceLevel = "Medium", description = "Medium skill", tags = new[] { "azure" } },
+            new { name = "Highest", source = "test", sourceUrl = "https://example.com/h", relevanceScore = 0.95, relevanceLevel = "High", description = "Highest skill", tags = new[] { "azure" } },
+            new { name = "High", source = "test", sourceUrl = "https://example.com/hi", relevanceScore = 0.8, relevanceLevel = "High", description = "High skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "search");
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Highest", result[0].Name);
+        Assert.Equal("High", result[1].Name);
+        Assert.Equal("Medium", result[2].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_CustomMinScore()
+    {
+        await WriteSkillsJsonAsync("redis", new[]
+        {
+            new { name = "High", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.9, relevanceLevel = "High", description = "High skill", tags = new[] { "azure" } },
+            new { name = "Medium", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.6, relevanceLevel = "Medium", description = "Medium skill", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "redis", minScore: 0.8);
+
+        Assert.Single(result);
+        Assert.Equal("High", result[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_SanitizesDescription_EscapesPipes()
+    {
+        await WriteSkillsJsonAsync("cosmos", new[]
+        {
+            new { name = "Pipe Skill", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.8, relevanceLevel = "High", description = "Uses pipes | in text", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "cosmos");
+
+        Assert.Single(result);
+        Assert.Equal(@"Uses pipes \| in text", result[0].Description);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_SanitizesDescription_RemovesNewlines()
+    {
+        await WriteSkillsJsonAsync("functions", new[]
+        {
+            new { name = "Newline Skill", source = "test", sourceUrl = "https://example.com", relevanceScore = 0.8, relevanceLevel = "High", description = "Line1\nLine2\r\nLine3", tags = new[] { "azure" } }
+        });
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "functions");
+
+        Assert.Single(result);
+        Assert.Equal("Line1 Line2 Line3", result[0].Description);
+    }
+
+    [Fact]
+    public async Task LoadSkillsAsync_EmptySkillsArray_ReturnsEmptyList()
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        var json = JsonSerializer.Serialize(new { serviceName = "test", generatedAt = "2025-01-01", skills = Array.Empty<object>() });
+        await File.WriteAllTextAsync(Path.Combine(dir, "test-skills-relevance.json"), json);
+
+        var result = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, "test");
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("storage", "storage")]
+    [InlineData("Cosmos DB", "cosmos-db")]
+    [InlineData("KEY vault", "key-vault")]
+    public void SanitizeFileName_NormalizesCorrectly(string input, string expected)
+    {
+        Assert.Equal(expected, SkillsJsonReader.SanitizeFileName(input));
+    }
+
+    [Theory]
+    [InlineData("simple text", "simple text")]
+    [InlineData("has | pipe", @"has \| pipe")]
+    [InlineData("has\nnewline", "has newline")]
+    [InlineData("has\r\ncrlf", "has crlf")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void SanitizeForTable_HandlesEdgeCases(string? input, string expected)
+    {
+        Assert.Equal(expected, SkillsJsonReader.SanitizeForTable(input!));
+    }
+
+    private async Task WriteSkillsJsonAsync(string serviceId, object skills)
+    {
+        var dir = Path.Combine(_outputBasePath, "skills-relevance");
+        Directory.CreateDirectory(dir);
+        var data = new { serviceName = serviceId, generatedAt = DateTime.UtcNow.ToString("o"), skills };
+        var json = JsonSerializer.Serialize(data);
+        await File.WriteAllTextAsync(Path.Combine(dir, $"{serviceId}-skills-relevance.json"), json);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsTemplateSectionTests.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles.Tests/SkillsTemplateSectionTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HandlebarsDotNet;
+using Xunit;
+
+namespace HorizontalArticleGenerator.Tests;
+
+public class SkillsTemplateSectionTests
+{
+    private const string SkillsSectionTemplate = @"## Best practices
+
+When using Azure MCP Server with {{serviceBrandName}}:
+
+- **Be specific**: Include resource names and details.
+
+{{#if skills}}
+## GitHub Copilot extensions
+
+The following GitHub Copilot extensions can help you work with {{serviceBrandName}}:
+
+| Extension | Description |
+|-----------|-------------|
+{{#each skills}}
+| [{{name}}]({{sourceUrl}}) | {{description}} |
+{{/each}}
+{{/if}}
+
+## Related content
+
+* [Azure MCP Server overview](../overview.md)";
+
+    [Fact]
+    public void Template_WithSkills_RendersSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Storage",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Copilot for Azure",
+                    ["sourceUrl"] = "https://github.com/microsoft/copilot-azure",
+                    ["description"] = "Azure resource management skill"
+                },
+                new()
+                {
+                    ["name"] = "Storage Helper",
+                    ["sourceUrl"] = "https://github.com/test/storage-helper",
+                    ["description"] = "Blob and queue operations"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains("## GitHub Copilot extensions", result);
+        Assert.Contains("The following GitHub Copilot extensions can help you work with Azure Storage:", result);
+        Assert.Contains("| [Copilot for Azure](https://github.com/microsoft/copilot-azure) | Azure resource management skill |", result);
+        Assert.Contains("| [Storage Helper](https://github.com/test/storage-helper) | Blob and queue operations |", result);
+        Assert.Contains("| Extension | Description |", result);
+    }
+
+    [Fact]
+    public void Template_WithoutSkills_DoesNotRenderSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Cosmos DB",
+            ["skills"] = new List<Dictionary<string, object>>()
+        };
+
+        var result = template(data);
+
+        Assert.DoesNotContain("## GitHub Copilot extensions", result);
+        Assert.DoesNotContain("Extension | Description", result);
+        Assert.Contains("## Best practices", result);
+        Assert.Contains("## Related content", result);
+    }
+
+    [Fact]
+    public void Template_SkillsNotProvided_DoesNotRenderSkillsSection()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Key Vault"
+        };
+
+        var result = template(data);
+
+        Assert.DoesNotContain("## GitHub Copilot extensions", result);
+        Assert.Contains("## Best practices", result);
+        Assert.Contains("## Related content", result);
+    }
+
+    [Fact]
+    public void Template_SingleSkill_RendersOneTableRow()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Monitor",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Monitor Diagnostics",
+                    ["sourceUrl"] = "https://github.com/test/monitor",
+                    ["description"] = "Diagnostic queries and alerts"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains("## GitHub Copilot extensions", result);
+        Assert.Contains("| [Monitor Diagnostics](https://github.com/test/monitor) | Diagnostic queries and alerts |", result);
+    }
+
+    [Fact]
+    public void Template_SkillWithEscapedPipe_RendersCorrectly()
+    {
+        var handlebars = Handlebars.Create();
+        var template = handlebars.Compile(SkillsSectionTemplate);
+
+        var data = new Dictionary<string, object>
+        {
+            ["serviceBrandName"] = "Azure Functions",
+            ["skills"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["name"] = "Functions Helper",
+                    ["sourceUrl"] = "https://github.com/test/functions",
+                    ["description"] = @"Handles input \| output bindings"
+                }
+            }
+        };
+
+        var result = template(data);
+
+        Assert.Contains(@"Handles input \| output bindings", result);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using GenerativeAI;
 using CSharpGenerator.Models;
 using HorizontalArticleGenerator.Models;
+using HorizontalArticleGenerator.Services;
 using TemplateEngine;
 using Shared;
 using Azure.Mcp.TextTransformation.Models;
@@ -88,6 +89,11 @@ public class HorizontalArticleGenerator
             
             // Merge static + AI data
             var templateData = MergeData(staticData, aiData);
+
+            // Load skills from Step 5 output (optional, graceful fallback)
+            var skills = await SkillsJsonReader.LoadSkillsAsync(_outputBasePath, staticData.ServiceIdentifier);
+            templateData.Skills = skills;
+
             // Render and save
             await RenderAndSaveArticle(templateData);
             Console.WriteLine($"{progress} ✓ Generated: horizontal-article-{staticData.ServiceIdentifier}.md");
@@ -616,6 +622,14 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
                 ["command"] = t.Command,
                 ["moreInfoLink"] = t.MoreInfoLink,
                 ["genai-shortDescription"] = t.ShortDescription
+            }).ToList(),
+
+            // Skills from Step 5 (optional)
+            ["skills"] = templateData.Skills.Select(s => new Dictionary<string, object>
+            {
+                ["name"] = s.Name,
+                ["description"] = s.Description,
+                ["sourceUrl"] = s.SourceUrl
             }).ToList()
         };
         

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Models/HorizontalArticleTemplateData.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Models/HorizontalArticleTemplateData.cs
@@ -63,6 +63,22 @@ public class HorizontalArticleTemplateData
     
     [JsonPropertyName("genai-additionalLinks")]
     public List<AdditionalLink> AdditionalLinks { get; set; } = new();
+
+    // ===== Skills from Step 5 (optional, may be empty) =====
+
+    public List<SkillEntry> Skills { get; set; } = new();
+}
+
+/// <summary>
+/// Skill entry for rendering in horizontal articles.
+/// Separate read model — not coupled to SkillsRelevance step internals.
+/// </summary>
+public class SkillEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string SourceUrl { get; set; } = string.Empty;
+    public double RelevanceScore { get; set; }
 }
 
 /// <summary>

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/Services/SkillsJsonReader.cs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/Services/SkillsJsonReader.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using HorizontalArticleGenerator.Models;
+
+namespace HorizontalArticleGenerator.Services;
+
+/// <summary>
+/// Reads skills relevance JSON produced by Step 5.
+/// Uses its own read model to avoid coupling to the SkillsRelevance project.
+/// </summary>
+public static class SkillsJsonReader
+{
+    private const double DefaultMinScore = 0.5;
+
+    /// <summary>
+    /// Loads skills from the Step 5 JSON output file.
+    /// Returns an empty list when the file is missing or malformed (graceful fallback).
+    /// Filters to skills with relevance score >= minScore.
+    /// </summary>
+    public static async Task<List<SkillEntry>> LoadSkillsAsync(
+        string outputBasePath,
+        string serviceIdentifier,
+        double minScore = DefaultMinScore)
+    {
+        var sanitized = SanitizeFileName(serviceIdentifier);
+        var jsonPath = Path.Combine(outputBasePath, "skills-relevance", $"{sanitized}-skills-relevance.json");
+
+        if (!File.Exists(jsonPath))
+        {
+            return new List<SkillEntry>();
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(jsonPath);
+            var data = JsonSerializer.Deserialize<SkillsJsonFile>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (data?.Skills == null)
+            {
+                return new List<SkillEntry>();
+            }
+
+            return data.Skills
+                .Where(s => s.RelevanceScore >= minScore)
+                .OrderByDescending(s => s.RelevanceScore)
+                .Select(s => new SkillEntry
+                {
+                    Name = s.Name,
+                    Description = SanitizeForTable(s.Description),
+                    SourceUrl = s.SourceUrl,
+                    RelevanceScore = s.RelevanceScore
+                })
+                .ToList();
+        }
+        catch (JsonException ex)
+        {
+            Console.WriteLine($"  ⚠️ Failed to parse skills JSON for '{serviceIdentifier}': {ex.Message}");
+            return new List<SkillEntry>();
+        }
+    }
+
+    /// <summary>
+    /// Sanitizes text for use in a markdown table cell.
+    /// Escapes pipes and removes newlines.
+    /// </summary>
+    internal static string SanitizeForTable(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return text.Replace("|", "\\|").Replace("\n", " ").Replace("\r", "");
+    }
+
+    internal static string SanitizeFileName(string name) =>
+        Regex.Replace(name.ToLowerInvariant().Replace(' ', '-'), @"[^a-z0-9\-]", "");
+
+    /// <summary>
+    /// Read model matching the Step 5 JSON output schema.
+    /// </summary>
+    internal class SkillsJsonFile
+    {
+        [JsonPropertyName("serviceName")]
+        public string ServiceName { get; set; } = string.Empty;
+
+        [JsonPropertyName("generatedAt")]
+        public string GeneratedAt { get; set; } = string.Empty;
+
+        [JsonPropertyName("skills")]
+        public List<SkillsJsonFileEntry> Skills { get; set; } = new();
+    }
+
+    internal class SkillsJsonFileEntry
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = string.Empty;
+
+        [JsonPropertyName("sourceUrl")]
+        public string SourceUrl { get; set; } = string.Empty;
+
+        [JsonPropertyName("relevanceScore")]
+        public double RelevanceScore { get; set; }
+
+        [JsonPropertyName("relevanceLevel")]
+        public string RelevanceLevel { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; } = new();
+    }
+}

--- a/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
+++ b/docs-generation/DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs
@@ -98,6 +98,18 @@ When using Azure MCP Server with {{serviceBrandName}}:
 - **Review actions before confirming**: Carefully review destructive operations before confirming them.
 {{/if}}
 
+{{#if skills}}
+## GitHub Copilot extensions
+
+The following GitHub Copilot extensions can help you work with {{serviceBrandName}}:
+
+| Extension | Description |
+|-----------|-------------|
+{{#each skills}}
+| [{{name}}]({{sourceUrl}}) | {{description}} |
+{{/each}}
+{{/if}}
+
 ## Related content
 
 * [Azure MCP Server overview](../overview.md)

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillsJsonWriterTests.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance.Tests/SkillsJsonWriterTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using SkillsRelevance.Models;
+using SkillsRelevance.Output;
+using Xunit;
+
+namespace DocGeneration.Steps.SkillsRelevance.Tests;
+
+public class SkillsJsonWriterTests : IDisposable
+{
+    private readonly string _outputDir;
+
+    public SkillsJsonWriterTests()
+    {
+        _outputDir = Path.Combine(Path.GetTempPath(), "skills-json-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputDir))
+            Directory.Delete(_outputDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_CreatesJsonFile()
+    {
+        var skills = new List<SkillInfo>
+        {
+            CreateSkill("Azure Skill", 0.85, "GitHub Awesome Copilot", "https://github.com/test/skill1")
+        };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "storage", skills);
+
+        var filePath = Path.Combine(_outputDir, "storage-skills-relevance.json");
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_JsonRoundtrips()
+    {
+        var skills = new List<SkillInfo>
+        {
+            CreateSkill("Copilot for Azure", 0.9, "Microsoft Skills", "https://github.com/ms/skill"),
+            CreateSkill("Storage Helper", 0.6, "GitHub Awesome Copilot", "https://github.com/test/storage")
+        };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "storage", skills);
+
+        var filePath = Path.Combine(_outputDir, "storage-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("storage", deserialized!.ServiceName);
+        Assert.Equal(2, deserialized.Skills.Count);
+        Assert.Equal("Copilot for Azure", deserialized.Skills[0].Name);
+        Assert.Equal(0.9, deserialized.Skills[0].RelevanceScore);
+        Assert.Equal("High", deserialized.Skills[0].RelevanceLevel);
+        Assert.Equal("Storage Helper", deserialized.Skills[1].Name);
+        Assert.Equal("Medium", deserialized.Skills[1].RelevanceLevel);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_EmptySkills_WritesEmptyArray()
+    {
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "keyvault", new List<SkillInfo>());
+
+        var filePath = Path.Combine(_outputDir, "keyvault-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.Empty(deserialized!.Skills);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_IncludesTagsAndDescription()
+    {
+        var skill = CreateSkill("Monitor Skill", 0.7, "Microsoft Skills", "https://github.com/ms/monitor");
+        skill.Description = "Helps with Azure Monitor diagnostics";
+        skill.Tags = new List<string> { "monitoring", "diagnostics", "azure" };
+
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "monitor", new List<SkillInfo> { skill });
+
+        var filePath = Path.Combine(_outputDir, "monitor-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        var entry = Assert.Single(deserialized!.Skills);
+        Assert.Equal("Helps with Azure Monitor diagnostics", entry.Description);
+        Assert.Equal(3, entry.Tags.Count);
+        Assert.Contains("monitoring", entry.Tags);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_SanitizesFilename()
+    {
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "Cosmos DB", new List<SkillInfo>());
+
+        var filePath = Path.Combine(_outputDir, "cosmos-db-skills-relevance.json");
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Theory]
+    [InlineData(0.95, "High")]
+    [InlineData(0.8, "High")]
+    [InlineData(0.65, "Medium")]
+    [InlineData(0.5, "Medium")]
+    [InlineData(0.35, "Low")]
+    [InlineData(0.2, "Low")]
+    [InlineData(0.1, "Minimal")]
+    [InlineData(0.0, "Minimal")]
+    public void ScoreToLevel_ReturnsCorrectLevel(double score, string expected)
+    {
+        Assert.Equal(expected, SkillJsonEntry.ScoreToLevel(score));
+    }
+
+    [Fact]
+    public void FromSkillInfo_MapsAllFields()
+    {
+        var skill = new SkillInfo
+        {
+            Name = "Test Skill",
+            SourceRepository = "test/repo",
+            SourceUrl = "https://github.com/test/repo/skill.md",
+            RelevanceScore = 0.75,
+            Description = "A test skill",
+            Tags = new List<string> { "test", "azure" }
+        };
+
+        var entry = SkillJsonEntry.FromSkillInfo(skill);
+
+        Assert.Equal("Test Skill", entry.Name);
+        Assert.Equal("test/repo", entry.Source);
+        Assert.Equal("https://github.com/test/repo/skill.md", entry.SourceUrl);
+        Assert.Equal(0.75, entry.RelevanceScore);
+        Assert.Equal("Medium", entry.RelevanceLevel);
+        Assert.Equal("A test skill", entry.Description);
+        Assert.Equal(2, entry.Tags.Count);
+    }
+
+    [Fact]
+    public async Task WriteServiceJsonAsync_HasValidGeneratedAt()
+    {
+        var before = DateTime.UtcNow;
+        await SkillsMarkdownWriter.WriteServiceJsonAsync(_outputDir, "redis", new List<SkillInfo>());
+        var after = DateTime.UtcNow;
+
+        var filePath = Path.Combine(_outputDir, "redis-skills-relevance.json");
+        var json = await File.ReadAllTextAsync(filePath);
+        var deserialized = JsonSerializer.Deserialize<SkillsRelevanceJsonOutput>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserialized);
+        Assert.True(DateTimeOffset.TryParse(deserialized!.GeneratedAt, out var parsed));
+        Assert.True(parsed >= before.AddSeconds(-1) && parsed <= after.AddSeconds(1));
+    }
+
+    private static SkillInfo CreateSkill(string name, double score, string source, string url)
+    {
+        return new SkillInfo
+        {
+            Name = name,
+            RelevanceScore = score,
+            SourceRepository = source,
+            SourceUrl = url,
+            Description = $"Description for {name}",
+            Tags = new List<string> { "azure" }
+        };
+    }
+}

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Models/SkillsRelevanceJsonOutput.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Models/SkillsRelevanceJsonOutput.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace SkillsRelevance.Models;
+
+/// <summary>
+/// JSON-serializable output for skills relevance data consumed by downstream steps.
+/// </summary>
+public class SkillsRelevanceJsonOutput
+{
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [JsonPropertyName("generatedAt")]
+    public string GeneratedAt { get; set; } = string.Empty;
+
+    [JsonPropertyName("skills")]
+    public List<SkillJsonEntry> Skills { get; set; } = new();
+}
+
+/// <summary>
+/// Individual skill entry in the JSON output.
+/// </summary>
+public class SkillJsonEntry
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceUrl")]
+    public string SourceUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("relevanceScore")]
+    public double RelevanceScore { get; set; }
+
+    [JsonPropertyName("relevanceLevel")]
+    public string RelevanceLevel { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
+    /// <summary>
+    /// Maps a relevance score to a human-readable level.
+    /// </summary>
+    public static string ScoreToLevel(double score) => score switch
+    {
+        >= 0.8 => "High",
+        >= 0.5 => "Medium",
+        >= 0.2 => "Low",
+        _ => "Minimal"
+    };
+
+    /// <summary>
+    /// Creates a SkillJsonEntry from a SkillInfo model.
+    /// </summary>
+    public static SkillJsonEntry FromSkillInfo(SkillInfo skill) => new()
+    {
+        Name = skill.Name,
+        Source = skill.SourceRepository,
+        SourceUrl = skill.SourceUrl,
+        RelevanceScore = skill.RelevanceScore,
+        RelevanceLevel = ScoreToLevel(skill.RelevanceScore),
+        Description = skill.Description,
+        Tags = skill.Tags
+    };
+}

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Output/SkillsMarkdownWriter.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Output/SkillsMarkdownWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using SkillsRelevance.Models;
 
@@ -135,6 +136,38 @@ public static class SkillsMarkdownWriter
         sb.AppendLine();
 
         await File.WriteAllTextAsync(filePath, sb.ToString(), Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Writes a JSON file containing skills relevance data for downstream consumption.
+    /// Uses the service identifier (not display name) for the filename.
+    /// </summary>
+    public static async Task WriteServiceJsonAsync(
+        string outputDir,
+        string serviceIdentifier,
+        List<SkillInfo> relevantSkills)
+    {
+        Directory.CreateDirectory(outputDir);
+
+        var jsonOutput = new SkillsRelevanceJsonOutput
+        {
+            ServiceName = serviceIdentifier,
+            GeneratedAt = DateTime.UtcNow.ToString("o"),
+            Skills = relevantSkills.Select(SkillJsonEntry.FromSkillInfo).ToList()
+        };
+
+        var fileName = $"{SanitizeFileName(serviceIdentifier)}-skills-relevance.json";
+        var filePath = Path.Combine(outputDir, fileName);
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        var json = JsonSerializer.Serialize(jsonOutput, options);
+        await File.WriteAllTextAsync(filePath, json, Encoding.UTF8);
+        Console.WriteLine($"  ✅ {fileName} (JSON, {relevantSkills.Count} skills)");
     }
 
     private static void WriteSkillSection(StringBuilder sb, SkillInfo skill, int index)

--- a/docs-generation/DocGeneration.Steps.SkillsRelevance/Program.cs
+++ b/docs-generation/DocGeneration.Steps.SkillsRelevance/Program.cs
@@ -110,6 +110,7 @@ internal static class Program
             // Write output
             Console.WriteLine($"Writing output to: {outputDir}");
             await SkillsMarkdownWriter.WriteServiceSummaryAsync(outputDir, serviceName, relevantSkills, sources);
+            await SkillsMarkdownWriter.WriteServiceJsonAsync(outputDir, serviceName, relevantSkills);
             await SkillsMarkdownWriter.WriteIndexAsync(outputDir, new List<string> { serviceName });
 
             Console.WriteLine();

--- a/docs-generation/data/compound-words.json
+++ b/docs-generation/data/compound-words.json
@@ -1,5 +1,6 @@
 {
   "activitylog": "activity-log",
+  "loganalytics": "log-analytics",
   "app-lens": "app-lens",
   "azqr": "compliance-review",
   "bestpractices": "best-practices",


### PR DESCRIPTION
## Summary

Fixes #383 — Three bugs in H2 title generation for tool family articles.

### Changes

**Bug 1: H2s now start with a verb**
- \getSimpleToolName\ detects verb in last or first remaining position
- Maps aliases: show→Get, remove→Delete, add→Create, describe→Get, etc.
- Example: \monitor activitylog list\ → **List Activity Logs** (was: Activitylog List)

**Bug 2: Compound CLI commands are split**
- Applies \compound-words.json\ mappings (e.g., activitylog → activity-log → Activity Log)
- Added \loganalytics\ → \log-analytics\ to compound-words.json
- Example: \monitor loganalytics query\ → **Query Log Analytics** (was: Loganalytics Query)

**Bug 3: Area prefix pattern removed**
- Defensive colon-prefix stripping in output
- Example: \workbooks workbooks list\ → **List Workbooks** (no 'Workbooks:' prefix)

**Bonus: Pluralization for list verb**
- Resources are pluralized for list operations (Blob→Blobs, Group→Groups)
- Already-plural words are not double-pluralized

### Files Changed

| File | Change |
|------|--------|
| \McpHelpers.cs\ | Rewrote \getSimpleToolName\ with VerbMap, compound words, verb-first logic |
| \McpHelpersGetSimpleToolNameTests.cs\ | 47 new tests covering all 3 bugs + edge cases |
| \DocGeneration.Core.TemplateEngine.csproj\ | Added reference to Shared for DataFileLoader |
| \compound-words.json\ | Added \loganalytics\ entry |
| \CHANGELOG.md\ | Added entry under [Unreleased] |

### Testing

- 47 new tests: verb-first ordering, compound splitting, area prefix, pluralization, edge cases, Handlebars integration
- All 2,175 solution tests pass with 0 failures
- TDD approach: tests written before implementation