### PR TITLE
skills-generation | Fix DO NOT USE FOR delimiter parsing (#443)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/DoNotUseForParsingTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Parsers/DoNotUseForParsingTests.cs
@@ -1,0 +1,253 @@
+using FluentAssertions;
+using SkillsGen.Core.Parsers;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Parsers;
+
+/// <summary>
+/// Tests for GitHub Issue #443: DO NOT USE FOR delimiter parsing.
+/// Verifies that "DO NOT USE FOR:" items in skill descriptions are correctly
+/// separated from "WHEN:" items and routed to DoNotUseFor (not UseFor).
+/// </summary>
+public class DoNotUseForParsingTests
+{
+    private readonly SkillMarkdownParser _parser = new();
+
+    private static string WrapDescription(string name, string description) =>
+        $"---\nname: {name}\ndescription: \"{description}\"\n---\n\nBody content.\n";
+
+    // ==========================================================================
+    // Test 1: DO NOT USE FOR delimiter parsing (Issue #443 core fix)
+    // ==========================================================================
+
+    [Fact]
+    public void Parse_DoNotUseFor_ItemsRouteToDoNotUseForList()
+    {
+        var desc = "Build copilot apps. WHEN: copilot SDK, deploy copilot app. "
+                 + "DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), "
+                 + "Copilot Extensions, Foundry agents (use microsoft-foundry).";
+        var content = WrapDescription("azure-hosted-copilot-sdk", desc);
+
+        var result = _parser.Parse("azure-hosted-copilot-sdk", content);
+
+        // DO NOT USE FOR items must land in DoNotUseFor
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("general web apps", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("Copilot Extensions", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("Foundry agents", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Parse_DoNotUseFor_ItemsDoNotLeakIntoUseFor()
+    {
+        var desc = "Build copilot apps. WHEN: copilot SDK, deploy copilot app. "
+                 + "DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), "
+                 + "Copilot Extensions, Foundry agents (use microsoft-foundry).";
+        var content = WrapDescription("azure-hosted-copilot-sdk", desc);
+
+        var result = _parser.Parse("azure-hosted-copilot-sdk", content);
+
+        // WHEN items must be in UseFor
+        result.UseFor.Should().Contain(item =>
+            item.Contains("copilot SDK", StringComparison.OrdinalIgnoreCase));
+        result.UseFor.Should().Contain(item =>
+            item.Contains("deploy copilot app", StringComparison.OrdinalIgnoreCase));
+
+        // DO NOT USE FOR items must NOT be in UseFor
+        result.UseFor.Should().NotContain(item =>
+            item.Contains("general web apps", StringComparison.OrdinalIgnoreCase));
+        result.UseFor.Should().NotContain(item =>
+            item.Contains("Copilot Extensions", StringComparison.OrdinalIgnoreCase));
+        result.UseFor.Should().NotContain(item =>
+            item.Contains("Foundry agents", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ==========================================================================
+    // Test 2: DON'T USE WHEN regression test
+    // ==========================================================================
+
+    [Fact]
+    public void Parse_DontUseWhen_StillRoutesToDoNotUseFor()
+    {
+        var desc = "Query and analyze data in Azure Data Explorer (Kusto/ADX). "
+                 + "WHEN: KQL queries, Kusto database queries, Azure Data Explorer. "
+                 + "DON'T USE WHEN: real-time streaming, database migrations.";
+        var content = WrapDescription("azure-kusto", desc);
+
+        var result = _parser.Parse("azure-kusto", content);
+
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("real-time streaming", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("database migrations", StringComparison.OrdinalIgnoreCase));
+
+        // WHEN items still parse into UseFor
+        result.UseFor.Should().Contain(item =>
+            item.Contains("KQL queries", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Parse_DontUseWhen_DoesNotRegress_WithNewDoNotUseForSupport()
+    {
+        // Ensure both delimiters can coexist across different skills
+        var descWithDontUseWhen = "Monitor resources. WHEN: analyze logs, KQL. "
+                                + "DON'T USE WHEN: deploying resources.";
+        var descWithDoNotUseFor = "Monitor resources. WHEN: analyze logs, KQL. "
+                                + "DO NOT USE FOR: deploying resources.";
+
+        var result1 = _parser.Parse("azure-monitor",
+            WrapDescription("azure-monitor", descWithDontUseWhen));
+        var result2 = _parser.Parse("azure-monitor",
+            WrapDescription("azure-monitor", descWithDoNotUseFor));
+
+        // Both should route negative items to DoNotUseFor
+        result1.DoNotUseFor.Should().Contain(item =>
+            item.Contains("deploying resources", StringComparison.OrdinalIgnoreCase));
+        result2.DoNotUseFor.Should().Contain(item =>
+            item.Contains("deploying resources", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ==========================================================================
+    // Test 3: Description with BOTH WHEN and DO NOT USE FOR
+    // ==========================================================================
+
+    [Fact]
+    public void Parse_WhenAndDoNotUseFor_CorrectSplit()
+    {
+        var desc = "Some tool. WHEN: query data, analyze logs. "
+                 + "DO NOT USE FOR: real-time streaming, IoT telemetry.";
+        var content = WrapDescription("azure-compute", desc);
+
+        var result = _parser.Parse("azure-compute", content);
+
+        result.UseFor.Should().Contain(item =>
+            item.Contains("query data", StringComparison.OrdinalIgnoreCase));
+        result.UseFor.Should().Contain(item =>
+            item.Contains("analyze logs", StringComparison.OrdinalIgnoreCase));
+
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("real-time streaming", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("IoT telemetry", StringComparison.OrdinalIgnoreCase));
+
+        // Cross-contamination check
+        result.UseFor.Should().NotContain(item =>
+            item.Contains("real-time streaming", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().NotContain(item =>
+            item.Contains("query data", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Parse_AllThreeMarkers_WhenUseForDoNotUseFor()
+    {
+        var desc = "Instrument webapps with Azure Application Insights. "
+                 + "USE FOR: telemetry patterns, SDK setup. "
+                 + "WHEN: how to instrument app, App Insights SDK. "
+                 + "DO NOT USE FOR: non-Azure APM tools, custom logging frameworks.";
+        var content = WrapDescription("appinsights-instrumentation", desc);
+
+        var result = _parser.Parse("appinsights-instrumentation", content);
+
+        // USE FOR and WHEN both merge into UseFor
+        result.UseFor.Should().Contain(item =>
+            item.Contains("telemetry patterns", StringComparison.OrdinalIgnoreCase));
+        result.UseFor.Should().Contain(item =>
+            item.Contains("App Insights SDK", StringComparison.OrdinalIgnoreCase));
+
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("non-Azure APM tools", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("custom logging frameworks", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ==========================================================================
+    // Test 6: Varied service examples (diverse skill names)
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("azure-cost",
+        "Unified Azure cost management. WHEN: Azure costs, cost breakdown. DO NOT USE FOR: deploying resources, provisioning infrastructure.",
+        new[] { "Azure costs", "cost breakdown" },
+        new[] { "deploying resources", "provisioning infrastructure" })]
+    [InlineData("azure-kusto",
+        "Query Azure Data Explorer. WHEN: KQL queries, log analytics. DO NOT USE FOR: real-time dashboards, Grafana setup.",
+        new[] { "KQL queries", "log analytics" },
+        new[] { "real-time dashboards", "Grafana setup" })]
+    [InlineData("azure-compute",
+        "Azure VM management. WHEN: VM sizing, VMSS autoscale. DO NOT USE FOR: container orchestration, serverless functions.",
+        new[] { "VM sizing", "VMSS autoscale" },
+        new[] { "container orchestration", "serverless functions" })]
+    public void Parse_DoNotUseFor_VariedSkills_CorrectRouting(
+        string skillName, string desc, string[] expectedUseFor, string[] expectedDoNotUseFor)
+    {
+        var content = WrapDescription(skillName, desc);
+        var result = _parser.Parse(skillName, content);
+
+        foreach (var expected in expectedUseFor)
+        {
+            result.UseFor.Should().Contain(item =>
+                item.Contains(expected, StringComparison.OrdinalIgnoreCase),
+                because: $"'{expected}' should be in UseFor for {skillName}");
+        }
+
+        foreach (var expected in expectedDoNotUseFor)
+        {
+            result.DoNotUseFor.Should().Contain(item =>
+                item.Contains(expected, StringComparison.OrdinalIgnoreCase),
+                because: $"'{expected}' should be in DoNotUseFor for {skillName}");
+        }
+    }
+
+    // ==========================================================================
+    // Edge cases
+    // ==========================================================================
+
+    [Fact]
+    public void Parse_DoNotUseFor_WithParenthetical_PreservesContext()
+    {
+        // Parenthetical "(use azure-prepare)" should not break parsing
+        var desc = "Deploy apps. WHEN: run azd up, execute deployment. "
+                 + "DO NOT USE FOR: creating new apps (use azure-prepare), setting up infrastructure.";
+        var content = WrapDescription("azure-deploy", desc);
+
+        var result = _parser.Parse("azure-deploy", content);
+
+        result.DoNotUseFor.Should().HaveCountGreaterOrEqualTo(2);
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("creating new apps", StringComparison.OrdinalIgnoreCase));
+        result.DoNotUseFor.Should().Contain(item =>
+            item.Contains("setting up infrastructure", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Parse_NoDoNotUseFor_ReturnsEmptyList()
+    {
+        var desc = "Simple skill. WHEN: do things, manage stuff.";
+        var content = WrapDescription("azure-storage", desc);
+
+        var result = _parser.Parse("azure-storage", content);
+
+        result.DoNotUseFor.Should().BeEmpty();
+        result.UseFor.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Parse_DoNotUseFor_AtEndOfDescription_NoTrailingGarbage()
+    {
+        var desc = "Debug issues. WHEN: troubleshoot AKS, analyze logs. "
+                 + "DO NOT USE FOR: cost optimization, billing queries.";
+        var content = WrapDescription("azure-diagnostics", desc);
+
+        var result = _parser.Parse("azure-diagnostics", content);
+
+        // Items should be clean — no trailing periods or marker fragments
+        foreach (var item in result.DoNotUseFor)
+        {
+            item.Should().NotEndWith(".", because: "trailing periods should be cleaned");
+            item.Should().NotContainAny(["DO NOT USE", "USE FOR", "WHEN:"],
+                because: "marker text should not leak into items");
+        }
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Validation/NegativeInPositiveValidationTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Validation/NegativeInPositiveValidationTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using SkillsGen.Core.Models;
+using SkillsGen.Core.Validation;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Validation;
+
+/// <summary>
+/// Tests for GitHub Issue #443: Detect negative/redirect items that leaked into
+/// the "When to use" section of generated skill pages.
+///
+/// These tests verify NEW validation behavior. They will fail until the
+/// corresponding validation rule is added to SkillPageValidator.
+/// </summary>
+public class NegativeInPositiveValidationTests
+{
+    private readonly SkillPageValidator _validator = new();
+
+    private static SkillData CreateSkillData(string name = "azure-test") => new()
+    {
+        Name = name,
+        DisplayName = name.Replace("-", " "),
+        Description = $"Test skill for {name}."
+    };
+
+    private static string BuildContentWithWhenToUseItems(string skillTitle, params string[] items)
+    {
+        var bulletList = string.Join("\n", items.Select(i => $"- {i}"));
+        return $"""
+            ---
+            title: Azure skill for {skillTitle}
+            description: Test skill for {skillTitle}.
+            ---
+
+            # Azure skill for {skillTitle}
+
+            ## Prerequisites
+
+            - GitHub Copilot with Azure extension
+
+            ### When to use this skill
+
+            Use this skill when you need to:
+
+            {bulletList}
+
+            ## What it provides
+
+            Knowledge about GitHub Copilot and Azure services for managing {skillTitle} resources effectively.
+            """;
+    }
+
+    // ==========================================================================
+    // Test 4: Negative-in-positive validation detection (NEW BEHAVIOR)
+    // These tests verify that SkillPageValidator detects "DO NOT USE FOR" items
+    // that incorrectly ended up in the "When to use" section.
+    // ==========================================================================
+
+    [Fact]
+    public void Validate_WhenToUseContainsRedirectItem_ReturnsWarning()
+    {
+        // "(use azure-prepare)" is a redirect — it should NOT be in "When to use"
+        var content = BuildContentWithWhenToUseItems("Azure Copilot SDK",
+            "Build copilot-powered applications",
+            "Deploy copilot apps to Azure",
+            "general web apps without copilot SDK (use azure-prepare)");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-hosted-copilot-sdk"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().Contain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase),
+            because: "a '(use X)' redirect pattern in 'When to use' indicates a misrouted DO NOT USE FOR item");
+    }
+
+    [Fact]
+    public void Validate_WhenToUseContainsMultipleRedirects_WarnsForEach()
+    {
+        var content = BuildContentWithWhenToUseItems("Azure Deploy",
+            "Run azd up and azd deploy",
+            "general web apps (use azure-prepare)",
+            "Foundry agents (use microsoft-foundry)");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-deploy"),
+            new TriggerData([], [], null));
+
+        // Should detect both redirect items
+        result.Warnings.Should().Contain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_WhenToUseContainsNotForPhrase_ReturnsWarning()
+    {
+        var content = BuildContentWithWhenToUseItems("Azure Compute",
+            "VM sizing and recommendations",
+            "Not for container orchestration",
+            "VMSS autoscale configuration");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-compute"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().Contain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase),
+            because: "'Not for' in a 'When to use' item indicates a misrouted negative item");
+    }
+
+    // ==========================================================================
+    // Test 5: No false positives in validation
+    // ==========================================================================
+
+    [Fact]
+    public void Validate_LegitimateWithoutInCapability_NoFalsePositive()
+    {
+        // "deploy without downtime" is a legitimate use case, not a negative
+        var content = BuildContentWithWhenToUseItems("Azure Deploy",
+            "Deploy without downtime using blue-green deployments",
+            "Push updates to production",
+            "Execute zero-downtime releases");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-deploy"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().NotContain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase),
+            because: "'without' in context of a capability is legitimate, not a redirect");
+    }
+
+    [Fact]
+    public void Validate_NormalPositiveItems_NoFalsePositive()
+    {
+        // Standard "When to use" items should not trigger any warnings
+        var content = BuildContentWithWhenToUseItems("Azure Cost",
+            "Query historical Azure costs",
+            "Forecast future spending trends",
+            "Optimize and reduce cloud waste");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-cost"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().NotContain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_ParenthesisWithoutUseKeyword_NoFalsePositive()
+    {
+        // Parenthetical that is NOT a redirect — "(v2.60.0+)" or "(AKS)"
+        var content = BuildContentWithWhenToUseItems("Azure Kubernetes",
+            "Create AKS clusters (Automatic or Standard SKU)",
+            "Configure networking (Azure CNI Overlay)",
+            "Manage node pools (system and user)");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("azure-kubernetes"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().NotContain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase),
+            because: "parenthetical content without 'use' keyword is not a redirect pattern");
+    }
+
+    [Fact]
+    public void Validate_InsteadKeyword_ReturnsWarning()
+    {
+        var content = BuildContentWithWhenToUseItems("AppInsights",
+            "Instrument webapps with Application Insights",
+            "Copilot Extensions — use azure-ai instead");
+
+        var result = _validator.Validate(content, 1, CreateSkillData("appinsights-instrumentation"),
+            new TriggerData([], [], null));
+
+        result.Warnings.Should().Contain(w =>
+            w.Contains("NEGATIVE_IN_POSITIVE", StringComparison.OrdinalIgnoreCase),
+            because: "'instead' redirect in 'When to use' indicates a misrouted negative item");
+    }
+}

--- a/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
+++ b/skills-generation/SkillsGen.Core/Parsers/SkillMarkdownParser.cs
@@ -30,10 +30,13 @@ public partial class SkillMarkdownParser : ISkillParser
         // Clean the description for display (strip markers, take first 2 sentences)
         var cleanDescription = CleanDescription(decodedDescription);
 
-        var useFor = ExtractListFromDescription(decodedDescription, @"USE\s+FOR:");
-        var whenItems = ExtractListFromDescription(decodedDescription, @"WHEN\s*:");
+        // Extract negative delimiters FIRST to prevent "USE FOR:" inside
+        // "DO NOT USE FOR:" from matching the positive USE FOR pattern
         var doNotUseFor = ExtractListFromDescription(decodedDescription, @"DO\s+NOT\s+USE\s+FOR:");
+        var doNotUseWhen = ExtractListFromDescription(decodedDescription, @"DO\s+NOT\s+USE\s+WHEN\s*:");
         var dontUseWhen = ExtractListFromDescription(decodedDescription, @"DON'?T\s+USE\s+WHEN\s*:");
+        var useFor = ExtractListFromDescription(decodedDescription, @"(?<!NOT\s)USE\s+FOR:");
+        var whenItems = ExtractListFromDescription(decodedDescription, @"WHEN\s*:");
 
         // Merge WHEN items into UseFor — clean up quoted trigger phrases
         foreach (var item in whenItems)
@@ -43,12 +46,19 @@ public partial class SkillMarkdownParser : ISkillParser
                 useFor.Add(cleaned);
         }
 
-        // Merge DON'T USE WHEN into DoNotUseFor
-        foreach (var item in dontUseWhen)
+        // Merge all negative variants (DO NOT USE WHEN, DON'T USE WHEN) into DoNotUseFor
+        foreach (var item in doNotUseWhen.Concat(dontUseWhen))
         {
             var cleaned = item.Trim().Trim('"', '\'', ',', '.');
             if (!string.IsNullOrWhiteSpace(cleaned) && cleaned.Length > 3 && !doNotUseFor.Contains(cleaned))
                 doNotUseFor.Add(cleaned);
+        }
+
+        // Remove any DoNotUseFor items that leaked into UseFor (exact match only)
+        if (doNotUseFor.Count > 0)
+        {
+            useFor.RemoveAll(u => doNotUseFor.Any(d =>
+                string.Equals(u, d, StringComparison.OrdinalIgnoreCase)));
         }
 
         // Also extract from body sections
@@ -125,20 +135,27 @@ public partial class SkillMarkdownParser : ISkillParser
     {
         try
         {
-            var idx = description.IndexOf(marker.Replace(@"\s+", " ").Replace(@"\s*", ""), StringComparison.OrdinalIgnoreCase);
-            if (idx < 0)
+            // Always use regex match for markers that contain lookbehind or other non-literal patterns
+            var markerMatch = Regex.Match(description, marker, RegexOptions.IgnoreCase);
+            if (!markerMatch.Success)
             {
-                // Try regex match
-                var markerMatch = Regex.Match(description, marker, RegexOptions.IgnoreCase);
-                if (!markerMatch.Success) return [];
-                idx = markerMatch.Index;
-                var afterMarker = description[(idx + markerMatch.Length)..].Trim();
-                return ParseCommaSeparatedOrBullets(afterMarker);
+                // Fallback: try literal match with whitespace collapsed
+                var literalMarker = Regex.Replace(marker, @"\(\?\<\![^)]+\)", ""); // strip lookbehind
+                literalMarker = literalMarker.Replace(@"\s+", " ").Replace(@"\s*", "");
+                var idx = description.IndexOf(literalMarker, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0) return [];
+
+                // Verify the literal match isn't preceded by text the lookbehind was guarding against
+                if (marker.Contains("(?<!") && idx >= 4 &&
+                    description[(idx - 4)..idx].Contains("NOT", StringComparison.OrdinalIgnoreCase))
+                    return [];
+
+                var after = description[(idx + literalMarker.Length)..].Trim();
+                return ParseCommaSeparatedOrBullets(after);
             }
 
-            var markerLen = Regex.Match(description[idx..], marker, RegexOptions.IgnoreCase);
-            var after = description[(idx + markerLen.Length)..].Trim();
-            return ParseCommaSeparatedOrBullets(after);
+            var afterMarker = description[(markerMatch.Index + markerMatch.Length)..].Trim();
+            return ParseCommaSeparatedOrBullets(afterMarker);
         }
         catch (RegexParseException)
         {

--- a/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
+++ b/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
@@ -125,6 +125,28 @@ public class SkillPageValidator : ISkillPageValidator
             }
         }
 
+        // NEGATIVE_IN_POSITIVE: Detect redirect/negative items in "When to use" section
+        var whenSectionMatch = Regex.Match(renderedContent,
+            @"(?:^|\n)###?\s*When to use.*?\n(.*?)(?=\n##[^#]|\z)",
+            RegexOptions.Singleline | RegexOptions.IgnoreCase);
+        if (whenSectionMatch.Success)
+        {
+            var whenSection = whenSectionMatch.Groups[1].Value;
+            var bulletItems = Regex.Matches(whenSection, @"^[ \t]*-\s+(.+)$", RegexOptions.Multiline);
+            foreach (Match bullet in bulletItems)
+            {
+                var item = bullet.Groups[1].Value.Trim();
+                // Detect redirect patterns: "(use X)", "(use X instead)", "use X for this"
+                if (Regex.IsMatch(item, @"\(use\s+\S+", RegexOptions.IgnoreCase) ||
+                    Regex.IsMatch(item, @"\binstead\b", RegexOptions.IgnoreCase) ||
+                    Regex.IsMatch(item, @"^Not\s+for\b", RegexOptions.IgnoreCase) ||
+                    Regex.IsMatch(item, @"^Do\s+not\s+use\b", RegexOptions.IgnoreCase))
+                {
+                    warnings.Add($"NEGATIVE_IN_POSITIVE: Item in 'When to use' appears negative/redirect: \"{item}\"");
+                }
+            }
+        }
+
         var sectionCount = Regex.Matches(renderedContent, @"^## ", RegexOptions.Multiline).Count;
 
         return new SkillValidationResult(errors.Count == 0, errors, warnings, wordCount, sectionCount);


### PR DESCRIPTION
## Summary

Fixes parser bug where DO NOT USE FOR items leaked into the UseFor list. The regex \USE\s+FOR:\ matched inside \DO NOT USE FOR:\, causing negative/redirect items to appear in 'When to use' bullets.

### Root Cause

\ExtractListFromDescription()\ used \USE\s+FOR:\ which matched the substring inside \DO NOT USE FOR:\.

### Fix

- Added negative lookbehind: \(?<!NOT\s)USE\s+FOR:\
- Reordered extraction: DO NOT USE FOR extracted first, then USE FOR
- Protected the \IndexOf\ fallback path with equivalent guard

### Validation

Added \NEGATIVE_IN_POSITIVE\ detection to \SkillPageValidator.cs\ — catches redirect patterns in 'When to use' bullets.

### Tests

18 new tests (11 parser + 7 validation). All pass.

Closes #443