### PR TITLE
feat: Branch-aware content generation with --mcp-branch (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Branch-aware content generation (`--mcp-branch`)** — The pipeline now fetches upstream files (`azmcp-commands.md`, `e2eTestPrompts.md`) from a configurable branch of `microsoft/mcp`. Default: `release/azure/2.x`. Override via `--mcp-branch <branch>` CLI flag or `MCP_BRANCH` environment variable. Local fallback preserved for offline use. (#387)
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)
 - `start-azure-skills.sh` entry point script

--- a/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/BootstrapUpstreamUrlTests.cs
+++ b/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/BootstrapUpstreamUrlTests.cs
@@ -1,0 +1,52 @@
+using PipelineRunner.Steps;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class BootstrapUpstreamUrlTests
+{
+    [Fact]
+    public void BuildUpstreamUrl_2xBranch_ReturnsCorrectUrl()
+    {
+        var url = BootstrapStep.BuildUpstreamUrl("release/azure/2.x", "azmcp-commands.md");
+        Assert.Equal(
+            "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/azmcp-commands.md",
+            url);
+    }
+
+    [Fact]
+    public void BuildUpstreamUrl_MainBranch_ReturnsCorrectUrl()
+    {
+        var url = BootstrapStep.BuildUpstreamUrl("main", "e2eTestPrompts.md");
+        Assert.Equal(
+            "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+            url);
+    }
+
+    [Fact]
+    public void BuildUpstreamUrl_1xBranch_ReturnsCorrectUrl()
+    {
+        var url = BootstrapStep.BuildUpstreamUrl("release/azure/1.x", "azmcp-commands.md");
+        Assert.Contains("release/azure/1.x", url);
+        Assert.EndsWith("azmcp-commands.md", url);
+    }
+
+    [Fact]
+    public void McpDocsPath_MatchesExpectedUpstreamLocation()
+    {
+        Assert.Equal("servers/Azure.Mcp.Server/docs", BootstrapStep.McpDocsPath);
+    }
+
+    [Fact]
+    public void BuildUpstreamUrl_BothFiles_UseSameBranchAndPath()
+    {
+        const string branch = "release/azure/2.x";
+        var azmcpUrl = BootstrapStep.BuildUpstreamUrl(branch, "azmcp-commands.md");
+        var e2eUrl = BootstrapStep.BuildUpstreamUrl(branch, "e2eTestPrompts.md");
+
+        // Both URLs share the same base and branch
+        var commonPrefix = $"https://raw.githubusercontent.com/microsoft/mcp/{branch}/{BootstrapStep.McpDocsPath}/";
+        Assert.StartsWith(commonPrefix, azmcpUrl);
+        Assert.StartsWith(commonPrefix, e2eUrl);
+    }
+}

--- a/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
+++ b/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
 
+[Collection("EnvironmentState")]
 public class McpBranchResolutionTests
 {
     [Fact]

--- a/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
+++ b/docs-generation/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
@@ -1,0 +1,128 @@
+using PipelineRunner.Cli;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class McpBranchResolutionTests
+{
+    [Fact]
+    public void ResolvedMcpBranch_DefaultsTo2x_WhenNothingSet()
+    {
+        // Ensure env var is not set for this test
+        var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+        try
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", null);
+            var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: null);
+            Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
+            Assert.Equal("release/azure/2.x", request.ResolvedMcpBranch);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", originalValue);
+        }
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_CliOverridesDefault()
+    {
+        var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: "main");
+        Assert.Equal("main", request.ResolvedMcpBranch);
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_CliOverridesEnvVar()
+    {
+        var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+        try
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", "release/azure/1.x");
+            var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: "main");
+            Assert.Equal("main", request.ResolvedMcpBranch);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", originalValue);
+        }
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_EnvVarOverridesDefault()
+    {
+        var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+        try
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", "release/azure/1.x");
+            var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: null);
+            Assert.Equal("release/azure/1.x", request.ResolvedMcpBranch);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", originalValue);
+        }
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_BlankCliValueFallsToDefault()
+    {
+        var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+        try
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", null);
+            var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: "  ");
+            Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", originalValue);
+        }
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_BlankEnvVarFallsToDefault()
+    {
+        var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+        try
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", "  ");
+            var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: null);
+            Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCP_BRANCH", originalValue);
+        }
+    }
+
+    [Fact]
+    public void ResolvedMcpBranch_TrimsWhitespace()
+    {
+        var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: "  main  ");
+        Assert.Equal("main", request.ResolvedMcpBranch);
+    }
+
+    [Fact]
+    public void Parse_McpBranchFlag_Parsed()
+    {
+        var result = PipelineCli.Parse(["--mcp-branch", "main"]);
+        Assert.NotNull(result.Request);
+        Assert.Equal("main", result.Request!.McpBranch);
+    }
+
+    [Fact]
+    public void Parse_McpBranchFlagWithNamespace_Parsed()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute", "--mcp-branch", "release/azure/1.x"]);
+        Assert.NotNull(result.Request);
+        Assert.Equal("compute", result.Request!.Namespace);
+        Assert.Equal("release/azure/1.x", result.Request.McpBranch);
+    }
+
+    [Fact]
+    public void Parse_NoMcpBranchFlag_DefaultsToNull()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute"]);
+        Assert.NotNull(result.Request);
+        Assert.Null(result.Request!.McpBranch);
+    }
+}

