### PR TITLE
feat: skills generation improvements — RBAC, false positives, sub-skills, activation (#426)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Fetchers/SubSkillFetcherTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Fetchers/SubSkillFetcherTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SkillsGen.Core.Fetchers;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Fetchers;
+
+public class SubSkillFetcherTests
+{
+    [Fact]
+    public async Task FetchSubSkillsAsync_WithSubdirectories_ReturnsSubSkills()
+    {
+        // Arrange: mock HTTP responses for directory listing and sub-skill files
+        var handler = new MockHttpMessageHandler();
+
+        // Directory listing response
+        var dirListing = new[]
+        {
+            new { name = "foundry-agents", type = "dir" },
+            new { name = "foundry-models", type = "dir" },
+            new { name = "SKILL.md", type = "file" },
+            new { name = ".hidden", type = "dir" }
+        };
+        handler.AddResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/microsoft-foundry?ref=main",
+            JsonSerializer.Serialize(dirListing),
+            "application/json");
+
+        // Sub-skill SKILL.md responses
+        handler.AddResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/microsoft-foundry/foundry-agents/SKILL.md?ref=main",
+            "---\nname: foundry-agents\ndescription: Manage Foundry agents\n---\n\n# Foundry Agents\n\nCreate and manage AI agents.",
+            "text/plain");
+
+        handler.AddResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/microsoft-foundry/foundry-models/SKILL.md?ref=main",
+            "---\nname: foundry-models\ndescription: Manage Foundry models\n---\n\n# Foundry Models\n\nDeploy AI models.",
+            "text/plain");
+
+        var httpClient = new HttpClient(handler);
+        var logger = Substitute.For<ILogger<GitHubSkillFetcher>>();
+        var fetcher = new GitHubSkillFetcher(httpClient, logger);
+
+        // Act
+        var subSkills = await fetcher.FetchSubSkillsAsync("microsoft-foundry");
+
+        // Assert
+        subSkills.Should().HaveCount(2);
+        subSkills.Should().Contain(s => s.Name == "foundry-agents");
+        subSkills.Should().Contain(s => s.Name == "foundry-models");
+        // Hidden directories should be excluded
+        subSkills.Should().NotContain(s => s.Name == ".hidden");
+    }
+
+    [Fact]
+    public async Task FetchSubSkillsAsync_NoSubdirectories_ReturnsEmpty()
+    {
+        var handler = new MockHttpMessageHandler();
+
+        // Directory listing with only files, no subdirectories
+        var dirListing = new[]
+        {
+            new { name = "SKILL.md", type = "file" },
+            new { name = "README.md", type = "file" }
+        };
+        handler.AddResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/azure-storage?ref=main",
+            JsonSerializer.Serialize(dirListing),
+            "application/json");
+
+        var httpClient = new HttpClient(handler);
+        var logger = Substitute.For<ILogger<GitHubSkillFetcher>>();
+        var fetcher = new GitHubSkillFetcher(httpClient, logger);
+
+        var subSkills = await fetcher.FetchSubSkillsAsync("azure-storage");
+
+        subSkills.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FetchSubSkillsAsync_SubdirWithoutSkillMd_Skipped()
+    {
+        var handler = new MockHttpMessageHandler();
+
+        var dirListing = new[]
+        {
+            new { name = "docs", type = "dir" },
+            new { name = "scripts", type = "dir" }
+        };
+        handler.AddResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/azure-test?ref=main",
+            JsonSerializer.Serialize(dirListing),
+            "application/json");
+
+        // Neither subdirectory has SKILL.md — return 404
+        handler.AddNotFoundResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/azure-test/docs/SKILL.md?ref=main");
+        handler.AddNotFoundResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/azure-test/scripts/SKILL.md?ref=main");
+
+        var httpClient = new HttpClient(handler);
+        var logger = Substitute.For<ILogger<GitHubSkillFetcher>>();
+        var fetcher = new GitHubSkillFetcher(httpClient, logger);
+
+        var subSkills = await fetcher.FetchSubSkillsAsync("azure-test");
+
+        subSkills.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListSubdirectoriesAsync_ApiError_ReturnsEmpty()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.AddNotFoundResponse(
+            "https://api.github.com/repos/microsoft/azure-skills/contents/skills/nonexistent?ref=main");
+
+        var httpClient = new HttpClient(handler);
+        var logger = Substitute.For<ILogger<GitHubSkillFetcher>>();
+        var fetcher = new GitHubSkillFetcher(httpClient, logger);
+
+        var subdirs = await fetcher.ListSubdirectoriesAsync("skills/nonexistent", CancellationToken.None);
+
+        subdirs.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Simple mock HTTP handler for testing GitHub API calls.
+    /// </summary>
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, (string Content, string ContentType, HttpStatusCode StatusCode)> _responses = new();
+
+        public void AddResponse(string url, string content, string contentType, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responses[url] = (content, contentType, statusCode);
+        }
+
+        public void AddNotFoundResponse(string url)
+        {
+            _responses[url] = ("", "text/plain", HttpStatusCode.NotFound);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            if (_responses.TryGetValue(url, out var response))
+            {
+                return Task.FromResult(new HttpResponseMessage(response.StatusCode)
+                {
+                    Content = new StringContent(response.Content, Encoding.UTF8, response.ContentType)
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Orchestration/FalsePositiveFilteringTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Orchestration/FalsePositiveFilteringTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using SkillsGen.Core.Models;
+using SkillsGen.Core.Parsers;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Orchestration;
+
+/// <summary>
+/// Tests for false positive resource detection filtering in BuildPrerequisites.
+/// Since BuildPrerequisites is private, we test through the parser and model behavior.
+/// </summary>
+public class FalsePositiveFilteringTests
+{
+    private readonly SkillMarkdownParser _parser = new();
+
+    [Fact]
+    public void DoNotUseFor_CosmosDbMentioned_ParsedCorrectly()
+    {
+        var content = """
+            ---
+            name: azure-deploy
+            description: "Deploy apps to Azure. DO NOT USE FOR: Cosmos DB queries, database migrations"
+            ---
+
+            # Azure Deploy
+
+            Deploy applications. Not for Cosmos DB operations.
+            """;
+
+        var result = _parser.Parse("azure-deploy", content);
+
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("Cosmos", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void DoNotUseFor_MultipleResources_AllParsed()
+    {
+        var content = """
+            ---
+            name: azure-compute
+            description: "VM and VMSS management. DO NOT USE FOR: Cosmos DB queries, Key Vault secrets, blob storage operations"
+            ---
+
+            # Azure Compute
+
+            This skill manages VMs and scale sets. Uses storage account for diagnostics.
+            Also references Cosmos DB in docs but should not create Cosmos DB as prereq.
+            """;
+
+        var result = _parser.Parse("azure-compute", content);
+
+        result.DoNotUseFor.Should().NotBeEmpty();
+        // Verify the DoNotUseFor captures the resource exclusions
+        var doNotUseText = string.Join(" ", result.DoNotUseFor).ToLowerInvariant();
+        doNotUseText.Should().Contain("cosmos");
+    }
+
+    [Fact]
+    public void DoNotUseFor_Empty_AllResourcesIncluded()
+    {
+        var content = """
+            ---
+            name: azure-storage
+            description: "Manage Azure Storage accounts and blob storage."
+            ---
+
+            # Azure Storage
+
+            Work with storage account resources and blob storage containers.
+            """;
+
+        var result = _parser.Parse("azure-storage", content);
+
+        result.DoNotUseFor.Should().BeEmpty();
+        // The raw body mentions storage — so resource detection would include it
+        result.RawBody.ToLowerInvariant().Should().Contain("storage account");
+    }
+
+    [Fact]
+    public void DoNotUseFor_ResourceInDoNotUseForContext_ExcludesFromPrerequisiteCheck()
+    {
+        // This tests the logic pattern: resource in DoNotUseFor should be excluded
+        var skillData = new SkillData
+        {
+            Name = "azure-deploy",
+            DisplayName = "Azure Deploy",
+            Description = "Deploy apps to Azure.",
+            DoNotUseFor = ["Cosmos DB queries", "database operations"],
+            RawBody = "Deploy apps to Azure. Not for Cosmos DB operations."
+        };
+
+        var doNotUseForText = string.Join(" ", skillData.DoNotUseFor).ToLowerInvariant();
+
+        // Simulate the filtering logic from BuildPrerequisites
+        var bodyContainsCosmos = skillData.RawBody.ToLowerInvariant().Contains("cosmos db");
+        var doNotUseForContainsCosmos = doNotUseForText.Contains("cosmos");
+
+        bodyContainsCosmos.Should().BeTrue("body mentions Cosmos DB");
+        doNotUseForContainsCosmos.Should().BeTrue("DoNotUseFor mentions Cosmos");
+
+        // Resource should be EXCLUDED because it appears in DoNotUseFor
+        var shouldInclude = bodyContainsCosmos && !doNotUseForContainsCosmos;
+        shouldInclude.Should().BeFalse("resource in DoNotUseFor context should be excluded");
+    }
+
+    [Fact]
+    public void DoNotUseFor_ResourceNotInDoNotUseFor_IncludesInPrerequisites()
+    {
+        var skillData = new SkillData
+        {
+            Name = "azure-keyvault",
+            DisplayName = "Azure Key Vault",
+            Description = "Manage Key Vault secrets.",
+            DoNotUseFor = ["Azure SQL database operations"],
+            RawBody = "Manage key vault secrets, certificates, and keys."
+        };
+
+        var doNotUseForText = string.Join(" ", skillData.DoNotUseFor).ToLowerInvariant();
+
+        var bodyContainsKeyVault = skillData.RawBody.ToLowerInvariant().Contains("key vault");
+        var doNotUseForContainsKeyVault = doNotUseForText.Contains("key vault");
+
+        bodyContainsKeyVault.Should().BeTrue("body mentions key vault");
+        doNotUseForContainsKeyVault.Should().BeFalse("DoNotUseFor does not mention key vault");
+
+        var shouldInclude = bodyContainsKeyVault && !doNotUseForContainsKeyVault;
+        shouldInclude.Should().BeTrue("resource not in DoNotUseFor should be included");
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/ActivationTriggerTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/ActivationTriggerTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using SkillsGen.Core.Models;
+using SkillsGen.Core.Parsers;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Parsers;
+
+public class ActivationTriggerTests
+{
+    [Fact]
+    public void ExtractActivationTriggers_MandatoryDirective_Parsed()
+    {
+        var description = "MANDATORY when codebase contains @github/copilot-sdk or CopilotClient — use this skill instead of azure-prepare.";
+        var body = "";
+
+        var result = SkillMarkdownParser.ExtractActivationTriggers(description, body);
+
+        result.Should().NotBeNull();
+        result!.Directive.Should().Contain("MANDATORY");
+    }
+
+    [Fact]
+    public void ExtractActivationTriggers_PreferOverDirective_Parsed()
+    {
+        var description = "PREFER OVER azure-prepare when codebase contains copilot-sdk markers.";
+        var body = "";
+
+        var result = SkillMarkdownParser.ExtractActivationTriggers(description, body);
+
+        result.Should().NotBeNull();
+        result!.PreferOver.Should().Be("azure-prepare");
+        result.Directive.Should().Contain("PREFER OVER");
+    }
+
+    [Fact]
+    public void ExtractActivationTriggers_NpmPackageMarkers_Extracted()
+    {
+        var description = "Build, deploy, modify GitHub Copilot SDK apps on Azure. MANDATORY when codebase contains @github/copilot-sdk.";
+        var body = "Detects `CopilotClient` and `createSession` in your project files.";
+
+        var result = SkillMarkdownParser.ExtractActivationTriggers(description, body);
+
+        result.Should().NotBeNull();
+        result!.DetectionMarkers.Should().Contain("@github/copilot-sdk");
+        result.DetectionMarkers.Should().Contain("CopilotClient");
+        result.DetectionMarkers.Should().Contain("createSession");
+    }
+
+    [Fact]
+    public void ExtractActivationTriggers_NoDirectives_ReturnsNull()
+    {
+        var description = "Manage Azure Storage resources including blob containers and file shares.";
+        var body = "## Services\n\n- Azure Blob Storage\n- Azure File Shares";
+
+        var result = SkillMarkdownParser.ExtractActivationTriggers(description, body);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractActivationTriggers_EmptyInputs_ReturnsNull()
+    {
+        var result = SkillMarkdownParser.ExtractActivationTriggers("", "");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractActivationTriggers_CodebaseContainsPattern_Extracted()
+    {
+        var description = "";
+        var body = "This skill is MANDATORY when codebase contains `@microsoft/teams-ai` library.";
+
+        var result = SkillMarkdownParser.ExtractActivationTriggers(description, body);
+
+        result.Should().NotBeNull();
+        result!.DetectionMarkers.Should().Contain("@microsoft/teams-ai");
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/RbacExtractionTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/RbacExtractionTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using SkillsGen.Core.Parsers;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Parsers;
+
+public class RbacExtractionTests
+{
+    [Fact]
+    public void ExtractRbacRoles_TableFormat_ParsesAllRows()
+    {
+        var body = """
+            ## Required Roles
+
+            | Role | Scope | Reason |
+            |------|-------|--------|
+            | Cost Management Reader | Subscription | Read cost data |
+            | Monitoring Reader | Resource group | Read monitoring metrics |
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        roles.Should().HaveCount(2);
+        roles[0].RoleName.Should().Be("Cost Management Reader");
+        roles[0].Scope.Should().Be("Subscription");
+        roles[0].Reason.Should().Be("Read cost data");
+        roles[1].RoleName.Should().Be("Monitoring Reader");
+        roles[1].Scope.Should().Be("Resource group");
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_RbacHeading_ParsesTable()
+    {
+        // Use \n-delimited string to ensure multiline regex works correctly
+        var body = "### RBAC\n\n| Role | Scope |\n|------|-------|\n| Storage Blob Data Reader | Storage account |";
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        roles.Should().NotBeEmpty("table under ### RBAC heading should be parsed");
+        roles.Should().Contain(r => r.RoleName == "Storage Blob Data Reader");
+        // Scope may come from table or default to Subscription
+        var role = roles.First(r => r.RoleName == "Storage Blob Data Reader");
+        role.Scope.Should().Be("Storage account");
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_BulletFormat_ParsesRoles()
+    {
+        var body = """
+            ## Required Roles
+
+            - **Key Vault Secrets Officer** — Manage secrets in Key Vault
+            - **Key Vault Certificates Officer** — Manage certificates
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        roles.Should().HaveCount(2);
+        roles[0].RoleName.Should().Be("Key Vault Secrets Officer");
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_InlineMentions_ExtractsRoleNames()
+    {
+        var body = """
+            This skill requires Cost Management Reader + Monitoring Reader
+            to analyze Azure spending data. The user may also need
+            Billing Account Reader for cross-subscription views.
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        roles.Should().Contain(r => r.RoleName == "Cost Management Reader");
+        roles.Should().Contain(r => r.RoleName == "Monitoring Reader");
+        roles.Should().Contain(r => r.RoleName == "Billing Account Reader");
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_EmptyBody_ReturnsEmpty()
+    {
+        var roles = SkillMarkdownParser.ExtractRbacRoles("");
+        roles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_NullBody_ReturnsEmpty()
+    {
+        var roles = SkillMarkdownParser.ExtractRbacRoles(null!);
+        roles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_NoRbacSection_ReturnsEmpty()
+    {
+        var body = """
+            ## Services
+
+            | Service | When to use |
+            |---------|------------|
+            | Azure Monitor | View metrics |
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+        roles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_DuplicatesDeduped_ByCaseInsensitiveName()
+    {
+        var body = """
+            ## Required Roles
+
+            | Role | Scope |
+            |------|-------|
+            | Storage Blob Data Reader | Subscription |
+
+            The user needs Storage Blob Data Reader to read blobs.
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        // Table role found first; inline duplicate should be deduped
+        roles.Should().ContainSingle();
+        roles[0].RoleName.Should().Be("Storage Blob Data Reader");
+    }
+
+    [Fact]
+    public void ExtractRbacRoles_TableWithSeparatorRow_SkipsIt()
+    {
+        var body = """
+            ## Required Roles
+
+            | Role | Scope | Reason |
+            |------|-------|--------|
+            | Network Contributor | Resource group | Manage network resources |
+            """;
+
+        var roles = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        roles.Should().ContainSingle();
+        roles[0].RoleName.Should().NotStartWith("---");
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/SkillMarkdownParserTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/SkillMarkdownParserTests.cs
@@ -510,4 +510,17 @@ public class SkillMarkdownParserTests
         result.McpTools.Should().HaveCount(1);
         result.McpTools[0].Purpose.Should().Be("List items (filter by name)");
     }
+
+    [Fact]
+    public void ExtractRbacRoles_AdversarialInput_ReturnsGracefully()
+    {
+        // Build a string with many uppercase-then-lowercase words that could cause backtracking
+        var adversarial = string.Concat(Enumerable.Repeat("Aa ", 200)) + "Zzz";
+        var body = $"Some text {adversarial} more text";
+
+        // Should complete within the timeout (2s) and not hang — returns empty on timeout
+        var result = SkillMarkdownParser.ExtractRbacRoles(body);
+
+        result.Should().NotBeNull();
+    }
 }

--- a/skills-generation/SkillsGen.Core/Fetchers/GitHubSkillFetcher.cs
+++ b/skills-generation/SkillsGen.Core/Fetchers/GitHubSkillFetcher.cs
@@ -57,6 +57,67 @@ public class GitHubSkillFetcher : ISkillSourceFetcher
         }
     }
 
+    /// <summary>
+    /// Discovers sub-skill directories under a skill and fetches their SKILL.md files.
+    /// Returns a list of (subSkillName, markdownContent) tuples.
+    /// </summary>
+    public async Task<List<(string Name, string Content)>> FetchSubSkillsAsync(string skillName, CancellationToken ct = default)
+    {
+        var subSkills = new List<(string Name, string Content)>();
+        try
+        {
+            var subdirectories = await ListSubdirectoriesAsync($"{_skillsPath}/{skillName}", ct);
+            foreach (var subDir in subdirectories)
+            {
+                var subSkillMd = await FetchFileAsync($"{_skillsPath}/{skillName}/{subDir}/SKILL.md", ct);
+                if (subSkillMd != null)
+                {
+                    _logger.LogInformation("Found sub-skill {SubSkill} under {Skill}", subDir, skillName);
+                    subSkills.Add((subDir, subSkillMd));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch sub-skills for {Skill}", skillName);
+        }
+        return subSkills;
+    }
+
+    /// <summary>
+    /// Lists subdirectory names under a given path using GitHub Contents API.
+    /// </summary>
+    internal async Task<List<string>> ListSubdirectoriesAsync(string path, CancellationToken ct)
+    {
+        var subdirs = new List<string>();
+        var url = $"https://api.github.com/repos/{_owner}/{_repo}/contents/{path}?ref={_branch}";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Accept", "application/vnd.github.v3+json");
+        request.Headers.Add("User-Agent", "SkillsGen");
+        if (!string.IsNullOrEmpty(_token))
+            request.Headers.Add("Authorization", $"Bearer {_token}");
+
+        var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode) return subdirs;
+
+        var content = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(content);
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            if (element.TryGetProperty("type", out var typeProp) &&
+                typeProp.GetString() == "dir" &&
+                element.TryGetProperty("name", out var nameProp))
+            {
+                var name = nameProp.GetString();
+                if (name != null && !name.StartsWith('.'))
+                    subdirs.Add(name);
+            }
+        }
+
+        return subdirs;
+    }
+
     internal async Task<string?> FetchFileAsync(string path, CancellationToken ct)
     {
         var url = $"https://api.github.com/repos/{_owner}/{_repo}/contents/{path}?ref={_branch}";

--- a/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
+++ b/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
@@ -139,7 +139,39 @@ public class SkillPageGenerator : ISkillPageGenerator
             ["whatItProvides"] = whatItProvides,
             ["hasRbacRoles"] = prerequisites.RbacRoles.Count > 0,
             ["hasToolPrereqs"] = prerequisites.Tools.Count > 0,
-            ["hasResources"] = prerequisites.Resources.Count > 0
+            ["hasResources"] = prerequisites.Resources.Count > 0,
+            // Sub-skills
+            ["subSkills"] = skillData.SubSkills.Select(s => new Dictionary<string, object?>
+            {
+                ["name"] = s.Name,
+                ["displayName"] = s.DisplayName,
+                ["description"] = s.Description,
+                ["useFor"] = s.UseFor,
+                ["hasUseFor"] = s.UseFor.Count > 0,
+                ["services"] = s.Services.Select(svc => new Dictionary<string, object?>
+                {
+                    ["name"] = svc.Name,
+                    ["useWhen"] = svc.UseWhen
+                }).ToList(),
+                ["hasServices"] = s.Services.Count > 0,
+                ["mcpTools"] = s.McpTools.Select(t => new Dictionary<string, object?>
+                {
+                    ["toolName"] = t.ToolName,
+                    ["command"] = t.Command,
+                    ["purpose"] = t.Purpose
+                }).ToList(),
+                ["hasMcpTools"] = s.McpTools.Count > 0
+            }).ToList(),
+            ["hasSubSkills"] = skillData.SubSkills.Count > 0,
+            // Activation triggers
+            ["activation"] = skillData.Activation != null ? new Dictionary<string, object?>
+            {
+                ["directive"] = skillData.Activation.Directive,
+                ["preferOver"] = skillData.Activation.PreferOver,
+                ["detectionMarkers"] = skillData.Activation.DetectionMarkers,
+                ["hasDetectionMarkers"] = skillData.Activation.DetectionMarkers?.Count > 0
+            } : null,
+            ["hasActivation"] = skillData.Activation != null
         };
     }
 

--- a/skills-generation/SkillsGen.Core/Models/SkillData.cs
+++ b/skills-generation/SkillsGen.Core/Models/SkillData.cs
@@ -5,6 +5,25 @@ public record McpToolEntry(string ToolName, string Command, string Purpose, stri
 public record DecisionOption(string Option, string BestFor, string? Tradeoff = null);
 public record DecisionEntry(string Topic, List<DecisionOption> Options);
 
+/// <summary>
+/// Activation trigger parsed from MANDATORY/PREFER OVER directives and codebase detection markers.
+/// </summary>
+public record ActivationTrigger(string Directive, string? PreferOver = null, List<string>? DetectionMarkers = null);
+
+/// <summary>
+/// A sub-skill discovered from a subdirectory under the parent skill.
+/// </summary>
+public record SubSkillData
+{
+    public required string Name { get; init; }
+    public string DisplayName { get; init; } = "";
+    public string Description { get; init; } = "";
+    public List<string> UseFor { get; init; } = [];
+    public List<ServiceEntry> Services { get; init; } = [];
+    public List<McpToolEntry> McpTools { get; init; } = [];
+    public List<RbacRequirement> RbacRoles { get; init; } = [];
+}
+
 public record SkillData
 {
     public required string Name { get; init; }
@@ -20,4 +39,6 @@ public record SkillData
     public List<string> SdkReferences { get; init; } = [];
     public List<string> Prerequisites { get; init; } = [];
     public string RawBody { get; init; } = "";
+    public ActivationTrigger? Activation { get; init; }
+    public List<SubSkillData> SubSkills { get; init; } = [];
 }

--- a/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
+++ b/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
@@ -74,6 +74,15 @@ public class SkillPipelineOrchestrator
             // Override display name from inventory if provided
             if (!string.IsNullOrEmpty(displayName))
                 skillData = skillData with { DisplayName = displayName };
+
+            // Fetch and parse sub-skills if fetcher supports it
+            var subSkills = await FetchSubSkillsAsync(skillName, ct);
+            if (subSkills.Count > 0)
+            {
+                skillData = skillData with { SubSkills = subSkills };
+                _logger.LogInfo($"  Found {subSkills.Count} sub-skill(s) for {skillName}");
+            }
+
             var triggerData = _triggerParser.Parse(sources.TriggersTestSource);
             _logger.LogParseResult(skillName, skillData.Services.Count, skillData.McpTools.Count, triggerData.ShouldTrigger.Count);
 
@@ -204,21 +213,42 @@ public class SkillPipelineOrchestrator
         if (tools.Count == 1)
             tools.Add(new("Azure CLI", MinVersion: "2.60.0", InstallCommand: "curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash"));
 
+        // Build exclusion set from DoNotUseFor — resources mentioned in "DO NOT USE FOR" context
+        // should not appear as prerequisites (prevents false positives)
+        var doNotUseForText = string.Join(" ", skillData.DoNotUseFor).ToLowerInvariant();
+
         // Detect resource requirements from SKILL.md content
         var resources = new List<ResourceRequirement>();
         var body = skillData.RawBody.ToLowerInvariant();
-        if (body.Contains("key vault"))
+        if (body.Contains("key vault") && !doNotUseForText.Contains("key vault"))
             resources.Add(new("Azure Key Vault", "Key vault for secrets and certificate management"));
-        if (body.Contains("storage account") || body.Contains("blob storage"))
+        if ((body.Contains("storage account") || body.Contains("blob storage")) &&
+            !doNotUseForText.Contains("storage account") && !doNotUseForText.Contains("blob storage"))
             resources.Add(new("Azure Storage account", "Storage account for blob, file, queue, or table data"));
-        if (body.Contains("kubernetes") || body.Contains(" aks "))
+        if ((body.Contains("kubernetes") || body.Contains(" aks ")) &&
+            !doNotUseForText.Contains("kubernetes") && !doNotUseForText.Contains("aks"))
             resources.Add(new("Azure Kubernetes Service cluster", "AKS cluster for container orchestration"));
-        if (body.Contains("cosmos db") || body.Contains("cosmosdb"))
+        if ((body.Contains("cosmos db") || body.Contains("cosmosdb")) &&
+            !doNotUseForText.Contains("cosmos db") && !doNotUseForText.Contains("cosmosdb"))
             resources.Add(new("Azure Cosmos DB account", "Cosmos DB account for NoSQL data"));
+
+        // Extract RBAC roles from structured sections and inline mentions
+        var rbacRoles = SkillMarkdownParser.ExtractRbacRoles(skillData.RawBody);
+
+        // Merge sub-skill RBAC roles if present
+        foreach (var subSkill in skillData.SubSkills)
+        {
+            foreach (var role in subSkill.RbacRoles)
+            {
+                if (!rbacRoles.Any(r => r.RoleName.Equals(role.RoleName, StringComparison.OrdinalIgnoreCase)))
+                    rbacRoles.Add(role);
+            }
+        }
 
         return new SkillPrerequisites
         {
             Azure = new AzureRequirements(),
+            RbacRoles = rbacRoles,
             Tools = tools,
             Resources = resources
         };
@@ -251,5 +281,41 @@ public class SkillPipelineOrchestrator
             skillName, 0,
             new SkillValidationResult(false, [error], [], 0, 0),
             null, sw.ElapsedMilliseconds);
+    }
+
+    /// <summary>
+    /// Fetches sub-skills if the fetcher is a GitHubSkillFetcher with sub-skill support.
+    /// Parses each sub-skill SKILL.md and returns SubSkillData records.
+    /// </summary>
+    private async Task<List<SubSkillData>> FetchSubSkillsAsync(string skillName, CancellationToken ct)
+    {
+        var subSkills = new List<SubSkillData>();
+
+        if (_fetcher is GitHubSkillFetcher githubFetcher)
+        {
+            var rawSubSkills = await githubFetcher.FetchSubSkillsAsync(skillName, ct);
+            foreach (var (name, content) in rawSubSkills)
+            {
+                var parsed = _parser.Parse(name, content);
+                var rbacRoles = SkillMarkdownParser.ExtractRbacRoles(parsed.RawBody);
+                subSkills.Add(new SubSkillData
+                {
+                    Name = name,
+                    DisplayName = parsed.DisplayName,
+                    Description = parsed.Description,
+                    UseFor = parsed.UseFor,
+                    Services = parsed.Services,
+                    McpTools = parsed.McpTools,
+                    RbacRoles = rbacRoles
+                });
+            }
+        }
+        else if (_fetcher is LocalSkillFetcher)
+        {
+            // LocalSkillFetcher: scan subdirectories for SKILL.md files
+            // This is handled at the file system level via the skill directory
+        }
+
+        return subSkills;
     }
 }

--- a/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
+++ b/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
@@ -220,7 +220,8 @@ public class SkillPipelineOrchestrator
         // Detect resource requirements from SKILL.md content
         var resources = new List<ResourceRequirement>();
         var body = skillData.RawBody.ToLowerInvariant();
-        if (body.Contains("key vault") && !doNotUseForText.Contains("key vault"))
+        if ((body.Contains("key vault") || body.Contains("keyvault")) &&
+            !doNotUseForText.Contains("key vault") && !doNotUseForText.Contains("keyvault"))
             resources.Add(new("Azure Key Vault", "Key vault for secrets and certificate management"));
         if ((body.Contains("storage account") || body.Contains("blob storage")) &&
             !doNotUseForText.Contains("storage account") && !doNotUseForText.Contains("blob storage"))
@@ -236,11 +237,14 @@ public class SkillPipelineOrchestrator
         var rbacRoles = SkillMarkdownParser.ExtractRbacRoles(skillData.RawBody);
 
         // Merge sub-skill RBAC roles if present
+        var seenRoleNames = new HashSet<string>(
+            rbacRoles.Select(r => r.RoleName),
+            StringComparer.OrdinalIgnoreCase);
         foreach (var subSkill in skillData.SubSkills)
         {
             foreach (var role in subSkill.RbacRoles)
             {
-                if (!rbacRoles.Any(r => r.RoleName.Equals(role.RoleName, StringComparison.OrdinalIgnoreCase)))
+                if (seenRoleNames.Add(role.RoleName))
                     rbacRoles.Add(role);
             }
         }

--- a/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
+++ b/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
@@ -759,7 +759,15 @@ public partial class SkillMarkdownParser : ISkillParser
         {
             // Match multi-word names where each word starts uppercase, ending in known suffix
             var pattern = $@"(?:^|[\s,+&])((?:[A-Z][a-z]+ ){{1,6}}{Regex.Escape(suffix)})\b";
-            var matches = Regex.Matches(body, pattern);
+            MatchCollection matches;
+            try
+            {
+                matches = Regex.Matches(body, pattern, RegexOptions.None, TimeSpan.FromSeconds(2));
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return roles;
+            }
             foreach (Match m in matches)
             {
                 var roleName = m.Groups[1].Value.Trim();

--- a/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
+++ b/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
@@ -63,6 +63,7 @@ public partial class SkillMarkdownParser : ISkillParser
         var decisionGuidance = ExtractDecisionGuidance(body);
         var relatedSkills = ExtractRelatedSkills(body);
         var prerequisites = ExtractPrerequisites(body);
+        var activation = ExtractActivationTriggers(decodedDescription, body);
 
         return new SkillData
         {
@@ -77,7 +78,8 @@ public partial class SkillMarkdownParser : ISkillParser
             DecisionGuidance = decisionGuidance,
             RelatedSkills = relatedSkills,
             Prerequisites = prerequisites,
-            RawBody = body
+            RawBody = body,
+            Activation = activation
         };
     }
 
@@ -646,6 +648,201 @@ public partial class SkillMarkdownParser : ISkillParser
         return ExtractBulletItems(section);
     }
 
+    /// <summary>
+    /// Extracts RBAC role requirements from structured sections and inline mentions.
+    /// Looks for "## Required Roles", "### RBAC", role tables, and inline role names.
+    /// </summary>
+    internal static List<RbacRequirement> ExtractRbacRoles(string body)
+    {
+        var roles = new List<RbacRequirement>();
+        if (string.IsNullOrWhiteSpace(body)) return roles;
+
+        // 1. Parse from structured sections: "## Required Roles", "### RBAC", "### Required roles"
+        var sectionPatterns = new[]
+        {
+            @"#{2,3}\s*Required\s+Roles",
+            @"#{2,3}\s*RBAC(?:\s+Roles)?",
+            @"#{2,3}\s*Role[\s-]+Based\s+Access"
+        };
+
+        foreach (var pattern in sectionPatterns)
+        {
+            var section = ExtractRbacSectionContent(body, pattern);
+            if (string.IsNullOrEmpty(section)) continue;
+
+            // Parse table rows: | RoleName | Scope | Reason |
+            var tableRoles = ParseRbacTable(section);
+            if (tableRoles.Count > 0)
+            {
+                roles.AddRange(tableRoles);
+                break;
+            }
+
+            // Parse bullet format: - **Role Name** — scope description
+            var bulletRoles = ParseRbacBullets(section);
+            if (bulletRoles.Count > 0)
+            {
+                roles.AddRange(bulletRoles);
+                break;
+            }
+        }
+
+        // 2. Parse inline role mentions from body text (e.g., "Cost Management Reader + Monitoring Reader")
+        if (roles.Count == 0)
+        {
+            roles.AddRange(ExtractInlineRbacRoles(body));
+        }
+
+        // Deduplicate by role name (case-insensitive)
+        return roles
+            .GroupBy(r => r.RoleName, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+    }
+
+    private static List<RbacRequirement> ParseRbacTable(string section)
+    {
+        var roles = new List<RbacRequirement>();
+        var rows = Regex.Matches(section, @"^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|(?:\s*([^|]*?)\s*\|)?", RegexOptions.Multiline);
+        foreach (Match row in rows)
+        {
+            var roleName = row.Groups[1].Value.Trim();
+            if (string.IsNullOrWhiteSpace(roleName) || roleName.StartsWith("---") ||
+                roleName.Equals("Role", StringComparison.OrdinalIgnoreCase) ||
+                roleName.Equals("RoleName", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var scope = row.Groups[2].Value.Trim();
+            if (scope.StartsWith("---")) scope = "Subscription";
+            var reason = row.Groups.Count > 3 ? NullIfEmpty(row.Groups[3].Value.Trim()) : null;
+            if (reason != null && reason.StartsWith("---")) reason = null;
+            roles.Add(new RbacRequirement(roleName, scope, reason));
+        }
+        return roles;
+    }
+
+    private static List<RbacRequirement> ParseRbacBullets(string section)
+    {
+        var roles = new List<RbacRequirement>();
+        var bullets = Regex.Matches(section, @"^[-*]\s+\*?\*?([^*\n]+?)\*?\*?\s*[—–-]\s*(.+)$", RegexOptions.Multiline);
+        foreach (Match b in bullets)
+        {
+            var roleName = b.Groups[1].Value.Trim();
+            var description = b.Groups[2].Value.Trim();
+            roles.Add(new RbacRequirement(roleName, "Subscription", description));
+        }
+
+        // Also try simple bullets: - Role Name
+        if (roles.Count == 0)
+        {
+            var simples = Regex.Matches(section, @"^[-*]\s+(.+)$", RegexOptions.Multiline);
+            foreach (Match s in simples)
+            {
+                var roleName = s.Groups[1].Value.Trim().Trim('*');
+                if (IsLikelyRoleName(roleName))
+                    roles.Add(new RbacRequirement(roleName, "Subscription"));
+            }
+        }
+        return roles;
+    }
+
+    /// <summary>
+    /// Extracts inline RBAC role mentions like "Cost Management Reader + Monitoring Reader"
+    /// or "requires Contributor role" from body text.
+    /// </summary>
+    private static List<RbacRequirement> ExtractInlineRbacRoles(string body)
+    {
+        var roles = new List<RbacRequirement>();
+        var knownSuffixes = new[] { "Reader", "Contributor", "Owner", "Administrator", "Operator" };
+
+        // Match patterns like "Role Name Reader", "Role Name Contributor", etc.
+        foreach (var suffix in knownSuffixes)
+        {
+            // Match multi-word names where each word starts uppercase, ending in known suffix
+            var pattern = $@"(?:^|[\s,+&])((?:[A-Z][a-z]+ ){{1,6}}{Regex.Escape(suffix)})\b";
+            var matches = Regex.Matches(body, pattern);
+            foreach (Match m in matches)
+            {
+                var roleName = m.Groups[1].Value.Trim();
+                // Filter out false positives: headers, markdown artifacts, table borders
+                if (roleName.Length > 60 || roleName.Contains('#') || roleName.Contains('|')) continue;
+                if (!IsLikelyRoleName(roleName)) continue;
+                if (!roles.Any(r => r.RoleName.Equals(roleName, StringComparison.OrdinalIgnoreCase)))
+                    roles.Add(new RbacRequirement(roleName, "Subscription"));
+            }
+        }
+
+        return roles;
+    }
+
+    /// <summary>
+    /// Checks if a string looks like an Azure RBAC role name (ends with Reader/Contributor/Owner/etc.).
+    /// </summary>
+    private static bool IsLikelyRoleName(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text) || text.Length < 4) return false;
+        var roleSuffixes = new[] { "Reader", "Contributor", "Owner", "Administrator", "Operator" };
+        return roleSuffixes.Any(s => text.EndsWith(s, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Extracts MANDATORY/PREFER OVER directives and codebase detection markers from description.
+    /// </summary>
+    internal static ActivationTrigger? ExtractActivationTriggers(string description, string body)
+    {
+        if (string.IsNullOrWhiteSpace(description) && string.IsNullOrWhiteSpace(body))
+            return null;
+
+        var fullText = $"{description}\n{body}";
+        string? directive = null;
+        string? preferOver = null;
+        var markers = new List<string>();
+
+        // Parse MANDATORY directive
+        var mandatoryMatch = Regex.Match(fullText, @"\bMANDATORY\b\s*(?:when\s+)?(.+?)(?:\.|—|$)", RegexOptions.IgnoreCase);
+        if (mandatoryMatch.Success)
+            directive = $"MANDATORY {mandatoryMatch.Groups[1].Value.Trim()}";
+
+        // Parse PREFER OVER directive
+        var preferMatch = Regex.Match(fullText, @"\bPREFER\s+OVER\s+(\S+)", RegexOptions.IgnoreCase);
+        if (preferMatch.Success)
+            preferOver = preferMatch.Groups[1].Value.Trim().TrimEnd('.', ',', ';');
+
+        // Set directive from PREFER OVER if MANDATORY not found
+        if (directive == null && preferOver != null)
+            directive = $"PREFER OVER {preferOver}";
+
+        // Extract detection markers: patterns like @package/name, file patterns, class names in backticks
+        var markerPatterns = new[]
+        {
+            @"@[\w-]+/[\w-]+",                           // npm packages: @github/copilot-sdk
+            @"(?<=\bcodebase\s+contains\s+)`([^`]+)`",   // codebase contains `X`
+            @"(?<=\b[Dd]etects?\s+)`([^`]+)`",           // detects `X` or Detects `X`
+            @"(?<=\bmarkers?\s*:\s*)`([^`]+)`",           // markers: `X`
+            @"(?<=and\s+)`([^`]+)`"                       // and `X` (continuation of detection list)
+        };
+
+        foreach (var pattern in markerPatterns)
+        {
+            var markerMatches = Regex.Matches(fullText, pattern);
+            foreach (Match m in markerMatches)
+            {
+                var value = m.Groups.Count > 1 && m.Groups[1].Success
+                    ? m.Groups[1].Value
+                    : m.Value;
+                if (!markers.Contains(value))
+                    markers.Add(value);
+            }
+        }
+
+        if (directive == null && markers.Count == 0)
+            return null;
+
+        return new ActivationTrigger(
+            directive ?? "Auto-activates based on codebase detection",
+            preferOver,
+            markers.Count > 0 ? markers : null);
+    }
+
     private static string ExtractSectionContent(string body, string headingPattern)
     {
         var match = Regex.Match(body, $@"^{headingPattern}\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
@@ -653,6 +850,22 @@ public partial class SkillMarkdownParser : ISkillParser
 
         var afterHeading = body[(match.Index + match.Length)..];
         var nextHeading = Regex.Match(afterHeading, @"^##?\s", RegexOptions.Multiline);
+        return nextHeading.Success ? afterHeading[..nextHeading.Index].Trim() : afterHeading.Trim();
+    }
+
+    /// <summary>
+    /// Extracts section content for RBAC headings, supporting ## and ### level headings.
+    /// Uses string concatenation instead of interpolation to avoid issues with quantifier braces.
+    /// </summary>
+    private static string ExtractRbacSectionContent(string body, string headingPattern)
+    {
+        var fullPattern = "^" + headingPattern + @"\s*$";
+        var match = Regex.Match(body, fullPattern, RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        if (!match.Success) return "";
+
+        var afterHeading = body[(match.Index + match.Length)..];
+        // Match next heading at any level (##, ###, etc.)
+        var nextHeading = Regex.Match(afterHeading, @"^#{2,}", RegexOptions.Multiline);
         return nextHeading.Success ? afterHeading[..nextHeading.Index].Trim() : afterHeading.Trim();
     }
 

--- a/skills-generation/templates/skill-page-template.hbs
+++ b/skills-generation/templates/skill-page-template.hbs
@@ -126,6 +126,55 @@ Try these prompts with GitHub Copilot to activate this skill:
 {{/each}}
 {{/if}}
 
+{{#if hasSubSkills}}
+## Sub-skills
+
+This skill includes the following specialized sub-skills:
+
+{{#each subSkills}}
+### {{{displayName}}}
+
+{{{description}}}
+
+{{#if hasUseFor}}
+**Use when:**
+{{#each useFor}}
+- {{{this}}}
+{{/each}}
+{{/if}}
+
+{{#if hasMcpTools}}
+**MCP tools:**
+
+| Tool | Description |
+|------|-------------|
+{{#each mcpTools}}
+| `{{{toolName}}}` | {{{purpose}}} |
+{{/each}}
+{{/if}}
+
+{{/each}}
+{{/if}}
+
+{{#if hasActivation}}
+## Automatic activation
+
+{{activation.directive}}
+
+{{#if activation.hasDetectionMarkers}}
+This skill automatically activates when your codebase contains any of the following markers:
+
+{{#each activation.detectionMarkers}}
+- `{{{this}}}`
+{{/each}}
+{{/if}}
+{{#if activation.preferOver}}
+
+> [!NOTE]
+> When auto-activation conditions are met, this skill takes priority over **{{{activation.preferOver}}}**.
+{{/if}}
+{{/if}}
+
 ## Related content
 
 - [Azure MCP Server overview](/azure/developer/azure-mcp-server/overview)


### PR DESCRIPTION
## Summary

Implements 4 categories of skills generation improvements based on PR #8712 review feedback.

### Changes

**Category 1: RBAC Role Extraction**
- Added \ExtractRbacRoles()\ to parse structured RBAC sections (tables, bullet lists)
- Added \ExtractInlineRbacRoles()\ for inline role mentions (e.g., \Cost Management Reader\)
- Wired into \BuildPrerequisites()\ to populate prerequisite roles

**Category 2: False Positive Filtering**
- Modified \BuildPrerequisites()\ to cross-reference detected resources against \DoNotUseFor\ list
- Prevents adding resources as prerequisites when the skill explicitly says not to use them

**Category 3: Sub-Skill Traversal**
- Added \FetchSubSkillsAsync()\ and \ListSubdirectoriesAsync()\ to \GitHubSkillFetcher\
- Orchestrator fetches and parses sub-skill SKILL.md files
- Generator adds sub-skills section to template output

**Category 4: Activation/Codebase Detection**
- Added \ExtractActivationTriggers()\ to parser for MANDATORY/PREFER OVER directives
- Detects npm packages, codebase markers, and activation conditions
- Generator surfaces activation behavior in generated pages

### Tests
- 24 new tests across 4 test files (208 total, all passing)
- Zero warnings in Release configuration

Closes #426