### PR TITLE
fix: escape bare angle bracket placeholders in generated content (#416)

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/PlaceholderEscaperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/PlaceholderEscaperTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for PlaceholderEscaper — escapes bare angle-bracket placeholders
+/// that MS Learn build validation flags as disallowed HTML tags.
+/// Fixes: #416
+/// </summary>
+public class PlaceholderEscaperTests
+{
+    // ── Basic escaping ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(
+        "Use <resource-name> for the name.",
+        @"Use \<resource-name\> for the name.")]
+    [InlineData(
+        "Set <subscription-id> to your ID.",
+        @"Set \<subscription-id\> to your ID.")]
+    [InlineData(
+        "Provide <your-resource-group>.",
+        @"Provide \<your-resource-group\>.")]
+    [InlineData(
+        "Enter <cluster-name> and <region>.",
+        @"Enter \<cluster-name\> and \<region\>.")]
+    public void Escape_BarePlaceholder_BackslashEscaped(string input, string expected)
+    {
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Escape_PlaceholderWithUnderscores_Escaped()
+    {
+        var input = "Use <my_resource_name> here.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(@"Use \<my_resource_name\> here.", result);
+    }
+
+    [Fact]
+    public void Escape_PlaceholderWithDigits_Escaped()
+    {
+        var input = "Use <server1> for testing.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(@"Use \<server1\> for testing.", result);
+    }
+
+    // ── Already escaped — idempotent ────────────────────────────────
+
+    [Fact]
+    public void Escape_AlreadyBackslashEscaped_NotDoubleEscaped()
+    {
+        var input = @"Use \<resource-name\> for the name.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(input, result);
+    }
+
+    // ── Protected content: code fences ──────────────────────────────
+
+    [Fact]
+    public void Escape_InsideCodeFence_NotEscaped()
+    {
+        var input = "```\naz group create --name <resource-group>\n```";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Escape_MixedCodeFenceAndProse_OnlyProseEscaped()
+    {
+        var input = "Set <resource-name> first.\n\n```bash\naz vm create --name <vm-name>\n```\n\nThen use <region>.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains(@"\<resource-name\>", result);
+        Assert.Contains("<vm-name>", result); // inside code fence — preserved
+        Assert.Contains(@"\<region\>", result);
+    }
+
+    // ── Protected content: inline code ──────────────────────────────
+
+    [Fact]
+    public void Escape_InsideInlineCode_NotEscaped()
+    {
+        var input = "Run `az group create --name <resource-group>` to create.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains("`az group create --name <resource-group>`", result);
+    }
+
+    [Fact]
+    public void Escape_MixedInlineCodeAndProse_OnlyProseEscaped()
+    {
+        var input = "Use `<resource-name>` or provide <resource-name> directly.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains("`<resource-name>`", result); // inside backticks — preserved
+        Assert.Contains(@"\<resource-name\>", result); // bare in prose — escaped
+    }
+
+    // ── Protected content: HTML comments ────────────────────────────
+
+    [Fact]
+    public void Escape_HtmlComment_NotEscaped()
+    {
+        var input = "<!-- @mcpcli azmcp monitor workspace list -->\nUse <resource-name>.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains("<!-- @mcpcli azmcp monitor workspace list -->", result);
+        Assert.Contains(@"\<resource-name\>", result);
+    }
+
+    [Fact]
+    public void Escape_NonMcpcliHtmlComment_NotEscaped()
+    {
+        var input = "<!-- This comment has <placeholder> in it -->\nUse <name>.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains("<!-- This comment has <placeholder> in it -->", result);
+        Assert.Contains(@"\<name\>", result);
+    }
+
+    // ── Protected content: frontmatter ──────────────────────────────
+
+    [Fact]
+    public void Escape_Frontmatter_NotEscaped()
+    {
+        var input = "---\ntitle: Use <resource-name>\n---\n\nProvide <resource-name>.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Contains("title: Use <resource-name>", result);
+        Assert.Contains(@"\<resource-name\>", result);
+    }
+
+    // ── Non-placeholder angle brackets — NOT escaped ────────────────
+
+    [Fact]
+    public void Escape_UppercaseHtmlTag_NotEscaped()
+    {
+        // Pattern only matches lowercase starting char
+        var input = "The <A href='url'>link</A> goes here.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Escape_ComparisonOperators_NotEscaped()
+    {
+        // Pattern requires [a-z] as first char; "5" doesn't match
+        var input = "Use values where x < 10 and y > 5.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(input, result);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Escape_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal("", PlaceholderEscaper.Escape(""));
+        Assert.Equal("", PlaceholderEscaper.Escape(null!));
+    }
+
+    [Fact]
+    public void Escape_NoPlaceholders_ReturnsUnchanged()
+    {
+        var input = "This is a normal sentence about Azure resources.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Escape_MultiplePlaceholders_AllEscaped()
+    {
+        var input = "Set <resource-group>, <location>, and <name>.";
+        var result = PlaceholderEscaper.Escape(input);
+        Assert.Equal(@"Set \<resource-group\>, \<location\>, and \<name\>.", result);
+    }
+
+    [Fact]
+    public void Escape_Idempotent_RunTwice()
+    {
+        var input = "Use <resource-name> here.";
+        var first = PlaceholderEscaper.Escape(input);
+        var second = PlaceholderEscaper.Escape(first);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Escape_ComplexDocument_MixedContent()
+    {
+        var input = """
+            ---
+            title: Create <resource-name>
+            ---
+
+            ## Create a resource
+
+            Provide <resource-name> and <location>.
+
+            ```bash
+            az group create --name <resource-group> --location <location>
+            ```
+
+            Use `<subscription-id>` from your account, or enter <subscription-id> directly.
+
+            <!-- @mcpcli azmcp monitor workspace list -->
+            """;
+
+        var result = PlaceholderEscaper.Escape(input);
+
+        // Frontmatter preserved
+        Assert.Contains("title: Create <resource-name>", result);
+        // Prose escaped
+        Assert.Contains(@"\<resource-name\>", result);
+        Assert.Contains(@"\<location\>", result);
+        // Code fence preserved
+        Assert.Contains("--name <resource-group>", result);
+        // Inline code preserved
+        Assert.Contains("`<subscription-id>`", result);
+        // Bare prose version escaped
+        Assert.Contains(@"\<subscription-id\>", result);
+        // HTML comment preserved
+        Assert.Contains("<!-- @mcpcli azmcp monitor workspace list -->", result);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -84,6 +84,9 @@ public class FamilyFileStitcher
         // 14. Post-processing: strip HTML scaffolding comments (preserve @mcpcli markers)
         markdown = ScaffoldingCommentStripper.Strip(markdown);
 
+        // 15. Post-processing: escape bare <placeholder> values for MS Learn validation (#416)
+        markdown = PlaceholderEscaper.Escape(markdown);
+
         return markdown;
     }
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/PlaceholderEscaper.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/PlaceholderEscaper.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Escapes bare angle-bracket placeholders in generated markdown content.
+///
+/// Generated example prompts contain bare &lt;placeholder&gt; values
+/// (e.g., &lt;resource-name&gt;, &lt;subscription-id&gt;) that MS Learn
+/// build validation flags as disallowed HTML tags.
+///
+/// Converts bare placeholders to backslash-escaped form per MS Learn convention:
+///   &lt;resource-name&gt;  →  \&lt;resource-name\&gt;
+///
+/// Protected content (not escaped):
+///   - Code fences (``` ... ```)
+///   - Inline code spans (`...`)
+///   - HTML comments (&lt;!-- ... --&gt;)
+///   - Frontmatter (--- ... ---)
+///   - Already-escaped placeholders (\&lt;...\&gt;)
+///   - Already-backtick-wrapped placeholders (`&lt;...&gt;`)
+///
+/// Fixes: #416
+/// </summary>
+public static class PlaceholderEscaper
+{
+    // ── Protection patterns ─────────────────────────────────────────
+
+    private static readonly Regex CodeBlockPattern = new(
+        @"```[\s\S]*?```",
+        RegexOptions.Compiled);
+
+    private static readonly Regex InlineCodePattern = new(
+        @"`[^`]+`",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HtmlCommentPattern = new(
+        @"<!--[\s\S]*?-->",
+        RegexOptions.Compiled);
+
+    // ── Placeholder pattern ─────────────────────────────────────────
+    // Matches <word> where word is lowercase letters, digits, hyphens, underscores.
+    // Negative lookbehind: not preceded by backslash (already escaped) or backtick.
+    // Negative lookahead after closing >: not followed by closing backtick.
+    private static readonly Regex PlaceholderPattern = new(
+        @"(?<![\\\x00`])<([a-z][a-z0-9_-]*)>(?![\x00`])",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Escapes bare angle-bracket placeholders in markdown content.
+    /// Protects frontmatter, code blocks, inline code, and HTML comments.
+    /// </summary>
+    public static string Escape(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+            return markdown ?? "";
+
+        // Separate frontmatter from body
+        string frontmatter = "";
+        string body = markdown;
+        if (markdown.StartsWith("---"))
+        {
+            int endFm = markdown.IndexOf("\n---", 3, StringComparison.Ordinal);
+            if (endFm > 0)
+            {
+                int fmEnd = markdown.IndexOf('\n', endFm + 4);
+                if (fmEnd > 0)
+                {
+                    frontmatter = markdown[..(fmEnd + 1)];
+                    body = markdown[(fmEnd + 1)..];
+                }
+            }
+        }
+
+        // Protect code blocks, inline code, and HTML comments with placeholders
+        var placeholders = new Dictionary<string, string>();
+        int placeholderIndex = 0;
+
+        body = CodeBlockPattern.Replace(body, m =>
+        {
+            var key = $"\x00PB{placeholderIndex++}\x00";
+            placeholders[key] = m.Value;
+            return key;
+        });
+
+        body = InlineCodePattern.Replace(body, m =>
+        {
+            var key = $"\x00PI{placeholderIndex++}\x00";
+            placeholders[key] = m.Value;
+            return key;
+        });
+
+        body = HtmlCommentPattern.Replace(body, m =>
+        {
+            var key = $"\x00PH{placeholderIndex++}\x00";
+            placeholders[key] = m.Value;
+            return key;
+        });
+
+        // Escape bare placeholders: <word> → \<word\>
+        body = PlaceholderPattern.Replace(body, @"\<$1\>");
+
+        // Restore protected content
+        foreach (var (key, value) in placeholders)
+        {
+            body = body.Replace(key, value);
+        }
+
+        return frontmatter + body;
+    }
+}


### PR DESCRIPTION
## Summary

Adds pipeline post-processing to escape bare angle bracket placeholders that trigger MS Learn build validation errors.

### Problem
Generated example prompts contain bare `<placeholder>` values (e.g., `<resource-name>`, `<subscription-id>`) that MS Learn flags as disallowed HTML tags (`disallowed-html-tag` warning).

### Solution
Added `PlaceholderEscaper` post-processor (step 15 in `FamilyFileStitcher`) that converts bare `<placeholder>` patterns to `\<placeholder\>` per MS Learn conventions.

### What's protected (not escaped)
- Content inside code fences (`` ... ``)
- Inline code spans (`  ...  `)
- HTML comments (`<!-- @mcpcli ... -->`)
- Frontmatter (`--- ... ---`)
- Already-escaped placeholders (`\<...\>`)

### Tests
21 new tests in `PlaceholderEscaperTests.cs` covering:
- Basic escaping of various placeholder formats
- Protection of code fences, inline code, HTML comments, frontmatter
- Idempotency (running twice produces same result)
- Edge cases (null/empty, no placeholders, mixed content)
- Complex document with all content types

Partially addresses #416