### PR TITLE
fix: Update E2eTestPromptParser to fetch from release/azure/2.x (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **E2E test prompts now fetched from `release/azure/2.x` branch** — Updated E2eTestPromptParser config to fetch `e2eTestPrompts.md` from the `release/azure/2.x` branch of `microsoft/mcp` instead of `main`. This ensures documentation generation uses the correct 2.x-versioned test prompts. (#387)
+
 ### Added
 
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj" />
+    <ProjectReference Include="../DocGeneration.TestInfrastructure/DocGeneration.TestInfrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using DocGeneration.TestInfrastructure;
+using E2eTestPromptParser.Models;
+using Xunit;
+
+namespace E2eTestPromptParser.Tests;
+
+public class ParserConfigTests
+{
+    private static string GetConfigPath()
+    {
+        var docsGenRoot = ProjectRootFinder.FindDocsGenerationRoot();
+        return Path.Combine(docsGenRoot,
+            "DocGeneration.Steps.Bootstrap.E2eTestPromptParser",
+            "config.json");
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_PointsTo2xBranch()
+    {
+        var configPath = GetConfigPath();
+        Assert.True(File.Exists(configPath), $"config.json not found at {configPath}");
+
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.Contains("release/azure/2.x", config!.RemoteUrl,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/main/", config.RemoteUrl,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_PointsToE2eTestPromptsFile()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.EndsWith("e2eTestPrompts.md", config!.RemoteUrl);
+        Assert.Contains("servers/Azure.Mcp.Server/docs/", config.RemoteUrl);
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_IsValidRawGitHubUrl()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.StartsWith("https://raw.githubusercontent.com/microsoft/mcp/",
+            config!.RemoteUrl);
+    }
+
+    [Fact]
+    public void Config_LocalFileName_IsE2eTestPromptsMd()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.Equal("e2eTestPrompts.md", config!.LocalFileName);
+    }
+}

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
@@ -12,7 +12,7 @@ The remote URL is configured in `config.json`:
 
 ```json
 {
-  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "localFileName": "e2eTestPrompts.md"
 }
 ```
@@ -181,7 +181,7 @@ The parser relies on these structural conventions:
 
 1. **Download the new file and inspect it**:
    ```bash
-   curl -o /tmp/e2eTestPrompts.md https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+   curl -o /tmp/e2eTestPrompts.md https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
    head -50 /tmp/e2eTestPrompts.md
    ```
 

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
@@ -1,4 +1,4 @@
 {
-  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "localFileName": "e2eTestPrompts.md"
 }


### PR DESCRIPTION
## Quick Win — Fix E2E test prompts branch (Issue #387)

### Problem
The E2eTestPromptParser \config.json\ hardcodes \main\ as the branch for fetching \2eTestPrompts.md\ from \microsoft/mcp\. For 2.x documentation generation, the canonical source is on \elease/azure/2.x\.

### Changes
- **\config.json\**: Updated \emoteUrl\ from \main\ → \elease/azure/2.x\
- **\README.md\**: Updated all references to match the new branch
- **\ParserConfigTests.cs\** (NEW): 4 tests validating the config points to the correct branch, URL format, file target, and local filename
- **\CHANGELOG.md\**: Added fix entry under \[Unreleased]\

### TDD Evidence
- Tests written first, confirmed \Config_RemoteUrl_PointsTo2xBranch\ fails against \main\ URL
- Config updated → all 22 tests pass (18 existing + 4 new)

### Note
This is the quick-win fix. A companion PR will add full branch-aware configuration (\--mcp-branch\ CLI flag, upstream azmcp-commands.md fetching, etc.). See \docs/proposals/issue-387-branch-aware-generation.md\ for the full PRD.

Closes #387 (partial)