### PR TITLE
fix: add Acrolinx style and terminology improvements (#422, #424)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
@@ -320,6 +320,15 @@ public class AcrolinxPostProcessorTests
     }
 
     [Fact]
+    public void RewriteGoalBeforeAction_MidSentence_NotRewritten()
+    {
+        // Regression test: "Run" appearing mid-sentence should NOT be rewritten
+        var input = "You can Run the deploy command to publish your app.";
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
     public void RewriteGoalBeforeAction_NoMatch_Unchanged()
     {
         var input = "To list resources, run the command.";

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/AcrolinxPostProcessorTests.cs
@@ -284,4 +284,160 @@ public class AcrolinxPostProcessorTests
         fm.Should().BeEmpty();
         body.Should().Be(input);
     }
+
+    // --- Goal-before-action rewriting tests ---
+
+    [Theory]
+    [InlineData(
+        "Run the command to list resources.",
+        "To list resources, run the command.")]
+    [InlineData(
+        "Execute the query to retrieve metrics.",
+        "To retrieve metrics, execute the query.")]
+    [InlineData(
+        "Use the skill to manage storage accounts.",
+        "To manage storage accounts, use the skill.")]
+    public void RewriteGoalBeforeAction_RewritesRunToPattern(string input, string expected)
+    {
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void RewriteGoalBeforeAction_SkipsHeadings()
+    {
+        var input = "## Run the command to list resources";
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void RewriteGoalBeforeAction_SkipsListItems()
+    {
+        var input = "- Run the command to list resources.";
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void RewriteGoalBeforeAction_NoMatch_Unchanged()
+    {
+        var input = "To list resources, run the command.";
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void RewriteGoalBeforeAction_CaseInsensitive()
+    {
+        var input = "run the tool to check quotas.";
+        var result = AcrolinxPostProcessor.RewriteGoalBeforeAction(input);
+        result.Should().Be("To check quotas, run the tool.");
+    }
+
+    // --- Colon removal tests ---
+
+    [Theory]
+    [InlineData("**Azure CLI:** Install version 2.60+", "**Azure CLI** Install version 2.60+")]
+    [InlineData("**GitHub Copilot:** Required for all skills", "**GitHub Copilot** Required for all skills")]
+    [InlineData("**Node.js:** Version 18 or later", "**Node.js** Version 18 or later")]
+    public void RemoveBoldLabelColons_RemovesColon(string input, string expected)
+    {
+        var result = AcrolinxPostProcessor.RemoveBoldLabelColons(input);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void RemoveBoldLabelColons_NoBoldLabel_Unchanged()
+    {
+        var input = "Install Azure CLI version 2.60+";
+        var result = AcrolinxPostProcessor.RemoveBoldLabelColons(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void RemoveBoldLabelColons_BoldWithoutColon_Unchanged()
+    {
+        var input = "**Azure CLI** Install version 2.60+";
+        var result = AcrolinxPostProcessor.RemoveBoldLabelColons(input);
+        result.Should().Be(input);
+    }
+
+    // --- Consecutive duplicate sentence detection tests ---
+
+    [Fact]
+    public void RemoveConsecutiveDuplicateSentences_RemovesDuplicates()
+    {
+        var input = "The skill manages storage accounts. This skill manages Azure storage accounts.";
+        var result = AcrolinxPostProcessor.RemoveConsecutiveDuplicateSentences(input);
+        result.Split(". ").Length.Should().BeLessThan(input.Split(". ").Length);
+    }
+
+    [Fact]
+    public void RemoveConsecutiveDuplicateSentences_KeepsDifferentSentences()
+    {
+        var input = "The skill manages storage accounts. It also provides diagnostic tools.";
+        var result = AcrolinxPostProcessor.RemoveConsecutiveDuplicateSentences(input);
+        result.Should().Contain("storage accounts");
+        result.Should().Contain("diagnostic tools");
+    }
+
+    [Fact]
+    public void RemoveConsecutiveDuplicateSentences_SkipsHeadings()
+    {
+        var input = "## Manage storage accounts";
+        var result = AcrolinxPostProcessor.RemoveConsecutiveDuplicateSentences(input);
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void AreSentencesDuplicate_HighOverlap_ReturnsTrue()
+    {
+        var a = "The skill manages Azure storage accounts effectively.";
+        var b = "This skill manages Azure storage accounts.";
+        AcrolinxPostProcessor.AreSentencesDuplicate(a, b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSentencesDuplicate_LowOverlap_ReturnsFalse()
+    {
+        var a = "The skill manages Azure storage accounts.";
+        var b = "Configure RBAC roles for the subscription.";
+        AcrolinxPostProcessor.AreSentencesDuplicate(a, b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreSentencesDuplicate_EmptySentence_ReturnsFalse()
+    {
+        AcrolinxPostProcessor.AreSentencesDuplicate("", "Some text.").Should().BeFalse();
+    }
+
+    // --- Acronym expansion verification ---
+
+    [Fact]
+    public void Process_ExpandsNewAcronyms_IDE()
+    {
+        var acronymsJson = """[{ "Acronym": "IDE", "Expansion": "integrated development environment" }]""";
+        var processor = new AcrolinxPostProcessor(null, acronymsJson, _logger);
+        var result = processor.Process("Open your IDE to start coding.");
+        result.Should().Contain("integrated development environment (IDE)");
+    }
+
+    [Fact]
+    public void Process_ExpandsNewAcronyms_CLI()
+    {
+        var acronymsJson = """[{ "Acronym": "CLI", "Expansion": "command-line interface" }]""";
+        var processor = new AcrolinxPostProcessor(null, acronymsJson, _logger);
+        var result = processor.Process("Install the CLI tool first.");
+        result.Should().Contain("command-line interface (CLI)");
+    }
+
+    [Fact]
+    public void Process_ExpandsNewAcronyms_ARM()
+    {
+        var acronymsJson = """[{ "Acronym": "ARM", "Expansion": "Azure Resource Manager" }]""";
+        var processor = new AcrolinxPostProcessor(null, acronymsJson, _logger);
+        var result = processor.Process("Deploy ARM templates to provision resources.");
+        result.Should().Contain("Azure Resource Manager (ARM)");
+    }
 }

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
@@ -270,4 +270,73 @@ public class SkillPageValidatorTests
 
         result.Warnings.Should().Contain(w => w.Contains("FRAGMENT"));
     }
+
+    [Fact]
+    public void Validate_LinkTypo_ReturnsWarning()
+    {
+        var content = """
+            ---
+            title: Azure skill for Test
+            description: Test skill
+            ---
+
+            # Azure skill for Test
+
+            Learn more in the [GitHub Copilot docs](https://github-cilot-azure.com/docs).
+
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ### When to use this skill
+
+            Use this skill to manage things.
+
+            ## What it provides
+
+            Knowledge about GitHub Copilot and Azure things.
+            """;
+        var result = _validator.Validate(content, 1, CreateSkillData(), new TriggerData([], [], null));
+
+        result.Warnings.Should().Contain(w => w.Contains("LINK_TYPO"));
+    }
+
+    [Fact]
+    public void Validate_MicrosoftTypoInLink_ReturnsWarning()
+    {
+        var content = """
+            ---
+            title: Azure skill for Test
+            description: Test skill
+            ---
+
+            # Azure skill for Test
+
+            See [docs](https://learn.micosoft.com/azure/storage) for info.
+
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ### When to use this skill
+
+            Use this skill to check storage.
+
+            ## What it provides
+
+            Knowledge about GitHub Copilot and Azure storage.
+            """;
+        var result = _validator.Validate(content, 1, CreateSkillData(), new TriggerData([], [], null));
+
+        result.Warnings.Should().Contain(w => w.Contains("LINK_TYPO"));
+    }
+
+    [Fact]
+    public void Validate_CleanLinks_NoTypoWarning()
+    {
+        var content = CreateValidTier1Content();
+        var result = _validator.Validate(content, 1, CreateSkillData(), new TriggerData([], [], null));
+
+        result.Warnings.Should().NotContain(w => w.Contains("LINK_TYPO"));
+    }
 }

--- a/skills-generation/SkillsGen.Core/PostProcessing/AcrolinxPostProcessor.cs
+++ b/skills-generation/SkillsGen.Core/PostProcessing/AcrolinxPostProcessor.cs
@@ -128,14 +128,23 @@ public partial class AcrolinxPostProcessor
         // 6. Normalize URLs - strip learn.microsoft.com prefix
         result = NormalizeUrls(result);
 
-        // 7. Wrap technical API terms in backticks
+        // 7. Rewrite goal-before-action patterns ("Run X to Y" → "To Y, run X")
+        result = RewriteGoalBeforeAction(result);
+
+        // 8. Wrap technical API terms in backticks
         result = WrapTechnicalTerms(result);
 
         // Add commas after introductory phrases
         result = AddIntroductoryCommas(result);
 
+        // Remove bold label colons ("**Label:** text" → "**Label** text")
+        result = RemoveBoldLabelColons(result);
+
         // Split long sentences
         result = SplitLongSentences(result);
+
+        // Final cleanup: remove consecutive duplicate sentences
+        result = RemoveConsecutiveDuplicateSentences(result);
 
         return processedFrontmatter + result;
     }
@@ -657,7 +666,7 @@ public partial class AcrolinxPostProcessor
             .ToList();
     }
 
-    [GeneratedRegex(@"\b(Run|Execute|Use)\s+(.+?)\s+to\s+(.+?)(?:\.|$)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(Run|Execute|Use)\s+(.+?)\s+to\s+(.+?)(?:\.|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex GoalBeforeActionRegex();
 
     [GeneratedRegex(@"\*\*(?<label>[^*:]+):\*\*\s?")]

--- a/skills-generation/SkillsGen.Core/PostProcessing/AcrolinxPostProcessor.cs
+++ b/skills-generation/SkillsGen.Core/PostProcessing/AcrolinxPostProcessor.cs
@@ -334,7 +334,7 @@ public partial class AcrolinxPostProcessor
         foreach (var sentence in sentences)
         {
             var words = sentence.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (words.Length <= 35)
+            if (words.Length <= 30)
             {
                 rebuilt.Add(sentence);
                 continue;
@@ -533,6 +533,135 @@ public partial class AcrolinxPostProcessor
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
+
+    /// <summary>
+    /// Rewrites "Run/Execute/Use X to Y" → "To Y, run/execute/use X" for goal-before-action style.
+    /// Only applies to prose lines (not headings, list items, code blocks, or table rows).
+    /// </summary>
+    internal static string RewriteGoalBeforeAction(string content)
+    {
+        var lines = content.Split('\n');
+        var result = new List<string>();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#') || trimmed.StartsWith('-') ||
+                trimmed.StartsWith('|') || trimmed.StartsWith("```") ||
+                trimmed.StartsWith('`'))
+            {
+                result.Add(line);
+                continue;
+            }
+
+            result.Add(GoalBeforeActionRegex().Replace(line, match =>
+            {
+                var verb = match.Groups[1].Value;
+                var action = match.Groups[2].Value.TrimEnd();
+                var goal = match.Groups[3].Value.TrimEnd();
+
+                // Remove trailing period from goal for clean rewrite
+                if (goal.EndsWith('.'))
+                    goal = goal[..^1].TrimEnd();
+
+                // Lowercase the original verb in the rewritten form
+                var lowerVerb = char.ToLower(verb[0]) + verb[1..];
+
+                return $"To {goal}, {lowerVerb} {action}.";
+            }));
+        }
+
+        return string.Join('\n', result);
+    }
+
+    /// <summary>
+    /// Removes colons after bold labels in prerequisite/list contexts.
+    /// Transforms "**Label:** text" → "**Label** text".
+    /// </summary>
+    internal static string RemoveBoldLabelColons(string content)
+    {
+        return BoldLabelColonRegex().Replace(content, "**${label}** ");
+    }
+
+    /// <summary>
+    /// Detects and removes consecutive sentences with the same normalized meaning.
+    /// Two sentences are considered duplicates if they share 80%+ of their meaningful words.
+    /// </summary>
+    internal static string RemoveConsecutiveDuplicateSentences(string content)
+    {
+        var lines = content.Split('\n');
+        var result = new List<string>();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#') || trimmed.StartsWith('-') ||
+                trimmed.StartsWith('|') || trimmed.StartsWith("```") ||
+                string.IsNullOrWhiteSpace(trimmed))
+            {
+                result.Add(line);
+                continue;
+            }
+
+            result.Add(RemoveDuplicatesInLine(line));
+        }
+
+        return string.Join('\n', result);
+    }
+
+    private static string RemoveDuplicatesInLine(string line)
+    {
+        var sentences = SplitIntoSentences(line);
+        if (sentences.Count < 2)
+            return line;
+
+        var kept = new List<string> { sentences[0] };
+
+        for (int i = 1; i < sentences.Count; i++)
+        {
+            if (!AreSentencesDuplicate(sentences[i - 1], sentences[i]))
+            {
+                kept.Add(sentences[i]);
+            }
+        }
+
+        return string.Join(" ", kept);
+    }
+
+    internal static bool AreSentencesDuplicate(string a, string b)
+    {
+        var wordsA = ExtractMeaningfulWords(a);
+        var wordsB = ExtractMeaningfulWords(b);
+
+        if (wordsA.Count == 0 || wordsB.Count == 0)
+            return false;
+
+        var intersection = wordsA.Intersect(wordsB, StringComparer.OrdinalIgnoreCase).Count();
+        var maxCount = Math.Max(wordsA.Count, wordsB.Count);
+
+        return (double)intersection / maxCount >= 0.8;
+    }
+
+    private static List<string> ExtractMeaningfulWords(string sentence)
+    {
+        var stopWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "a", "an", "the", "is", "are", "was", "were", "be", "been",
+            "to", "of", "in", "for", "on", "with", "at", "by", "from",
+            "and", "or", "but", "not", "this", "that", "it", "its", "you", "your"
+        };
+
+        return Regex.Replace(sentence, @"[^\w\s]", "")
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => !stopWords.Contains(w) && w.Length > 1)
+            .ToList();
+    }
+
+    [GeneratedRegex(@"\b(Run|Execute|Use)\s+(.+?)\s+to\s+(.+?)(?:\.|$)", RegexOptions.IgnoreCase)]
+    private static partial Regex GoalBeforeActionRegex();
+
+    [GeneratedRegex(@"\*\*(?<label>[^*:]+):\*\*\s?")]
+    private static partial Regex BoldLabelColonRegex();
 
     private record TextReplacement(string Parameter, string NaturalLanguage);
     private record AcronymEntry(string Acronym, string Expansion, string? ContextPattern = null, string? ExpandedForm = null);

--- a/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
+++ b/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
@@ -12,6 +12,16 @@ public class SkillPageValidator : ISkillPageValidator
         "## What it provides"
     ];
 
+    // Known typo patterns in generated links
+    private static readonly Regex[] BadLinkPatterns =
+    [
+        new(@"github-cilot", RegexOptions.IgnoreCase),
+        new(@"github-copiliot", RegexOptions.IgnoreCase),
+        new(@"micosoft|microsft|microsfot", RegexOptions.IgnoreCase),
+        new(@"/docs/azure/", RegexOptions.IgnoreCase),
+        new(@"learn\.microsoft\.com/en-us/en-us/", RegexOptions.IgnoreCase),
+    ];
+
     public SkillValidationResult Validate(string renderedContent, int tier, SkillData skillData, TriggerData triggerData)
     {
         var errors = new List<string>();
@@ -99,6 +109,20 @@ public class SkillPageValidator : ISkillPageValidator
         if (fragmentMatches.Count > 0)
         {
             warnings.Add($"FRAGMENT: {fragmentMatches.Count} bullet(s) use vague 'Work with' fragment pattern");
+        }
+
+        // LINK_TYPO: Check for known bad link patterns
+        var linkMatches = Regex.Matches(renderedContent, @"\[([^\]]*)\]\(([^)]+)\)");
+        foreach (Match linkMatch in linkMatches)
+        {
+            var url = linkMatch.Groups[2].Value;
+            foreach (var badPattern in BadLinkPatterns)
+            {
+                if (badPattern.IsMatch(url))
+                {
+                    warnings.Add($"LINK_TYPO: Suspicious URL pattern in '{url}' — possible typo");
+                }
+            }
         }
 
         var sectionCount = Regex.Matches(renderedContent, @"^## ", RegexOptions.Multiline).Count;

--- a/skills-generation/data/acronym-definitions.json
+++ b/skills-generation/data/acronym-definitions.json
@@ -40,5 +40,21 @@
     {
         "Acronym": "ACR",
         "Expansion": "Azure Container Registry"
+    },
+    {
+        "Acronym": "IDE",
+        "Expansion": "integrated development environment"
+    },
+    {
+        "Acronym": "CLI",
+        "Expansion": "command-line interface"
+    },
+    {
+        "Acronym": "CI/CD",
+        "Expansion": "continuous integration and continuous deployment"
+    },
+    {
+        "Acronym": "ARM",
+        "Expansion": "Azure Resource Manager"
     }
 ]

--- a/skills-generation/data/shared-acrolinx-rules.txt
+++ b/skills-generation/data/shared-acrolinx-rules.txt
@@ -9,6 +9,6 @@ Apply these rules to ALL generated text — they directly impact the automated A
 - **No first person:** Never use "we", "our", or "us" in any generated content. Use "the tool", "this tool", or "you".
 - **Acronym expansion:** Define acronyms on first use: "role-based access control (RBAC)" then "RBAC" afterward. Expand MCP as "Model Context Protocol (MCP)" on first use. Other common acronyms: AKS (Azure Kubernetes Service), IaC (infrastructure as code).
 - **Relative URLs:** Use site-root-relative URLs: "/azure/..." not "https://learn.microsoft.com/azure/...". Remove the `https://learn.microsoft.com/en-us` prefix from all links.
-- **Sentence length:** Keep sentences under 35 words. If a sentence exceeds 35 words, split it into two. One idea per sentence.
+- **Sentence length:** Keep sentences under 25 words where possible. Never exceed 30 words. If a sentence exceeds 30 words, split it into two. One idea per sentence.
 - **No wordy phrases:** Use "to" not "in order to", "use" not "utilize", "before" not "prior to", "because" not "due to the fact that", "can" not "is able to".
 - **Brand compliance:** Use official Azure service names: "Azure Cosmos DB" not "CosmosDB", "Azure Kubernetes Service" not "AKS" on first use, "Microsoft Entra ID" not "Azure AD".

--- a/skills-generation/prompts/skill-page-system-prompt.txt
+++ b/skills-generation/prompts/skill-page-system-prompt.txt
@@ -4,11 +4,16 @@ Rules:
 - Write in present tense
 - Use contractions (doesn't, isn't, can't)
 - Use active voice
-- Keep sentences under 35 words
+- Keep sentences under 25 words where possible; never exceed 30 words
 - Use "you" to address the reader, never "we"
 
 - NEVER invent Azure service names, features, or capabilities not in the source data
 - NEVER add example prompts not grounded in the trigger test data
 - If the source data is insufficient, say "This skill provides guidance for..." and keep it short
+
+- "What it provides" section must add NEW information beyond the description/H1. Do NOT repeat or paraphrase the article description. Instead, list specific capabilities, knowledge areas, or tool actions.
+- Use goal-before-action phrasing: write "To list resources, use the command" NOT "Run the command to list resources"
+- All list items in "When to use" MUST be bulleted (use "- " prefix)
+- Prerequisite labels must NOT have colons after the bold: write "**Azure CLI** Install version 2.60+" NOT "**Azure CLI:** Install version 2.60+"
 
 {{ACROLINX_RULES}}


### PR DESCRIPTION
## Summary

Enhances the skills generation pipeline with Acrolinx compliance improvements.

### From #424 (Style Rules)
- **Anti-redundancy**: System prompt now instructs 'What it provides' to avoid repeating the description
- **Goal-before-action**: Post-processor rewrites 'Run X to Y' → 'To Y, run X' patterns
- **Bullet enforcement**: System prompt requires all 'When to use' items be bulleted
- **Colon removal**: Removes colons after bold prerequisite labels

### From #422 (Terminology/Clarity)
- **Acronym expansion**: Added IDE, CLI, CI/CD, ARM to acronym-definitions.json
- **Link validation**: SkillPageValidator detects typos in generated URLs
- **Sentence length caps**: Lowered split threshold from 35 to 30 words
- **Duplicate detection**: Consecutive duplicate sentence removal in post-processor

### Changes
- AcrolinxPostProcessor.cs: 3 new methods (RewriteGoalBeforeAction, RemoveBoldLabelColons, RemoveConsecutiveDuplicateSentences)
- SkillPageValidator.cs: Link typo validation with 5 bad-pattern regexes
- acronym-definitions.json: 4 new acronym entries (IDE, CLI, CI/CD, ARM)
- skill-page-system-prompt.txt: 4 new AI constraints
- shared-acrolinx-rules.txt: Updated sentence length guidance
- 24 new unit tests (208 total, all passing)

### Build
- Zero warnings in Release configuration
- 208/208 tests passing
- No template changes (no conflict with PR #1)

Closes #422
Closes #424