### PR TITLE
chore(deps): upgrade @azure/mcp from 2.x to 3.0.0-beta.1

### DIFF
--- a/test-npm-azure-mcp/package-lock.json
+++ b/test-npm-azure-mcp/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@azure/mcp": "^2.0.0-beta.38"
+        "@azure/mcp": "^3.0.0-beta.1"
       }
     },
     "node_modules/@azure/mcp": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp/-/mcp-2.0.0-beta.38.tgz",
-      "integrity": "sha512-Y0lWZRHseu8yYLg5yqSy1gRT2g2yoPMuHQtRCYhqB8ScQk+w4xg6EwPVyWzr7awmqNX5TGHbVKbwZjPp397AIg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp/-/mcp-3.0.0-beta.1.tgz",
+      "integrity": "sha512-oO98ksg7DakDQElEorRBKf5pDeiUKr3yyAO/4Mij9X6AmH/ReycNaShprxSFlIwT9nxfyxKYgF78Y4pDCdO1tQ==",
       "cpu": [
         "x64",
         "arm64"
@@ -34,18 +34,18 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@azure/mcp-darwin-arm64": "2.0.0-beta.38",
-        "@azure/mcp-darwin-x64": "2.0.0-beta.38",
-        "@azure/mcp-linux-arm64": "2.0.0-beta.38",
-        "@azure/mcp-linux-x64": "2.0.0-beta.38",
-        "@azure/mcp-win32-arm64": "2.0.0-beta.38",
-        "@azure/mcp-win32-x64": "2.0.0-beta.38"
+        "@azure/mcp-darwin-arm64": "3.0.0-beta.1",
+        "@azure/mcp-darwin-x64": "3.0.0-beta.1",
+        "@azure/mcp-linux-arm64": "3.0.0-beta.1",
+        "@azure/mcp-linux-x64": "3.0.0-beta.1",
+        "@azure/mcp-win32-arm64": "3.0.0-beta.1",
+        "@azure/mcp-win32-x64": "3.0.0-beta.1"
       }
     },
     "node_modules/@azure/mcp-darwin-arm64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-darwin-arm64/-/mcp-darwin-arm64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-d1swMHNU7DwiLmOQXJxMbykLLK0l/sb0k6Ukl40tpVqNGdtslj2e9PAlhK833BS2AYpcKXViaAW9UPo5tDtTTw==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-darwin-arm64/-/mcp-darwin-arm64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-iSw5z0qNheJHy2yxZAWXzJbQwPELRtXQQqHnKVNngOiQb8qAci7F7BSk4xl3MZnSLIidDucLp4o2b7I1/fQaYA==",
       "cpu": [
         "arm64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@azure/mcp-darwin-x64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-darwin-x64/-/mcp-darwin-x64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-TXVZZTwm6/YorIri58Nfchi+UrpF3LgNy+WZc1Y3QNuVXilHGyU52Yoyj/Y/ivRoeuy12IL/gPzetpkRpU36PQ==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-darwin-x64/-/mcp-darwin-x64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-VAD1HVUdGE/fx2mtEVkg0tQRTo4xhkQyIj0oZrTctrvwa8dxv5Fq4wYv4YQS+DzKiLoIe3Z5tHAm2LGtMNGSOg==",
       "cpu": [
         "x64"
       ],
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@azure/mcp-linux-arm64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-linux-arm64/-/mcp-linux-arm64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-kzl/WgI8f9AYkmhQt97TECoJrL6geDXeXYenDtvT77knKYH2b0nWVAAQZz1e1JXUgcTBo9klyE9cmfLLRXs6bA==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-linux-arm64/-/mcp-linux-arm64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-5OMHTqNLdGyLRZPWeov4Gvm2xoBT8abPEszK66n751xzooT4q7TG5AWTMTUG48cNO16FkQgzaCbq+rjdX5R1yA==",
       "cpu": [
         "arm64"
       ],
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@azure/mcp-linux-x64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-linux-x64/-/mcp-linux-x64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-IYji0C0qRFVlCVTh5WVvrO5W2R5z+kKytn/F+kyl3uUGavsyuIPlFj9ba7R2Pkmg8Nn1NbBaWaI/ps9c2R6TXQ==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-linux-x64/-/mcp-linux-x64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-eFuvFAVGgWH9CK6BECEWejTAmuKYaAXkLuiJLva+0TZ/MOwKmrcHdRnCHjqPjBEWf8lQuMrETKYvGuAo9g4xgQ==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@azure/mcp-win32-arm64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-win32-arm64/-/mcp-win32-arm64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-jztj31QwltxRhBHweqYlaoWxYzks99sBCYVkmVi0MUCJNsSSztthqstR4/uyykrf+GEsofQAG8tE5DcZBCAcDQ==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-win32-arm64/-/mcp-win32-arm64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-OcC8rrhoSTu/wcRWIqmBkgQAgGYpAnFmQt/+lRX/w2xsDUo32e2gTVAZ0C3Yrq9zz0GfhNP1buQluAfHc1e5pQ==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@azure/mcp-win32-x64": {
-      "version": "2.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@azure/mcp-win32-x64/-/mcp-win32-x64-2.0.0-beta.38.tgz",
-      "integrity": "sha512-+xU8d7dfKSoDWI0miINzV2UtDG67X5rxgAGdCNPRC79EiSGL59Vr4TIDEFb3UVAjmJ8gz3wRQCz2eVPDH7TEbg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-win32-x64/-/mcp-win32-x64-3.0.0-beta.1.tgz",
+      "integrity": "sha512-TMFMTblyxfhaxdFxw8XNG2ZmpXDotNun3moPaI64sruv2tfzfor4XffD9oOXDwM1UZThdHCkyeql62rII3JqbA==",
       "cpu": [
         "x64"
       ],

--- a/test-npm-azure-mcp/package.json
+++ b/test-npm-azure-mcp/package.json
@@ -21,6 +21,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/mcp": "^2.0.0-beta.38"
+    "@azure/mcp": "^3.0.0-beta.1"
   }
 }


### PR DESCRIPTION
## Summary

Moves the content generation pipeline from the 2.x line to the **3.x major version** of `@azure/mcp`.

### Changes
- **package.json**: `^2.0.0-beta.38` to `^3.0.0-beta.1`
- **package-lock.json**: resolves to `3.0.0-beta.1`

### Verification

Compared 2.0.0-beta.39 vs 3.0.0-beta.1 tool output:

| Metric | Result |
|--------|--------|
| Total tools | 235 = 235 |
| Namespaces | 55 = 55 |
| New/removed tools | 0 |
| Parameter changes | 0 |
| Required status changes | 0 |
| JSON format | Identical |
| Description changes | 1 (trivial typo fix in virtualdesktop hostpool list) |

### Tests
- All .NET tests pass (700+ across 15 test projects)
- All npm tests pass (28 tests)
- azmcp --version returns 3.0.0-beta.1
- Solution builds with 0 errors in Release configuration

### Impact on existing content
- **No content changes needed** - tool data is identical
- The update-azure-mcp.yml workflow will now track 3.x betas automatically
- Existing tool page mcp-cli.version frontmatter values remain as-is (they indicate when each page was last generated)
