### PR TITLE
skills-generation | Example prompts fallback from useFor (#444)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/ExamplePromptsFallbackTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/ExamplePromptsFallbackTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using SkillsGen.Core.Generation;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Generation;
+
+public class ExamplePromptsFallbackTests
+{
+    [Fact]
+    public void GenerateFallbackPrompts_EmptyList_ReturnsEmpty()
+    {
+        var result = SkillPageGenerator.GenerateFallbackPrompts([], "Azure Storage");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GenerateFallbackPrompts_VerbPhrase_ConvertsToHowDoI()
+    {
+        var result = SkillPageGenerator.GenerateFallbackPrompts(
+            ["deploy copilot app", "create storage account"], "Test Skill");
+
+        result.Should().Contain("How do I deploy copilot app?");
+        result.Should().Contain("How do I create storage account?");
+    }
+
+    [Fact]
+    public void GenerateFallbackPrompts_NounPhrase_ConvertsToWorkWith()
+    {
+        var result = SkillPageGenerator.GenerateFallbackPrompts(
+            ["semantic caching", "token metrics"], "AI Gateway");
+
+        result.Should().Contain("How do I work with semantic caching?");
+        result.Should().Contain("How do I work with token metrics?");
+    }
+
+    [Fact]
+    public void GenerateFallbackPrompts_QuestionPassthrough_KeptAsIs()
+    {
+        var result = SkillPageGenerator.GenerateFallbackPrompts(
+            ["How do I configure SSL?"], "Test Skill");
+
+        result.Should().Contain("How do I configure SSL?");
+    }
+
+    [Fact]
+    public void GenerateFallbackPrompts_CapAtMaxPrompts()
+    {
+        var items = Enumerable.Range(1, 20)
+            .Select(i => $"deploy service {i}")
+            .ToList();
+
+        var result = SkillPageGenerator.GenerateFallbackPrompts(items, "Test");
+
+        // MaxExamplePrompts is 10
+        result.Count.Should().BeLessOrEqualTo(10);
+    }
+
+    [Fact]
+    public void ConvertToPrompt_TrailingPeriodStripped()
+    {
+        var result = SkillPageGenerator.ConvertToPrompt("deploy to Azure.", "Test");
+        result.Should().Be("How do I deploy to Azure?");
+    }
+
+    [Fact]
+    public void ConvertToPrompt_MixedCaseVerbRecognized()
+    {
+        var result = SkillPageGenerator.ConvertToPrompt("Monitor resource health", "Test");
+        result.Should().Be("How do I monitor resource health?");
+    }
+
+    [Fact]
+    public void ConvertToPrompt_ExistingQuestion_Preserved()
+    {
+        var result = SkillPageGenerator.ConvertToPrompt("What is the cost?", "Test");
+        result.Should().Be("What is the cost?");
+    }
+}

--- a/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
+++ b/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
@@ -49,9 +49,25 @@ public class SkillPageGenerator : ISkillPageGenerator
         var doNotUseForList = NaturalizeItems(rawDoNotUseFor, skillData.DisplayName);
 
         // Cap example prompts and optionally post-process them
-        var examplePrompts = triggerData.ShouldTrigger.Take(MaxExamplePrompts)
-            .Select(t => triggerProcessor != null ? triggerProcessor(t) : t)
-            .ToList();
+        // When trigger test files are missing, fall back to useFor/WHEN items as prompts
+        List<string> examplePrompts;
+        if (triggerData.ShouldTrigger.Count > 0)
+        {
+            examplePrompts = triggerData.ShouldTrigger.Take(MaxExamplePrompts)
+                .Select(t => triggerProcessor != null ? triggerProcessor(t) : t)
+                .ToList();
+        }
+        else
+        {
+            // Fallback: generate natural-language prompts from UseFor items
+            var fallbackSources = skillData.UseFor.Count > 0
+                ? skillData.UseFor
+                : skillData.Activation?.DetectionMarkers?.Count > 0
+                    ? skillData.Activation.DetectionMarkers
+                    : new List<string>();
+
+            examplePrompts = GenerateFallbackPrompts(fallbackSources, skillData.DisplayName);
+        }
 
         // Build "What it provides" with concrete capabilities from services/tools
         var whatItProvides = BuildWhatItProvides(skillData);
@@ -227,8 +243,45 @@ public class SkillPageGenerator : ISkillPageGenerator
     }
 
     /// <summary>
-    /// Converts raw keyword fragments into natural-language bullet points.
-    /// Groups related short items and adds verb phrases to bare nouns.
+    /// Generates natural-language example prompts from UseFor items when triggers.test.ts is missing.
+    /// </summary>
+    internal static List<string> GenerateFallbackPrompts(List<string> useForItems, string displayName)
+    {
+        if (useForItems.Count == 0) return new List<string>();
+
+        return useForItems
+            .Take(MaxExamplePrompts)
+            .Select(item => ConvertToPrompt(item, displayName))
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Converts a single UseFor item into a natural-language prompt question.
+    /// </summary>
+    internal static string ConvertToPrompt(string item, string displayName)
+    {
+        var trimmed = item.Trim().TrimEnd('.');
+
+        // If it already looks like a question, keep it
+        if (trimmed.EndsWith('?')) return trimmed;
+
+        // If it starts with a verb phrase (e.g., "deploy copilot app"), frame as "How do I..."
+        var verbStarters = new[] { "deploy", "create", "configure", "set up", "manage", "build",
+            "monitor", "diagnose", "troubleshoot", "migrate", "optimize", "analyze", "query",
+            "list", "get", "add", "remove", "update", "delete", "run", "test", "check", "find",
+            "enable", "disable", "connect", "plan", "design", "review", "install", "generate" };
+
+        var lower = trimmed.ToLowerInvariant();
+        foreach (var verb in verbStarters)
+        {
+            if (lower.StartsWith(verb + " ") || lower.StartsWith(verb + ","))
+                return $"How do I {char.ToLower(trimmed[0])}{trimmed[1..]}?";
+        }
+
+        // Noun phrase — frame as "How do I work with..."
+        return $"How do I work with {char.ToLower(trimmed[0])}{trimmed[1..]}?";
+    }
     /// </summary>
     internal static List<string> NaturalizeItems(List<string> items, string skillDisplayName)
     {

--- a/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
+++ b/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
@@ -147,6 +147,30 @@ public class SkillPageValidator : ISkillPageValidator
             }
         }
 
+        // PROMPT_COUNT: Validate example prompts in rendered content
+        var promptSectionMatch = Regex.Match(renderedContent,
+            @"(?:^|\n)###?\s*Example prompts.*?\n(.*?)(?=\n##[^#]|\z)",
+            RegexOptions.Singleline | RegexOptions.IgnoreCase);
+        if (promptSectionMatch.Success)
+        {
+            var promptSection = promptSectionMatch.Groups[1].Value;
+            var promptBullets = Regex.Matches(promptSection, @"^[ \t]*-\s+", RegexOptions.Multiline);
+            if (promptBullets.Count == 0)
+            {
+                errors.Add("PROMPT_COUNT: No example prompts in rendered content");
+            }
+            else if (promptBullets.Count < 5)
+            {
+                warnings.Add($"PROMPT_COUNT: Only {promptBullets.Count} example prompts (recommended minimum: 5)");
+            }
+        }
+
+        // PROMPT_SOURCE: Warn when trigger test file is missing (fallback prompts used)
+        if (triggerData.ShouldTrigger.Count == 0 && skillData.UseFor.Count > 0)
+        {
+            warnings.Add("PROMPT_SOURCE: No triggers.test.ts found; example prompts generated from UseFor items");
+        }
+
         var sectionCount = Regex.Matches(renderedContent, @"^## ", RegexOptions.Multiline).Count;
 
         return new SkillValidationResult(errors.Count == 0, errors, warnings, wordCount, sectionCount);


### PR DESCRIPTION
## Summary

When \	riggers.test.ts\ is missing for a skill, generate example prompts from UseFor/WHEN items instead of leaving the section empty.

### Changes

1. **SkillPageGenerator.cs** — Added:
   - \GenerateFallbackPrompts()\ — converts UseFor items to natural-language questions
   - \ConvertToPrompt()\ — verb phrases → 'How do I ...?', noun phrases → 'How do I work with ...?', existing questions preserved

2. **SkillPageValidator.cs** — Added:
   - \PROMPT_COUNT\ — error if 0 prompts, warning if <5
   - \PROMPT_SOURCE\ — warning when triggers.test.ts missing and fallback used

### Tests

8 new tests in \ExamplePromptsFallbackTests.cs\. All tests pass.

Closes #444