--- a/docs-generation/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -19,6 +19,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipEnvValidation);
         rootCommand.AddOption(options.SkipDeps);
         rootCommand.AddOption(options.DryRun);
+        rootCommand.AddOption(options.McpBranch);
         return rootCommand;
     }
 
@@ -55,7 +56,8 @@ public static class PipelineCli
             parseResult.GetValueForOption(options.SkipValidation),
             parseResult.GetValueForOption(options.DryRun),
             parseResult.GetValueForOption(options.SkipEnvValidation),
-            parseResult.GetValueForOption(options.SkipDeps));
+            parseResult.GetValueForOption(options.SkipDeps),
+            parseResult.GetValueForOption(options.McpBranch));
 
         var validationErrors = request.Validate();
         return validationErrors.Count > 0
@@ -108,6 +110,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipEnvValidation);
         rootCommand.AddOption(options.SkipDeps);
         rootCommand.AddOption(options.DryRun);
+        rootCommand.AddOption(options.McpBranch);
         return rootCommand;
     }
 
@@ -120,7 +123,8 @@ public static class PipelineCli
             new Option<bool>("--skip-validation", "Skip validation checks executed by the typed runner."),
             new Option<bool>("--skip-env-validation", "Skip Azure OpenAI environment validation during bootstrap."),
             new Option<bool>("--skip-deps", "Skip step dependency validation. Allows running a step without its prerequisites."),
-            new Option<bool>("--dry-run", "Print the resolved execution plan without running bootstrap or steps."));
+            new Option<bool>("--dry-run", "Print the resolved execution plan without running bootstrap or steps."),
+            new Option<string?>("--mcp-branch", "Branch of microsoft/mcp to fetch upstream files from. Overrides MCP_BRANCH env var. Default: release/azure/2.x."));
 
     private sealed record CliOptions(
         Option<string?> Namespace,
@@ -130,5 +134,6 @@ public static class PipelineCli
         Option<bool> SkipValidation,
         Option<bool> SkipEnvValidation,
         Option<bool> SkipDeps,
-        Option<bool> DryRun);
+        Option<bool> DryRun,
+        Option<string?> McpBranch);
 }

--- a/docs-generation/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -8,8 +8,32 @@ public sealed record PipelineRequest(
     bool SkipValidation,
     bool DryRun,
     bool SkipEnvValidation = false,
-    bool SkipDependencyValidation = false)
+    bool SkipDependencyValidation = false,
+    string? McpBranch = null)
 {
+    /// <summary>
+    /// Default upstream branch for fetching files from the microsoft/mcp repository.
+    /// </summary>
+    public const string DefaultMcpBranch = "release/azure/2.x";
+
+    /// <summary>
+    /// Resolves the effective MCP branch: CLI flag > MCP_BRANCH env var > default constant.
+    /// Blank values are treated as unset.
+    /// </summary>
+    public string ResolvedMcpBranch
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(McpBranch))
+                return McpBranch.Trim();
+
+            var envValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
+            if (!string.IsNullOrWhiteSpace(envValue))
+                return envValue.Trim();
+
+            return DefaultMcpBranch;
+        }
+    }
     public static IReadOnlyList<int> DefaultSteps { get; } = [1, 2, 3, 4, 5, 6];
 
     public static string GetDefaultOutputPath(string? targetNamespace)

--- a/docs-generation/DocGeneration.PipelineRunner/Context/PipelineContext.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Context/PipelineContext.cs
@@ -30,6 +30,12 @@ public sealed class PipelineContext
 
     public required IReportWriter Reports { get; init; }
 
+    /// <summary>
+    /// The resolved upstream branch for fetching files from microsoft/mcp.
+    /// Delegates to <see cref="PipelineRequest.ResolvedMcpBranch"/>.
+    /// </summary>
+    public string McpBranch => Request.ResolvedMcpBranch;
+
     public string? CliVersion { get; set; }
 
     public CliMetadataSnapshot? CliOutput { get; set; }

--- a/docs-generation/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -15,6 +15,11 @@ public sealed class BootstrapStep : StepDefinition
     internal const string McpDocsPath = "servers/Azure.Mcp.Server/docs";
 
     /// <summary>
+    /// Shared HttpClient for upstream file fetching. Static to avoid socket exhaustion.
+    /// </summary>
+    private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+
+    /// <summary>
     /// Constructs a raw GitHub URL for a file in the microsoft/mcp repo on the given branch.
     /// </summary>
     internal static string BuildUpstreamUrl(string branch, string fileName)
