### PR TITLE
fix: restructure skills template per PR #8712 review (#421)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
@@ -916,3 +916,174 @@ public class AcrolinxPostProcessorIdempotenceTests
         secondPass.Should().Be(firstPass, "post-processing should be idempotent");
     }
 }
+
+// === Issue #421: Template restructure per PR #8712 review ===
+
+public class TemplateRestructureTests
+{
+    private readonly ILogger<SkillPageGenerator> _logger = Substitute.For<ILogger<SkillPageGenerator>>();
+
+    private static string LoadRealTemplate()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "skills-generation.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        if (dir == null) throw new InvalidOperationException("Cannot find solution root");
+        return File.ReadAllText(Path.Combine(dir, "templates", "skill-page-template.hbs"));
+    }
+
+    private static SkillData CreateFullSkillData() => new()
+    {
+        Name = "azure-storage",
+        DisplayName = "Azure Storage",
+        Description = "Manage Azure Storage accounts.",
+        UseFor = ["Creating storage accounts", "Managing blob containers"],
+        Services = [new ServiceEntry("Blob Storage", "Unstructured data")],
+        McpTools = [new McpToolEntry("storage_list", "storage list", "List accounts")]
+    };
+
+    private static SkillPrerequisites CreateFullPrereqs() => new()
+    {
+        Azure = new AzureRequirements { RequiresAzureLogin = true, RequiresSubscription = true },
+        Tools =
+        [
+            new ToolRequirement("GitHub Copilot", Required: true),
+            new ToolRequirement("Azure CLI", MinVersion: "2.60.0", InstallCommand: "curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash")
+        ],
+        Resources = [new ResourceRequirement("Azure Storage account", "Storage account for blob data")],
+        RbacRoles = [new RbacRequirement("Storage Blob Data Reader", "Resource group", "Read blob data")]
+    };
+
+    [Fact]
+    public void Template_SectionOrder_WhatItProvidesBeforePrerequisites()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData(["Create a storage account"], [], null);
+        var tier = new TierAssessment(1, [], "Test", true, true, false, false, true);
+        var prereqs = CreateFullPrereqs();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        var whatIdx = result.IndexOf("## What it provides");
+        var prereqIdx = result.IndexOf("## Prerequisites");
+        var whenIdx = result.IndexOf("## When to use this skill");
+        var exampleIdx = result.IndexOf("## Example prompts");
+        var relatedIdx = result.IndexOf("## Related content");
+
+        whatIdx.Should().BeGreaterThan(-1, "What it provides section must exist");
+        prereqIdx.Should().BeGreaterThan(-1, "Prerequisites section must exist");
+
+        whatIdx.Should().BeLessThan(prereqIdx, "What it provides must appear before Prerequisites");
+        prereqIdx.Should().BeLessThan(whenIdx, "Prerequisites must appear before When to use");
+        whenIdx.Should().BeLessThan(exampleIdx, "When to use must appear before Example prompts");
+        exampleIdx.Should().BeLessThan(relatedIdx, "Example prompts must appear before Related content");
+    }
+
+    [Fact]
+    public void Template_PrerequisitesFlat_NoSubheadings()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData(["Create a storage account"], [], null);
+        var tier = new TierAssessment(1, [], "Test", true, true, false, false, true);
+        var prereqs = CreateFullPrereqs();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().NotContain("### Required tools");
+        result.Should().NotContain("### Required resources");
+        result.Should().NotContain("### Required roles");
+
+        // All prereq items should be flat bullets under ## Prerequisites
+        result.Should().Contain("## Prerequisites");
+        result.Should().Contain("**Azure CLI**");
+        result.Should().Contain("**Azure Storage account**");
+        result.Should().Contain("**Storage Blob Data Reader**");
+    }
+
+    [Fact]
+    public void Template_ExamplePrompts_NotExampleTriggers()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData(["Create a storage account"], [], null);
+        var tier = new TierAssessment(1, [], "Test", true, true, false, false, true);
+        var prereqs = new SkillPrerequisites();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().Contain("## Example prompts");
+        result.Should().NotContain("## Example triggers");
+        result.Should().Contain("Try these prompts to activate this skill:");
+        result.Should().NotContain("Try these prompts with GitHub Copilot to activate this skill:");
+    }
+
+    [Fact]
+    public void Template_SourceCodeLink_PointsToSkillMd()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData([], [], null);
+        var tier = new TierAssessment(1, [], "Test", false, false, false, false, false);
+        var prereqs = new SkillPrerequisites();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().Contain("https://github.com/microsoft/azure-skills/blob/main/skills/azure-storage/skill.md");
+        result.Should().NotContain("/tree/main/skills/azure-storage)");
+    }
+
+    [Fact]
+    public void Template_RelatedContent_NoGitHubCopilotForAzureLink()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData([], [], null);
+        var tier = new TierAssessment(1, [], "Test", false, false, false, false, false);
+        var prereqs = new SkillPrerequisites();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().NotContain("GitHub Copilot for Azure documentation");
+        result.Should().NotContain("/azure/developer/github-copilot-azure/introduction");
+        result.Should().Contain("Skill source code");
+        result.Should().Contain("https://github.com/microsoft/azure-skills/blob/main/skills/azure-storage/skill.md");
+    }
+
+    [Fact]
+    public void Template_NoPluginTerminology()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData(["Create a storage account"], [], null);
+        var tier = new TierAssessment(1, [], "Test", true, true, false, false, true);
+        var prereqs = CreateFullPrereqs();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().NotContainEquivalentOf("plugin");
+    }
+
+    [Fact]
+    public void Template_McpToolsSection_UsesCallsLanguage()
+    {
+        var template = LoadRealTemplate();
+        var gen = new SkillPageGenerator(template, _logger);
+        var skill = CreateFullSkillData();
+        var triggers = new TriggerData([], [], null);
+        var tier = new TierAssessment(1, [], "Test", true, false, false, false, false);
+        var prereqs = new SkillPrerequisites();
+
+        var result = gen.Generate(skill, triggers, tier, prereqs);
+
+        result.Should().Contain("uses the following Azure MCP tools");
+        result.Should().NotContain("available with this skill");
+    }
+}

