### PR TITLE
fix: remove misleading total params column from namespace report (#391)

### DIFF
--- a/test-npm-azure-mcp/generate-report.js
+++ b/test-npm-azure-mcp/generate-report.js
@@ -121,11 +121,11 @@ function generateReport({ cliOutput, cliNamespace, cliVersion, commonParams }) {
   // ── Namespace Summary Table ──
   lines.push('## Namespace Summary');
   lines.push('');
-  lines.push('| Namespace | Tools | Total Params | Non-Global Params |');
-  lines.push('| --- | --- | --- | --- |');
+  lines.push('| Namespace | Tools | Non-Global Params |');
+  lines.push('| --- | --- | --- |');
   for (const ns of sortedNamespaces) {
     const s = nsSummary[ns];
-    lines.push(`| ${ns} | ${s.toolCount} | ${s.totalParams} | ${s.nonGlobalParams} |`);
+    lines.push(`| ${ns} | ${s.toolCount} | ${s.nonGlobalParams} |`);
   }
   lines.push('');
 

--- a/test-npm-azure-mcp/test/generate-report.test.js
+++ b/test-npm-azure-mcp/test/generate-report.test.js
@@ -158,22 +158,22 @@ describe('generateReport', () => {
   });
 
   it('has a markdown table with correct headers', () => {
-    assert.ok(report.includes('| Namespace | Tools | Total Params | Non-Global Params |'));
+    assert.ok(report.includes('| Namespace | Tools | Non-Global Params |'));
   });
 
   it('has a separator row after headers', () => {
-    assert.ok(report.includes('| --- | --- | --- | --- |'));
+    assert.ok(report.includes('| --- | --- | --- |'));
   });
 
   it('includes acr row with correct counts', () => {
-    // acr: 2 tools, 18 total params, 4 non-global
-    const acrRow = report.match(/\| acr \| 2 \| 18 \| 4 \|/);
+    // acr: 2 tools, 4 non-global
+    const acrRow = report.match(/\| acr \| 2 \| 4 \|/);
     assert.ok(acrRow, 'acr row should have correct values');
   });
 
   it('includes cosmos row with correct counts', () => {
-    // cosmos: 2 tools, 20 total params, 6 non-global
-    const cosmosRow = report.match(/\| cosmos \| 2 \| 20 \| 6 \|/);
+    // cosmos: 2 tools, 6 non-global
+    const cosmosRow = report.match(/\| cosmos \| 2 \| 6 \|/);
     assert.ok(cosmosRow, 'cosmos row should have correct values');
   });
 


### PR DESCRIPTION
## Summary
Fixes #391 — the namespace markdown report in test-npm-azure-mcp showed a **Total Params** column that included global/common parameters, contradicting the C# pipeline filtering behavior.

## Changes
- **generate-report.js**: Removed Total Params column from namespace summary table (header, separator, data row)
- **generate-report.test.js**: Updated 3 tests to expect new 3-column format

## Testing
- 28 tests pass (npm test)
- TDD: tests updated first to fail, then code fixed

## Root Cause
Line 128 displayed \s.totalParams\ (unfiltered) alongside \s.nonGlobalParams\ (filtered). The Total Params column was misleading since the C# pipeline (ParameterFilterHelper.cs) always filters common params from counts.