@@ -434,17 +439,20 @@ public sealed class BootstrapStep : StepDefinition
         CancellationToken cancellationToken)
     {
         var tempPath = Path.Combine(Path.GetTempPath(), $"mcp-upstream-{displayName}");
-        using var http = new HttpClient();
-        http.Timeout = TimeSpan.FromSeconds(30);
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             context.Reports.Info($"Fetching {displayName} from {remoteUrl}");
-            var content = await http.GetStringAsync(remoteUrl, cancellationToken);
+            var content = await SharedHttpClient.GetStringAsync(remoteUrl, cancellationToken);
             await File.WriteAllTextAsync(tempPath, content, cancellationToken);
             context.Reports.Info($"Fetched {displayName} ({content.Length:N0} bytes)");
             return tempPath;
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // Propagate user cancellation (Ctrl+C), don't fall back
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             warnings.Add($"Failed to fetch {displayName} from upstream: {ex.Message}. Using local fallback.");
             if (File.Exists(localFallback))

--- a/docs-generation/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/docs-generation/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using PipelineRunner.Cli;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
@@ -8,6 +9,17 @@ namespace PipelineRunner.Steps;
 
 public sealed class BootstrapStep : StepDefinition
 {
+    /// <summary>
+    /// Base path within the microsoft/mcp repo where upstream doc files live.
+    /// </summary>
+    internal const string McpDocsPath = "servers/Azure.Mcp.Server/docs";
+
+    /// <summary>
+    /// Constructs a raw GitHub URL for a file in the microsoft/mcp repo on the given branch.
+    /// </summary>
+    internal static string BuildUpstreamUrl(string branch, string fileName)
+        => $"https://raw.githubusercontent.com/microsoft/mcp/{branch}/{McpDocsPath}/{fileName}";
+
     private static readonly string[] BaseOutputDirectories =
     [
         "cli",
@@ -48,6 +60,8 @@ public sealed class BootstrapStep : StepDefinition
 
         try
         {
+            context.Reports.Info($"Upstream MCP branch: {context.McpBranch}");
+
             if (NeedsAiConfiguration(context))
             {
                 if (context.Request.SkipEnvValidation)
@@ -217,9 +231,31 @@ public sealed class BootstrapStep : StepDefinition
 
             var e2eOutputFile = Path.Combine(context.OutputPath, "e2e-test-prompts", "parsed.json");
             var e2eProject = Path.Combine(context.DocsGenerationRoot, "DocGeneration.Steps.Bootstrap.E2eTestPromptParser", "DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj");
+
+            // Centralized fetch: Bootstrap downloads e2eTestPrompts.md from the resolved branch,
+            // then passes the local file to the parser (no branch/URL logic in the parser itself).
+            var e2eLocalFallback = Path.Combine(context.DocsGenerationRoot, "azure-mcp", "e2eTestPrompts.md");
+            var e2eRemoteUrl = BuildUpstreamUrl(context.McpBranch, "e2eTestPrompts.md");
+            string? e2eFetchedFile = null;
+            try
+            {
+                e2eFetchedFile = await FetchUpstreamFileAsync(
+                    e2eRemoteUrl, e2eLocalFallback, "e2eTestPrompts.md", context, warnings, cancellationToken);
+            }
+            catch (FileNotFoundException)
+            {
+                warnings.Add("e2eTestPrompts.md not available from upstream or locally (non-blocking).");
+            }
+
+            var e2eArgs = new List<string> { e2eOutputFile };
+            if (e2eFetchedFile is not null)
+            {
+                e2eArgs.AddRange(["--file", e2eFetchedFile]);
+            }
+
             var e2eResult = await context.ProcessRunner.RunDotNetProjectAsync(
                 e2eProject,
-                [e2eOutputFile],
+                e2eArgs.ToArray(),
                 noBuild: true,
                 context.DocsGenerationRoot,
                 cancellationToken);
@@ -229,7 +265,10 @@ public sealed class BootstrapStep : StepDefinition
                 AddProcessIssue(e2eResult, warnings, "E2E test prompt parsing failed (non-blocking)");
             }
 
-            var azmcpSourceFile = Path.Combine(context.DocsGenerationRoot, "azure-mcp", "azmcp-commands.md");
+            var azmcpLocalFallback = Path.Combine(context.DocsGenerationRoot, "azure-mcp", "azmcp-commands.md");
+            var azmcpRemoteUrl = BuildUpstreamUrl(context.McpBranch, "azmcp-commands.md");
+            var azmcpSourceFile = await FetchUpstreamFileAsync(
+                azmcpRemoteUrl, azmcpLocalFallback, "azmcp-commands.md", context, warnings, cancellationToken);
             var azmcpOutputFile = Path.Combine(cliDirectory, "azmcp-commands.json");
             var azmcpProject = Path.Combine(context.DocsGenerationRoot, "DocGeneration.Steps.Bootstrap.CommandParser", "DocGeneration.Steps.Bootstrap.CommandParser.csproj");
             var azmcpResult = await context.ProcessRunner.RunDotNetProjectAsync(
@@ -380,6 +419,41 @@ public sealed class BootstrapStep : StepDefinition
         if (!string.IsNullOrWhiteSpace(processResult.StandardOutput))
         {
             warnings.Add(processResult.StandardOutput.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Downloads a file from the upstream microsoft/mcp repo. Falls back to a local copy on failure.
+    /// </summary>
+    internal static async Task<string> FetchUpstreamFileAsync(
+        string remoteUrl,
+        string localFallback,
+        string displayName,
+        PipelineContext context,
+        ICollection<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mcp-upstream-{displayName}");
+        using var http = new HttpClient();
+        http.Timeout = TimeSpan.FromSeconds(30);
+        try
+        {
+            context.Reports.Info($"Fetching {displayName} from {remoteUrl}");
+            var content = await http.GetStringAsync(remoteUrl, cancellationToken);
+            await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+            context.Reports.Info($"Fetched {displayName} ({content.Length:N0} bytes)");
+            return tempPath;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            warnings.Add($"Failed to fetch {displayName} from upstream: {ex.Message}. Using local fallback.");
+            if (File.Exists(localFallback))
+            {
+                return localFallback;
+            }
+
+            throw new FileNotFoundException(
+                $"Neither upstream ({remoteUrl}) nor local fallback ({localFallback}) for {displayName} is available.");
         }
     }
 

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj" />
+    <ProjectReference Include="../DocGeneration.TestInfrastructure/DocGeneration.TestInfrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using DocGeneration.TestInfrastructure;
+using E2eTestPromptParser.Models;
+using Xunit;
+
+namespace E2eTestPromptParser.Tests;
+
+public class ParserConfigTests
+{
+    private static string GetConfigPath()
+    {
+        var docsGenRoot = ProjectRootFinder.FindDocsGenerationRoot();
+        return Path.Combine(docsGenRoot,
+            "DocGeneration.Steps.Bootstrap.E2eTestPromptParser",
+            "config.json");
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_PointsTo2xBranch()
+    {
+        var configPath = GetConfigPath();
+        Assert.True(File.Exists(configPath), $"config.json not found at {configPath}");
+
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.Contains("release/azure/2.x", config!.RemoteUrl, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/main/", config.RemoteUrl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_PointsToE2eTestPromptsFile()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.EndsWith("e2eTestPrompts.md", config!.RemoteUrl);
+        Assert.Contains("servers/Azure.Mcp.Server/docs/", config.RemoteUrl);
+    }
+
+    [Fact]
+    public void Config_RemoteUrl_IsValidRawGitHubUrl()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.StartsWith("https://raw.githubusercontent.com/microsoft/mcp/", config!.RemoteUrl);
+    }
+
+    [Fact]
+    public void Config_LocalFileName_IsE2eTestPromptsMd()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.Equal("e2eTestPrompts.md", config!.LocalFileName);
+    }
+
+    [Fact]
+    public void Config_RemoteUrlTemplate_HasBranchPlaceholder()
+    {
+        var configPath = GetConfigPath();
+        var json = File.ReadAllText(configPath);
+        var config = JsonSerializer.Deserialize<ParserConfig>(json);
+
+        Assert.NotNull(config);
+        Assert.NotNull(config!.RemoteUrlTemplate);
+        Assert.Contains("{branch}", config.RemoteUrlTemplate);
+    }
+
+    // --- GetEffectiveUrl tests ---
+
+    [Fact]
+    public void GetEffectiveUrl_NoBranchOverride_ReturnsFallbackRemoteUrl()
+    {
+        var config = new ParserConfig
+        {
+            RemoteUrl = "https://example.com/main/file.md",
+            RemoteUrlTemplate = "https://example.com/{branch}/file.md"
+        };
+
+        Assert.Equal("https://example.com/main/file.md", config.GetEffectiveUrl(null));
+    }
+
+    [Fact]
+    public void GetEffectiveUrl_WithBranchOverride_SubstitutesTemplate()
+    {
+        var config = new ParserConfig
+        {
+            RemoteUrl = "https://example.com/main/file.md",
+            RemoteUrlTemplate = "https://example.com/{branch}/file.md"
+        };
+
+        Assert.Equal("https://example.com/release/azure/2.x/file.md",
+            config.GetEffectiveUrl("release/azure/2.x"));
+    }
+
+    [Fact]
+    public void GetEffectiveUrl_WithBranchOverrideButNoTemplate_ReturnsFallbackRemoteUrl()
+    {
+        var config = new ParserConfig
+        {
+            RemoteUrl = "https://example.com/main/file.md",
+            RemoteUrlTemplate = null
+        };
+
+        Assert.Equal("https://example.com/main/file.md", config.GetEffectiveUrl("release/azure/2.x"));
+    }
+
+    [Fact]
+    public void GetEffectiveUrl_BlankBranchOverride_ReturnsFallbackRemoteUrl()
+    {
+        var config = new ParserConfig
+        {
+            RemoteUrl = "https://example.com/main/file.md",
+            RemoteUrlTemplate = "https://example.com/{branch}/file.md"
+        };
+
+        Assert.Equal("https://example.com/main/file.md", config.GetEffectiveUrl("  "));
+    }
+
+    [Fact]
+    public void GetEffectiveUrl_TrimsOverrideBranch()
+    {
+        var config = new ParserConfig
+        {
+            RemoteUrl = "https://example.com/main/file.md",
+            RemoteUrlTemplate = "https://example.com/{branch}/file.md"
+        };
+
+        Assert.Equal("https://example.com/main/file.md", config.GetEffectiveUrl("  main  "));
+    }
+}

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
@@ -135,6 +135,8 @@ public class ParserConfigTests
             RemoteUrlTemplate = "https://example.com/{branch}/file.md"
         };
 
-        Assert.Equal("https://example.com/main/file.md", config.GetEffectiveUrl("  main  "));
+        // Use a branch different from fallback URL to prove template substitution actually happened
+        Assert.Equal("https://example.com/release/azure/2.x/file.md",
+            config.GetEffectiveUrl("  release/azure/2.x  "));
     }
 }

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Models/ParserConfig.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Models/ParserConfig.cs
@@ -9,13 +9,34 @@ public sealed class ParserConfig
 {
     /// <summary>
     /// The remote URL to download the markdown file from.
+    /// Used as the default when no branch override or template is provided.
     /// </summary>
     [JsonPropertyName("remoteUrl")]
     public string RemoteUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional URL template with {branch} placeholder for branch-parameterized fetching.
+    /// </summary>
+    [JsonPropertyName("remoteUrlTemplate")]
+    public string? RemoteUrlTemplate { get; set; }
 
     /// <summary>
     /// The local filename to save the downloaded file as.
     /// </summary>
     [JsonPropertyName("localFileName")]
     public string LocalFileName { get; set; } = "e2eTestPrompts.md";
+
+    /// <summary>
+    /// Returns the effective URL. If a branch override is given and a template exists,
+    /// the template is used with {branch} substituted. Otherwise falls back to <see cref="RemoteUrl"/>.
+    /// </summary>
+    public string GetEffectiveUrl(string? branchOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(branchOverride) && !string.IsNullOrWhiteSpace(RemoteUrlTemplate))
+        {
+            return RemoteUrlTemplate.Replace("{branch}", branchOverride.Trim());
+        }
+
+        return RemoteUrl;
+    }
 }

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Program.cs
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Program.cs
@@ -18,6 +18,8 @@ internal static class Program
     {
         var format = "json";
         string? outputFile = null;
+        string? branchOverride = null;
+        string? inputFile = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -25,43 +27,68 @@ internal static class Program
             {
                 format = args[++i].ToLowerInvariant();
             }
+            else if (args[i] == "--branch" && i + 1 < args.Length)
+            {
+                branchOverride = args[++i];
+            }
+            else if (args[i] == "--file" && i + 1 < args.Length)
+            {
+                inputFile = args[++i];
+            }
             else if (!args[i].StartsWith("--", StringComparison.Ordinal))
             {
                 outputFile = args[i];
             }
         }
 
-        // Load config
-        var configPath = Path.Combine(AppContext.BaseDirectory, "config.json");
-        if (!File.Exists(configPath))
-        {
-            Console.Error.WriteLine($"Error: config.json not found at {configPath}");
-            return 1;
-        }
+        string localPath;
 
-        var configJson = await File.ReadAllTextAsync(configPath);
-        var config = JsonSerializer.Deserialize<ParserConfig>(configJson);
-        if (config is null || string.IsNullOrWhiteSpace(config.RemoteUrl))
+        if (!string.IsNullOrWhiteSpace(inputFile))
         {
-            Console.Error.WriteLine("Error: config.json is missing or has empty remoteUrl");
-            return 1;
-        }
+            // Pre-fetched file provided by caller (e.g., BootstrapStep)
+            if (!File.Exists(inputFile))
+            {
+                Console.Error.WriteLine($"Error: input file not found: {inputFile}");
+                return 1;
+            }
 
-        // Download remote file
-        Console.WriteLine($"Downloading: {config.RemoteUrl}");
-        var localPath = Path.Combine(AppContext.BaseDirectory, config.LocalFileName);
-
-        using var httpClient = new HttpClient();
-        try
-        {
-            var markdown = await httpClient.GetStringAsync(config.RemoteUrl);
-            await File.WriteAllTextAsync(localPath, markdown);
-            Console.WriteLine($"Saved to:    {localPath}");
+            localPath = inputFile;
+            Console.WriteLine($"Using pre-fetched file: {localPath}");
         }
-        catch (HttpRequestException ex)
+        else
         {
-            Console.Error.WriteLine($"Error downloading file: {ex.Message}");
-            return 1;
+            // Standalone mode: download from upstream using config.json
+            var configPath = Path.Combine(AppContext.BaseDirectory, "config.json");
+            if (!File.Exists(configPath))
+            {
+                Console.Error.WriteLine($"Error: config.json not found at {configPath}");
+                return 1;
+            }
+
+            var configJson = await File.ReadAllTextAsync(configPath);
+            var config = JsonSerializer.Deserialize<ParserConfig>(configJson);
+            if (config is null || string.IsNullOrWhiteSpace(config.RemoteUrl))
+            {
+                Console.Error.WriteLine("Error: config.json is missing or has empty remoteUrl");
+                return 1;
+            }
+
+            var effectiveUrl = config.GetEffectiveUrl(branchOverride);
+            Console.WriteLine($"Downloading: {effectiveUrl}");
+            localPath = Path.Combine(AppContext.BaseDirectory, config.LocalFileName);
+
+            using var httpClient = new HttpClient();
+            try
+            {
+                var markdown = await httpClient.GetStringAsync(effectiveUrl);
+                await File.WriteAllTextAsync(localPath, markdown);
+                Console.WriteLine($"Saved to:    {localPath}");
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.Error.WriteLine($"Error downloading file: {ex.Message}");
+                return 1;
+            }
         }
 
         // Parse

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
@@ -20,6 +20,25 @@ The remote URL is configured in `config.json`:
 
 The app downloads the file from `remoteUrl` (or `remoteUrlTemplate` with a branch override) on each run and saves it locally as `localFileName` before parsing. When called by BootstrapStep, the `--file` flag provides a pre-fetched file, skipping the download.
 
+## CLI Flags
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `<outputFile>` | Positional — path to write parsed JSON | `parsed.json` |
+| `--file <path>` | Pre-fetched input file (skips download) | `--file /tmp/e2eTestPrompts.md` |
+| `--branch <name>` | Override branch in `remoteUrlTemplate` (standalone use) | `--branch main` |
+| `--format <type>` | Output format: `json` (default) or `summary` | `--format summary` |
+
+**Pipeline mode** (called by BootstrapStep):
+```bash
+dotnet run -- parsed.json --file /tmp/mcp-upstream-e2eTestPrompts.md
+```
+
+**Standalone mode** (downloads from upstream):
+```bash
+dotnet run -- parsed.json --branch release/azure/2.x
+```
+
 ## Data Model
 
 ```

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/README.md
@@ -12,12 +12,13 @@ The remote URL is configured in `config.json`:
 
 ```json
 {
-  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrlTemplate": "https://raw.githubusercontent.com/microsoft/mcp/{branch}/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "localFileName": "e2eTestPrompts.md"
 }
 ```
 
-The app downloads the file from `remoteUrl` on each run and saves it locally as `localFileName` before parsing.
+The app downloads the file from `remoteUrl` (or `remoteUrlTemplate` with a branch override) on each run and saves it locally as `localFileName` before parsing. When called by BootstrapStep, the `--file` flag provides a pre-fetched file, skipping the download.
 
 ## Data Model
 
@@ -181,7 +182,7 @@ The parser relies on these structural conventions:
 
 1. **Download the new file and inspect it**:
    ```bash
-   curl -o /tmp/e2eTestPrompts.md https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+   curl -o /tmp/e2eTestPrompts.md https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
    head -50 /tmp/e2eTestPrompts.md
    ```
 

--- a/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
+++ b/docs-generation/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
@@ -1,4 +1,5 @@
 {
-  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrlTemplate": "https://raw.githubusercontent.com/microsoft/mcp/{branch}/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "localFileName": "e2eTestPrompts.md"
 }

--- a/docs-generation/scripts/preflight.ps1
+++ b/docs-generation/scripts/preflight.ps1
@@ -159,10 +159,11 @@ $e2eOutputFile = Join-Path $e2eOutputDir "parsed.json"
 $e2eProject = Join-Path $docsGenDir "DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj"
 
 # Fetch e2e test prompts from upstream, then pass to parser via --file
+# NOTE: URL path pattern must stay in sync with BootstrapStep.McpDocsPath (source of truth)
 $e2eRemoteUrl = "https://raw.githubusercontent.com/microsoft/mcp/$McpBranch/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md"
 $e2eTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "mcp-upstream-e2eTestPrompts.md"
 try {
-    Invoke-WebRequest -Uri $e2eRemoteUrl -OutFile $e2eTempFile -ErrorAction Stop
+    Invoke-WebRequest -Uri $e2eRemoteUrl -OutFile $e2eTempFile -TimeoutSec 30 -ErrorAction Stop
     Write-Host "  Downloaded e2eTestPrompts.md from upstream" -ForegroundColor Gray
     & dotnet run --project $e2eProject --configuration Release --no-build -- $e2eOutputFile --file $e2eTempFile
 } catch {
@@ -178,11 +179,12 @@ Write-Host ""
 
 # Step 7: Fetch and parse azmcp-commands.md from upstream
 Write-Host "Fetching and parsing azmcp-commands.md (branch: $McpBranch)..." -ForegroundColor Yellow
+# NOTE: URL path pattern must stay in sync with BootstrapStep.McpDocsPath (source of truth)
 $azmcpRemoteUrl = "https://raw.githubusercontent.com/microsoft/mcp/$McpBranch/servers/Azure.Mcp.Server/docs/azmcp-commands.md"
 $azmcpLocalFallback = Join-Path $docsGenDir "azure-mcp/azmcp-commands.md"
 $azmcpTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "mcp-upstream-azmcp-commands.md"
 try {
-    Invoke-WebRequest -Uri $azmcpRemoteUrl -OutFile $azmcpTempFile -ErrorAction Stop
+    Invoke-WebRequest -Uri $azmcpRemoteUrl -OutFile $azmcpTempFile -TimeoutSec 30 -ErrorAction Stop
     $azmcpSourceFile = $azmcpTempFile
     Write-Host "  Downloaded azmcp-commands.md from upstream" -ForegroundColor Gray
 } catch {

--- a/docs-generation/scripts/preflight.ps1
+++ b/docs-generation/scripts/preflight.ps1
@@ -31,7 +31,8 @@
 param(
     [string]$OutputPath = "",
     [switch]$SkipBuild,
-    [switch]$SkipEnvValidation
+    [switch]$SkipEnvValidation,
+    [string]$McpBranch = "release/azure/2.x"
 )
 
 $ErrorActionPreference = "Stop"
@@ -151,12 +152,23 @@ try {
 Write-Host ""
 
 # Step 6: Download and parse e2e test prompts from upstream
-Write-Host "Downloading and parsing e2e test prompts..." -ForegroundColor Yellow
+Write-Host "Downloading and parsing e2e test prompts (branch: $McpBranch)..." -ForegroundColor Yellow
 $e2eOutputDir = Join-Path $OutputPath "e2e-test-prompts"
 New-Item -ItemType Directory -Path $e2eOutputDir -Force | Out-Null
 $e2eOutputFile = Join-Path $e2eOutputDir "parsed.json"
 $e2eProject = Join-Path $docsGenDir "DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj"
-& dotnet run --project $e2eProject --configuration Release --no-build -- $e2eOutputFile
+
+# Fetch e2e test prompts from upstream, then pass to parser via --file
+$e2eRemoteUrl = "https://raw.githubusercontent.com/microsoft/mcp/$McpBranch/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md"
+$e2eTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "mcp-upstream-e2eTestPrompts.md"
+try {
+    Invoke-WebRequest -Uri $e2eRemoteUrl -OutFile $e2eTempFile -ErrorAction Stop
+    Write-Host "  Downloaded e2eTestPrompts.md from upstream" -ForegroundColor Gray
+    & dotnet run --project $e2eProject --configuration Release --no-build -- $e2eOutputFile --file $e2eTempFile
+} catch {
+    Write-Host "  ⚠ Failed to fetch from upstream: $_. Falling back to config.json default." -ForegroundColor Yellow
+    & dotnet run --project $e2eProject --configuration Release --no-build -- $e2eOutputFile
+}
 if ($LASTEXITCODE -ne 0) {
     Write-Host "⚠ WARNING: E2e test prompt parsing failed (non-blocking)" -ForegroundColor Yellow
 } else {
@@ -164,9 +176,19 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Host ""
 
-# Step 7: Parse azmcp-commands.md into structured JSON
-Write-Host "Parsing azmcp-commands.md..." -ForegroundColor Yellow
-$azmcpSourceFile = Join-Path $docsGenDir "azure-mcp/azmcp-commands.md"
+# Step 7: Fetch and parse azmcp-commands.md from upstream
+Write-Host "Fetching and parsing azmcp-commands.md (branch: $McpBranch)..." -ForegroundColor Yellow
+$azmcpRemoteUrl = "https://raw.githubusercontent.com/microsoft/mcp/$McpBranch/servers/Azure.Mcp.Server/docs/azmcp-commands.md"
+$azmcpLocalFallback = Join-Path $docsGenDir "azure-mcp/azmcp-commands.md"
+$azmcpTempFile = Join-Path ([System.IO.Path]::GetTempPath()) "mcp-upstream-azmcp-commands.md"
+try {
+    Invoke-WebRequest -Uri $azmcpRemoteUrl -OutFile $azmcpTempFile -ErrorAction Stop
+    $azmcpSourceFile = $azmcpTempFile
+    Write-Host "  Downloaded azmcp-commands.md from upstream" -ForegroundColor Gray
+} catch {
+    Write-Host "  ⚠ Failed to fetch from upstream: $_. Using local fallback." -ForegroundColor Yellow
+    $azmcpSourceFile = $azmcpLocalFallback
+}
 $azmcpOutputFile = Join-Path $OutputPath "cli/azmcp-commands.json"
 $azmcpProject = Join-Path $docsGenDir "DocGeneration.Steps.Bootstrap.CommandParser/DocGeneration.Steps.Bootstrap.CommandParser.csproj"
 & dotnet run --project $azmcpProject --configuration Release --no-build -- --file $azmcpSourceFile --output $azmcpOutputFile

--- a/docs/START-SCRIPTS.md
+++ b/docs/START-SCRIPTS.md
@@ -58,11 +58,31 @@ These flags are passed through to the .NET runner:
 | `--namespace <name>` | all | Process single namespace |
 | `--steps <csv>` | `1,2,3,4,5,6` | Comma-separated step IDs |
 | `--output <path>` | auto | Output directory |
+| `--mcp-branch <branch>` | `release/azure/2.x` | Branch of `microsoft/mcp` for upstream files |
 | `--skip-build` | false | Reuse existing Release build |
 | `--skip-validation` | false | Skip post-assembly validation |
 | `--skip-env-validation` | false | Skip Azure OpenAI env check |
 | `--skip-deps` | false | Skip step dependency validation |
 | `--dry-run` | false | Print execution plan only |
+
+### Switching MCP Upstream Branch
+
+The `--mcp-branch` flag controls which branch of `microsoft/mcp` is used to fetch upstream documentation files (`azmcp-commands.md` and `e2eTestPrompts.md`). The default is `release/azure/2.x`.
+
+```bash
+# Generate docs from 2.x release branch (default)
+./start.sh
+
+# Generate docs from main branch (preview/next)
+./start.sh --mcp-branch main
+
+# Generate docs from 1.x branch
+./start.sh advisor --mcp-branch release/azure/1.x
+```
+
+**Resolution order**: CLI flag `--mcp-branch` > environment variable `MCP_BRANCH` > default (`release/azure/2.x`).
+
+If the upstream fetch fails (e.g., network issue), the pipeline falls back to the local copy at `docs-generation/azure-mcp/azmcp-commands.md` with a warning.
 
 ## Parallel Execution (Fan-Out)
 

--- a/docs/START-SCRIPTS.md
+++ b/docs/START-SCRIPTS.md
@@ -78,6 +78,9 @@ The `--mcp-branch` flag controls which branch of `microsoft/mcp` is used to fetc
 
 # Generate docs from 1.x branch
 ./start.sh advisor --mcp-branch release/azure/1.x
+
+# Override via environment variable
+MCP_BRANCH=main ./start.sh
 ```
 
 **Resolution order**: CLI flag `--mcp-branch` > environment variable `MCP_BRANCH` > default (`release/azure/2.x`).


### PR DESCRIPTION
## Full Implementation — Branch-Aware Content Generation (Issue #387)

### Problem
The documentation pipeline hardcoded \main\ as the branch for fetching upstream files from \microsoft/mcp\, and \zmcp-commands.md\ was a local-only file. For 2.x documentation generation, the canonical source is \elease/azure/2.x\.

### Solution: 4 Subsystem Changes

#### 1. PipelineRequest + PipelineCli
- New \--mcp-branch\ CLI option
- \ResolvedMcpBranch\ property with resolution: CLI flag → \MCP_BRANCH\ env var → default \elease/azure/2.x\
- Blank values correctly treated as unset

#### 2. PipelineContext
- Exposes \McpBranch\ from resolved request for all downstream steps

#### 3. BootstrapStep (centralized fetch)
- **Both** \zmcp-commands.md\ and \2eTestPrompts.md\ fetched from upstream using \BuildUpstreamUrl(branch, file)\
- Local fallback on HTTP failure (with warning)
- Passes pre-fetched file to E2eTestPromptParser via \--file\ flag

#### 4. E2eTestPromptParser
- New \--file\ flag accepts pre-fetched input (used by BootstrapStep)
- New \--branch\ flag for standalone use
- \ParserConfig\ gains \emoteUrlTemplate\ with \{branch}\ placeholder
- \config.json\ updated: default URL → \elease/azure/2.x\, template added

#### 5. preflight.ps1
- New \-McpBranch\ parameter (default: \elease/azure/2.x\)
- Upstream fetch with local fallback for both files

### Usage
\\\ash
# Default (2.x)
./start.sh

# Override to main
./start.sh --mcp-branch main

# Via environment variable
MCP_BRANCH=main ./start.sh
\\\

### Tests (25 new, 2,063 total — all pass)
- Branch resolution priority (CLI > env > default)
- Blank value handling
- CLI parsing (\--mcp-branch\)
- URL construction (\BuildUpstreamUrl\)
- ParserConfig template substitution
- Config file validation (points to 2.x)

### Docs Updated
- \docs/START-SCRIPTS.md\ — new \--mcp-branch\ flag + branch switching guide
- \CHANGELOG.md\ — feature entry
- \E2eTestPromptParser/README.md\ — updated config example and usage

### Design Notes
- Per rubber-duck critique: centralized fetch in BootstrapStep (single source of branch/URL resolution)
- Local \zmcp-commands.md\ kept as fallback, not deleted
- See \docs/proposals/issue-387-branch-aware-generation.md\ for full PRD

Closes #387