### PR TITLE
feat: group tools by resource sub-type on multi-resource pages (#412)

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ResourceGroupingTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ResourceGroupingTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for resource sub-type grouping in FamilyFileStitcher and ToolReader (#412).
+/// </summary>
+public class ResourceGroupingTests
+{
+    // --- ToolReader.GetResourceType tests ---
+
+    [Theory]
+    [InlineData("compute disk create", "disk")]
+    [InlineData("compute vm delete", "vm")]
+    [InlineData("storage account create", "account")]
+    [InlineData("storage blob list", "blob")]
+    [InlineData("foundry agent thread create", "agent thread")]
+    [InlineData("cosmos db container query", "db container")]
+    public void GetResourceType_MultiSegmentCommand_ReturnsResourcePortion(
+        string command, string expected)
+    {
+        var result = ToolReader.GetResourceType(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("advisor list", "")]
+    [InlineData("storage list", "")]
+    public void GetResourceType_TwoSegmentCommand_ReturnsEmpty(string command, string expected)
+    {
+        var result = ToolReader.GetResourceType(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("advisor")]
+    public void GetResourceType_NullEmptyOrSingleSegment_ReturnsEmpty(string? command)
+    {
+        var result = ToolReader.GetResourceType(command);
+        Assert.Equal(string.Empty, result);
+    }
+
+    // --- IsMultiResourceFamily tests ---
+
+    [Fact]
+    public void IsMultiResourceFamily_SingleResourceType_ReturnsFalse()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Get advisor", "advisor list", ""),
+            MakeTool("Get recommendation", "advisor recommendation list", "recommendation"),
+        };
+        // Only one non-empty resource type "recommendation" -> false
+        Assert.False(FamilyFileStitcher.IsMultiResourceFamily(tools));
+    }
+
+    [Fact]
+    public void IsMultiResourceFamily_AllBareVerbs_ReturnsFalse()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Get advisor", "advisor get", ""),
+            MakeTool("List advisor", "advisor list", ""),
+        };
+        Assert.False(FamilyFileStitcher.IsMultiResourceFamily(tools));
+    }
+
+    [Fact]
+    public void IsMultiResourceFamily_MultipleResourceTypes_ReturnsTrue()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Create disk", "compute disk create", "disk"),
+            MakeTool("Delete disk", "compute disk delete", "disk"),
+            MakeTool("Create VM", "compute vm create", "vm"),
+            MakeTool("Delete VM", "compute vm delete", "vm"),
+        };
+        Assert.True(FamilyFileStitcher.IsMultiResourceFamily(tools));
+    }
+
+    [Fact]
+    public void IsMultiResourceFamily_TwoResourceTypes_ReturnsTrue()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Create account", "storage account create", "account"),
+            MakeTool("Get blob", "storage blob get", "blob"),
+        };
+        Assert.True(FamilyFileStitcher.IsMultiResourceFamily(tools));
+    }
+
+    // --- FormatResourceTypeDisplayName tests ---
+
+    [Theory]
+    [InlineData("disk", "Disk")]
+    [InlineData("vm", "VM")]
+    [InlineData("vmss", "VMSS")]
+    [InlineData("db", "DB")]
+    [InlineData("account", "Account")]
+    [InlineData("blob", "Blob")]
+    [InlineData("db container", "DB container")]
+    [InlineData("agent thread", "Agent thread")]
+    [InlineData("", "General")]
+    [InlineData("   ", "General")]
+    public void FormatResourceTypeDisplayName_ProducesHumanReadableName(
+        string resourceType, string expected)
+    {
+        var result = FamilyFileStitcher.FormatResourceTypeDisplayName(resourceType);
+        Assert.Equal(expected, result);
+    }
+
+    // --- DemoteHeadings tests ---
+
+    [Fact]
+    public void DemoteHeadings_H2BecomesH3()
+    {
+        var input = "## Create a disk\n\nSome content.";
+        var result = FamilyFileStitcher.DemoteHeadings(input);
+        Assert.StartsWith("### Create a disk", result);
+    }
+
+    [Fact]
+    public void DemoteHeadings_H3BecomesH4()
+    {
+        var input = "### Parameters\n\nSome content.";
+        var result = FamilyFileStitcher.DemoteHeadings(input);
+        Assert.StartsWith("#### Parameters", result);
+    }
+
+    [Fact]
+    public void DemoteHeadings_H6StaysH6()
+    {
+        var input = "###### Deep heading\n\nSome content.";
+        var result = FamilyFileStitcher.DemoteHeadings(input);
+        Assert.StartsWith("###### Deep heading", result);
+    }
+
+    [Fact]
+    public void DemoteHeadings_MixedHeadingLevels_AllDemoted()
+    {
+        var input = "## Top\n\nContent\n\n### Sub\n\nMore content\n\n#### Deep\n\nDeepest";
+        var result = FamilyFileStitcher.DemoteHeadings(input);
+        Assert.Contains("### Top", result);
+        Assert.Contains("#### Sub", result);
+        Assert.Contains("##### Deep", result);
+    }
+
+    [Fact]
+    public void DemoteHeadings_NoHeadings_Unchanged()
+    {
+        var input = "Just some text with no headings.";
+        var result = FamilyFileStitcher.DemoteHeadings(input);
+        Assert.Equal(input, result);
+    }
+
+    // --- Stitch integration tests ---
+
+    [Fact]
+    public void Stitch_SingleResourceNamespace_NoGroupingHeaders()
+    {
+        var familyContent = new FamilyContent
+        {
+            FamilyName = "advisor",
+            Metadata = "---\ntitle: Advisor\n---\n# Advisor\n\nIntro paragraph.",
+            Tools = new List<ToolContent>
+            {
+                MakeTool("Get recommendations", "advisor get", ""),
+            },
+            RelatedContent = "## Related content\n\n- [Link](/path)"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("## Get recommendations", result);
+        Assert.DoesNotContain("## General", result);
+    }
+
+    [Fact]
+    public void Stitch_MultiResourceNamespace_GroupsToolsByResourceType()
+    {
+        var familyContent = new FamilyContent
+        {
+            FamilyName = "compute",
+            Metadata = "---\ntitle: Compute\n---\n# Compute\n\nIntro paragraph.",
+            Tools = new List<ToolContent>
+            {
+                MakeTool("Create a disk", "compute disk create", "disk"),
+                MakeTool("Delete a disk", "compute disk delete", "disk"),
+                MakeTool("Create a VM", "compute vm create", "vm"),
+                MakeTool("Delete a VM", "compute vm delete", "vm"),
+            },
+            RelatedContent = "## Related content\n\n- [Link](/path)"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("## Disk", result);
+        Assert.Contains("## VM", result);
+        Assert.Contains("### Create a disk", result);
+        Assert.Contains("### Delete a disk", result);
+        Assert.Contains("### Create a VM", result);
+        Assert.Contains("### Delete a VM", result);
+
+        var diskIndex = result.IndexOf("## Disk");
+        var vmIndex = result.IndexOf("## VM");
+        Assert.True(diskIndex < vmIndex, "Disk group should appear before VM group");
+    }
+
+    [Fact]
+    public void Stitch_MultiResourceWithThreeGroups_AllGroupsPresent()
+    {
+        var familyContent = new FamilyContent
+        {
+            FamilyName = "compute",
+            Metadata = "---\ntitle: Compute\n---\n# Compute\n\nIntro.",
+            Tools = new List<ToolContent>
+            {
+                MakeTool("Create disk", "compute disk create", "disk"),
+                MakeTool("Create VM", "compute vm create", "vm"),
+                MakeTool("Create VMSS", "compute vmss create", "vmss"),
+            },
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("## Disk", result);
+        Assert.Contains("## VM", result);
+        Assert.Contains("## VMSS", result);
+        Assert.Contains("### Create disk", result);
+        Assert.Contains("### Create VM", result);
+        Assert.Contains("### Create VMSS", result);
+    }
+
+    [Fact]
+    public void Stitch_MultiResourceWithSubHeadings_SubHeadingsDemoted()
+    {
+        var familyContent = new FamilyContent
+        {
+            FamilyName = "storage",
+            Metadata = "---\ntitle: Storage\n---\n# Storage\n\nIntro.",
+            Tools = new List<ToolContent>
+            {
+                MakeToolWithSubHeadings("Create account", "storage account create", "account"),
+                MakeToolWithSubHeadings("Get blob", "storage blob get", "blob"),
+            },
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("### Create account", result);
+        Assert.Contains("#### Parameters", result);
+    }
+
+    [Fact]
+    public void Stitch_SingleResourceWithMultipleTools_NoGrouping()
+    {
+        var familyContent = new FamilyContent
+        {
+            FamilyName = "keyvault",
+            Metadata = "---\ntitle: Key Vault\n---\n# Key Vault\n\nIntro.",
+            Tools = new List<ToolContent>
+            {
+                MakeTool("Create secret", "keyvault secret create", "secret"),
+                MakeTool("Get secret", "keyvault secret get", "secret"),
+                MakeTool("Delete secret", "keyvault secret delete", "secret"),
+            },
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+        var result = stitcher.Stitch(familyContent);
+
+        Assert.Contains("## Create secret", result);
+        Assert.Contains("## Get secret", result);
+        Assert.Contains("## Delete secret", result);
+        Assert.DoesNotContain("## Secret", result);
+    }
+
+    // --- Helpers ---
+
+    private static ToolContent MakeTool(string toolName, string? command, string resourceType)
+    {
+        return new ToolContent
+        {
+            ToolName = toolName,
+            FileName = $"{(command ?? toolName).Replace(' ', '-')}.md",
+            FamilyName = "test",
+            Content = $"## {toolName}\n\nDescription of {toolName}.",
+            Command = command,
+            ResourceType = resourceType
+        };
+    }
+
+    private static ToolContent MakeToolWithSubHeadings(string toolName, string? command, string resourceType)
+    {
+        return new ToolContent
+        {
+            ToolName = toolName,
+            FileName = $"{(command ?? toolName).Replace(' ', '-')}.md",
+            FamilyName = "test",
+            Content = $"## {toolName}\n\nDescription.\n\n### Parameters\n\n| Name | Type |\n|---|---|\n| foo | string |",
+            Command = command,
+            ResourceType = resourceType
+        };
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Models/ToolContent.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Models/ToolContent.cs
@@ -46,4 +46,11 @@ public class ToolContent
     /// Original full path to the source file for debugging
     /// </summary>
     public string? SourceFilePath { get; init; }
+
+    /// <summary>
+    /// Resource sub-type extracted from the command (e.g., "disk" from "compute disk create").
+    /// Empty string for bare namespace+verb commands (e.g., "advisor list").
+    /// Used for grouping tools by resource type on multi-resource pages (#412).
+    /// </summary>
+    public string ResourceType { get; set; } = string.Empty;
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using ToolFamilyCleanup.Models;
 
 namespace ToolFamilyCleanup.Services;
@@ -12,6 +14,15 @@ namespace ToolFamilyCleanup.Services;
 /// </summary>
 public class FamilyFileStitcher
 {
+    // Known acronyms that should remain uppercase in display names
+    private static readonly HashSet<string> KnownAcronyms = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "vm", "vmss", "db", "sql", "api", "aks", "acr", "dns", "ip", "nsg",
+        "vpn", "vnet", "hpc", "gpu", "cpu", "ssd", "hdd", "cdn", "waf", "rbac"
+    };
+
+    private static readonly Regex HeadingRegex = new(@"^(#{2,6})\s", RegexOptions.Multiline | RegexOptions.Compiled);
+
     /// <summary>
     /// Assembles a complete tool family markdown file from its parts.
     /// </summary>
@@ -21,24 +32,33 @@ public class FamilyFileStitcher
     {
         var sb = new StringBuilder();
 
-        // 1. Metadata section (frontmatter + H1 + intro — strip any H2s the AI may have generated)
+        // 1. Metadata section (frontmatter + H1 + intro - strip any H2s the AI may have generated)
         var metadataLines = familyContent.Metadata.Split('\n')
             .Where(line => !line.StartsWith("## "));
         sb.AppendLine(string.Join('\n', metadataLines));
         sb.AppendLine();
 
-        // 2. Tool sections (H2 + content for each tool)
-        foreach (var tool in familyContent.Tools)
+        // 2. Tool sections - group by resource type if multi-resource (#412)
+        var isMultiResource = IsMultiResourceFamily(familyContent.Tools);
+
+        if (isMultiResource)
         {
-            sb.AppendLine(tool.Content);
-            sb.AppendLine();
+            StitchMultiResource(sb, familyContent.Tools);
+        }
+        else
+        {
+            // Single-resource: keep current behavior (H2 per tool)
+            foreach (var tool in familyContent.Tools)
+            {
+                sb.AppendLine(tool.Content);
+                sb.AppendLine();
+            }
         }
 
         // 3. Related content section
         sb.AppendLine(familyContent.RelatedContent);
 
         // 4. Post-processing: expand all acronyms on first body mention (#142, #215)
-        //    Replaces the old single-MCP expander with generalized AcronymExpander
         var markdown = sb.ToString().TrimEnd();
         markdown = AcronymExpander.ExpandAll(markdown);
 
@@ -85,6 +105,110 @@ public class FamilyFileStitcher
         markdown = ScaffoldingCommentStripper.Strip(markdown);
 
         return markdown;
+    }
+
+    /// <summary>
+    /// Determines whether a set of tools spans multiple distinct resource types.
+    /// Returns true when there are 2+ distinct non-empty resource types.
+    /// </summary>
+    internal static bool IsMultiResourceFamily(List<ToolContent> tools)
+    {
+        var distinctResourceTypes = tools
+            .Select(t => t.ResourceType)
+            .Where(rt => !string.IsNullOrEmpty(rt))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return distinctResourceTypes.Count >= 2;
+    }
+
+    /// <summary>
+    /// Emits tool sections grouped by resource type. Each group gets an H2 header;
+    /// tool headings are demoted from H2 to H3 (and sub-headings shift accordingly).
+    /// </summary>
+    private static void StitchMultiResource(StringBuilder sb, List<ToolContent> tools)
+    {
+        // Group tools preserving existing sort order (already sorted by resource type then verb)
+        var groups = new List<(string ResourceType, List<ToolContent> Tools)>();
+        string currentResourceType = "";
+        List<ToolContent>? currentGroup = null;
+
+        foreach (var tool in tools)
+        {
+            var rt = string.IsNullOrEmpty(tool.ResourceType) ? "" : tool.ResourceType;
+            if (currentGroup == null || !string.Equals(rt, currentResourceType, StringComparison.OrdinalIgnoreCase))
+            {
+                currentGroup = new List<ToolContent>();
+                currentResourceType = rt;
+                groups.Add((rt, currentGroup));
+            }
+            currentGroup.Add(tool);
+        }
+
+        foreach (var (resourceType, groupTools) in groups)
+        {
+            // Emit H2 resource group header
+            var displayName = FormatResourceTypeDisplayName(resourceType);
+            sb.AppendLine($"## {displayName}");
+            sb.AppendLine();
+
+            foreach (var tool in groupTools)
+            {
+                // Demote all headings in tool content by one level (H2->H3, H3->H4, etc.)
+                var demotedContent = DemoteHeadings(tool.Content);
+                sb.AppendLine(demotedContent);
+                sb.AppendLine();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Demotes all markdown headings in content by one level (## -> ###, ### -> ####, etc.).
+    /// Caps at H6 (######) per markdown spec.
+    /// </summary>
+    internal static string DemoteHeadings(string content)
+    {
+        return HeadingRegex.Replace(content, match =>
+        {
+            var hashes = match.Groups[1].Value;
+            // Cap at 6 levels
+            if (hashes.Length >= 6)
+                return match.Value;
+            return hashes + "# ";
+        });
+    }
+
+    /// <summary>
+    /// Converts a resource type identifier to a human-readable display name.
+    /// Examples: "disk" -> "Disk", "vmss" -> "VMSS", "db container" -> "DB container"
+    /// </summary>
+    internal static string FormatResourceTypeDisplayName(string resourceType)
+    {
+        if (string.IsNullOrWhiteSpace(resourceType))
+            return "General";
+
+        var words = resourceType.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var result = new string[words.Length];
+
+        for (int i = 0; i < words.Length; i++)
+        {
+            if (KnownAcronyms.Contains(words[i]))
+            {
+                result[i] = words[i].ToUpperInvariant();
+            }
+            else if (i == 0)
+            {
+                // Title-case the first word
+                result[i] = char.ToUpper(words[i][0], CultureInfo.InvariantCulture) + words[i][1..];
+            }
+            else
+            {
+                // Lowercase subsequent non-acronym words
+                result[i] = words[i].ToLowerInvariant();
+            }
+        }
+
+        return string.Join(" ", result);
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
@@ -133,7 +133,8 @@ public class ToolReader
             Content = contentWithoutFrontmatter.Trim(),
             Command = command,
             Description = ExtractDescription(content),
-            SourceFilePath = filePath
+            SourceFilePath = filePath,
+            ResourceType = GetResourceType(command)
         };
     }
 
@@ -269,6 +270,28 @@ public class ToolReader
     /// </summary>
     private static string StripFrontmatter(string content) =>
         Shared.FrontmatterUtility.StripFrontmatter(content)!;
+
+    /// <summary>
+    /// Extracts the resource sub-type from a command string.
+    /// Command format: "namespace resource1 [resource2...] verb"
+    /// Returns the resource portion (e.g., "disk" from "compute disk create",
+    /// "agent thread" from "foundry agent thread create").
+    /// Returns empty string for two-segment commands (namespace + verb only).
+    /// </summary>
+    internal static string GetResourceType(string? command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+            return string.Empty;
+
+        var segments = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        // Two or fewer segments: no resource sub-type
+        if (segments.Length <= 2)
+            return string.Empty;
+
+        // Three+ segments: "namespace resource... verb" -> resource portion
+        return string.Join(" ", segments[1..^1]);
+    }
 
     /// <summary>
     /// Builds a sort key from a command that groups by resource type first, then by verb.


### PR DESCRIPTION
## Summary

Implements tool ordering/grouping by resource sub-type within a page (#412).

Multi-resource namespaces like `compute` (with disk/vm/vmss resources) now get:
- **H2 headers** per resource group (e.g., `## Disk`, `## VM`, `## VMSS`)
- **Tool headings demoted to H3** under each group

Single-resource namespaces remain **completely unchanged** (key invariant).

## Changes

| File | Change |
|------|--------|
| `ToolContent.cs` | Added `ResourceType` property |
| `ToolReader.cs` | Added `GetResourceType()` method, populated in `ParseToolFileAsync` |
| `FamilyFileStitcher.cs` | Multi-resource detection, grouping, heading demotion |
| `ResourceGroupingTests.cs` | 36 new tests covering all new logic |

## Design

- **Detection**: `IsMultiResourceFamily()` counts distinct non-empty resource types; 2+ triggers grouping
- **Extraction**: `GetResourceType()` parses command segments (reuses `GetResourceSortKey` patterns)
- **Display names**: `FormatResourceTypeDisplayName()` with acronym support (VM, VMSS, DB, DNS, etc.)
- **Heading demotion**: Regex-based `DemoteHeadings()` shifts all heading levels, caps at H6
- **Sort order**: Tools arrive pre-sorted by resource type via existing `GetResourceSortKey`

## Testing

- 568 total tests pass (was 532, +36 new)
- Covers: extraction, multi-resource detection, display names, heading demotion, full stitch integration
- Both single-resource and multi-resource scenarios tested

Closes #412