--- a/skills-generation/templates/skill-page-template.hbs
+++ b/skills-generation/templates/skill-page-template.hbs
@@ -12,52 +12,7 @@ ms.service: azure-mcp-server
 
 {{{description}}}
 
-**Skill:** `{{{name}}}` | [Source code](https://github.com/microsoft/azure-skills/tree/main/skills/{{{name}}})
-
-## Prerequisites
-
-{{#if prerequisites.azure.requiresAzureLogin}}
-- **Azure authentication**—Sign in with `az login` or use a service principal.
-{{/if}}
-{{#if prerequisites.azure.requiresSubscription}}
-- **Azure subscription**—An active Azure subscription is required.
-{{/if}}
-
-{{#if hasUseFor}}
-### When to use this skill
-
-Use the **{{{displayName}}}** skill when you need to:
-
-{{#each useFor}}
-- {{{this}}}
-{{/each}}
-{{/if}}
-{{#if hasRbacRoles}}
-
-### Required roles
-
-| Role | Scope | Reason |
-|------|-------|--------|
-{{#each prerequisites.rbacRoles}}
-| {{{roleName}}} | {{{scope}}} | {{{reason}}} |
-{{/each}}
-{{/if}}
-{{#if hasToolPrereqs}}
-
-### Required tools
-
-{{#each prerequisites.tools}}
-- **{{{name}}}**{{#if minVersion}} (v{{{minVersion}}}+){{/if}}{{#if installCommand}}—Install: `{{{installCommand}}}`{{/if}}
-{{/each}}
-{{/if}}
-{{#if hasResources}}
-
-### Required resources
-
-{{#each prerequisites.resources}}
-- **{{{resourceType}}}**—{{{description}}}{{#if quickCreateCommand}} Quick create: `{{{quickCreateCommand}}}`{{/if}}
-{{/each}}
-{{/if}}
+**Skill:** `{{{name}}}` | [Source code](https://github.com/microsoft/azure-skills/blob/main/skills/{{{name}}}/skill.md)
 
 ## What it provides
 
@@ -72,11 +27,45 @@ Use the **{{{displayName}}}** skill when you need to:
 | {{{name}}} | {{{useWhen}}} |
 {{/each}}
 {{/if}}
+
+## Prerequisites
+
+{{#if prerequisites.azure.requiresAzureLogin}}
+- **Azure authentication**—Sign in with `az login` or use a service principal.
+{{/if}}
+{{#if prerequisites.azure.requiresSubscription}}
+- **Azure subscription**—An active Azure subscription is required.
+{{/if}}
+{{#if hasRbacRoles}}
+{{#each prerequisites.rbacRoles}}
+- **{{{roleName}}}** role at {{{scope}}} scope—{{{reason}}}
+{{/each}}
+{{/if}}
+{{#if hasToolPrereqs}}
+{{#each prerequisites.tools}}
+- **{{{name}}}**{{#if minVersion}} (v{{{minVersion}}}+){{/if}}{{#if installCommand}}—Install: `{{{installCommand}}}`{{/if}}
+{{/each}}
+{{/if}}
+{{#if hasResources}}
+{{#each prerequisites.resources}}
+- **{{{resourceType}}}**—{{{description}}}{{#if quickCreateCommand}} Quick create: `{{{quickCreateCommand}}}`{{/if}}
+{{/each}}
+{{/if}}
+
+{{#if hasUseFor}}
+## When to use this skill
+
+Use the **{{{displayName}}}** skill when you need to:
+
+{{#each useFor}}
+- {{{this}}}
+{{/each}}
+{{/if}}
 {{#if hasMcpTools}}
 
 ## MCP tools
 
-The following MCP tools are available with this skill:
+This skill uses the following Azure MCP tools:
 
 | Tool | Description |
 |------|-------------|
@@ -109,9 +98,9 @@ The following MCP tools are available with this skill:
 {{/if}}
 
 {{#if hasTriggers}}
-## Example triggers
+## Example prompts
 
-Try these prompts with GitHub Copilot to activate this skill:
+Try these prompts to activate this skill:
 
 {{#each shouldTrigger}}
 - "{{{this}}}"
@@ -129,4 +118,4 @@ Try these prompts with GitHub Copilot to activate this skill:
 ## Related content
 
 - [Azure MCP Server overview](/azure/developer/azure-mcp-server/overview)
-- [GitHub Copilot for Azure documentation](/azure/developer/github-copilot-azure/introduction)
+- [Skill source code](https://github.com/microsoft/azure-skills/blob/main/skills/{{{name}}}/skill.md)


### PR DESCRIPTION
## Summary

Restructures the skills page template based on review feedback from PR MicrosoftDocs/azure-dev-docs-pr#8712.

### Changes
1. Moved 'What it provides' before Prerequisites
2. Flattened Prerequisites (removed subheadings)
3. Renamed 'Example triggers' to 'Example prompts'
4. Fixed source links to point to skill.md file
5. Replaced 'plugin' terminology with 'skill'
6. Changed 'built on' to 'uses' for MCP relationship
7. Updated Related content section

### Expected section order
- H1 + description + Skill line
- What it provides
- Prerequisites (flat bullets)
- When to use this skill
- Example prompts
- Related content

### Tests added
- Section order verification (What it provides before Prerequisites)
- Prerequisites flat structure (no subheadings)
- Example prompts heading (not triggers)
- Source code links point to /blob/main/skills/{name}/skill.md
- No 'plugin' terminology in output
- Related content links verified
- MCP tools uses 'calls' language

Closes #421