### PR TITLE
skills-generation | Add drift detection between generated and published content (#445)

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Validation/DriftDetectorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Validation/DriftDetectorTests.cs
@@ -1,0 +1,317 @@
+using FluentAssertions;
+using SkillsGen.Core.Models;
+using SkillsGen.Core.Validation;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Validation;
+
+public class DriftDetectorTests
+{
+    private readonly DriftDetector _detector = new();
+
+    private const string GeneratedPath = "/output/azure-storage.md";
+    private const string PublishedUrl = "https://learn.microsoft.com/en-us/azure/developer/azure-skills/skills/azure-storage";
+
+    private static string WrapWithFrontmatter(string body) => $"""
+        ---
+        title: Test
+        description: Test
+        ---
+
+        {body}
+        """;
+
+    #region Missing / Extra Sections
+
+    [Fact]
+    public void DetectDrift_MissingSectionInGenerated_ReturnsErrorItem()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ## What it provides
+
+            Things.
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ## Related tools
+
+            - Azure CLI
+
+            ## What it provides
+
+            Things.
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().Contain(i =>
+            i.Section == "Related tools" &&
+            i.Severity == DriftSeverity.Error &&
+            i.Description.Contains("missing from generated"));
+    }
+
+    [Fact]
+    public void DetectDrift_ExtraSectionInGenerated_ReturnsInfoItem()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ## Sub-skills
+
+            - Sub A
+            - Sub B
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().Contain(i =>
+            i.Section == "Sub-skills" &&
+            i.Severity == DriftSeverity.Info &&
+            i.Category == DriftCategory.ContentPrStale);
+    }
+
+    #endregion
+
+    #region Content Differences
+
+    [Fact]
+    public void DetectDrift_WordCountDifference_TriggersWarning()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## What it provides
+
+            Short.
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## What it provides
+
+            This section contains a much longer description with many words about what the skill provides to users, including detailed information about capabilities, features, integration points, and usage patterns that are documented extensively.
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().Contain(i =>
+            i.Section == "What it provides" &&
+            i.Severity == DriftSeverity.Warning &&
+            i.Description.Contains("Word count"));
+    }
+
+    [Fact]
+    public void DetectDrift_BulletCountDifference_Detected()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## When to use
+
+            - Scenario A
+            - Scenario B
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## When to use
+
+            - Scenario A
+            - Scenario B
+            - Scenario C
+            - Scenario D
+            - Scenario E
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().Contain(i =>
+            i.Section == "When to use" &&
+            i.Description.Contains("Bullet count"));
+    }
+
+    [Fact]
+    public void DetectDrift_TablePresenceAbsence_Detected()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## MCP tools
+
+            - tool-a: Does A
+            - tool-b: Does B
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## MCP tools
+
+            | Tool | Purpose |
+            |------|---------|
+            | tool-a | Does A |
+            | tool-b | Does B |
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().Contain(i =>
+            i.Section == "MCP tools" &&
+            i.Description.Contains("table") &&
+            i.Category == DriftCategory.GenerationBug);
+    }
+
+    #endregion
+
+    #region Empty Content
+
+    [Fact]
+    public void DetectDrift_EmptyGeneratedContent_ReturnsError()
+    {
+        var report = _detector.DetectDrift("azure-storage", "", "## Prerequisites\n\nContent.", GeneratedPath, PublishedUrl);
+
+        report.Items.Should().ContainSingle(i =>
+            i.Severity == DriftSeverity.Error &&
+            i.Category == DriftCategory.GenerationBug &&
+            i.Description.Contains("empty"));
+    }
+
+    [Fact]
+    public void DetectDrift_EmptyPublishedContent_ReturnsInfoItems()
+    {
+        var generated = WrapWithFrontmatter("## Prerequisites\n\n- GitHub Copilot");
+
+        var report = _detector.DetectDrift("azure-storage", generated, "", GeneratedPath, PublishedUrl);
+
+        report.Items.Should().ContainSingle(i =>
+            i.Severity == DriftSeverity.Info &&
+            i.Description.Contains("not yet available"));
+    }
+
+    #endregion
+
+    #region Section Name Normalization
+
+    [Fact]
+    public void DetectDrift_SectionNameNormalization_MatchesVariants()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## When to use
+
+            Use this for storage tasks.
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## When to use this skill
+
+            Use this for storage tasks.
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        // Should NOT report these as missing/extra — they match after normalization
+        report.Items.Should().NotContain(i =>
+            i.Description.Contains("missing from generated") &&
+            i.Section.Contains("When to use", StringComparison.OrdinalIgnoreCase));
+        report.Items.Should().NotContain(i =>
+            i.Description.Contains("not in published") &&
+            i.Section.Contains("When to use", StringComparison.OrdinalIgnoreCase));
+    }
+
+    #endregion
+
+    #region Categorization
+
+    [Fact]
+    public void CategorizeSection_KnownTemplateSection_ReturnsGenerationBug()
+    {
+        DriftDetector.CategorizeSection("Prerequisites").Should().Be(DriftCategory.GenerationBug);
+        DriftDetector.CategorizeSection("When to use this skill").Should().Be(DriftCategory.GenerationBug);
+        DriftDetector.CategorizeSection("What it provides").Should().Be(DriftCategory.GenerationBug);
+        DriftDetector.CategorizeSection("Example prompts").Should().Be(DriftCategory.GenerationBug);
+        DriftDetector.CategorizeSection("Related content").Should().Be(DriftCategory.GenerationBug);
+    }
+
+    [Fact]
+    public void CategorizeSection_UnknownSection_ReturnsSourceDataGap()
+    {
+        DriftDetector.CategorizeSection("Related tools").Should().Be(DriftCategory.SourceDataGap);
+        DriftDetector.CategorizeSection("Decision guidance").Should().Be(DriftCategory.SourceDataGap);
+        DriftDetector.CategorizeSection("Architecture overview").Should().Be(DriftCategory.SourceDataGap);
+    }
+
+    #endregion
+
+    #region Fix Suggestions
+
+    [Fact]
+    public void SuggestFix_MissingKnownSection_SuggestsTemplateCheck()
+    {
+        var fix = DriftDetector.SuggestFix("Prerequisites", "missing-from-generated");
+
+        fix.Should().Contain("template rendering");
+        fix.Should().Contain("Prerequisites");
+    }
+
+    [Fact]
+    public void SuggestFix_MissingUnknownSection_SuggestsSourceAddition()
+    {
+        var fix = DriftDetector.SuggestFix("Decision guidance", "missing-from-generated");
+
+        fix.Should().Contain("SKILL.md");
+        fix.Should().Contain("template support");
+    }
+
+    [Fact]
+    public void DetectDrift_AllItemsHaveSuggestedFix()
+    {
+        var generated = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+            """);
+
+        var published = WrapWithFrontmatter("""
+            ## Prerequisites
+
+            - GitHub Copilot
+            - Azure CLI
+            - Azure subscription
+
+            ## Related tools
+
+            - Azure CLI
+            """);
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.Items.Should().AllSatisfy(item =>
+            item.SuggestedFix.Should().NotBeNullOrWhiteSpace());
+    }
+
+    #endregion
+
+    #region Report Metadata
+
+    [Fact]
+    public void DetectDrift_ReportContainsCorrectMetadata()
+    {
+        var generated = WrapWithFrontmatter("## Prerequisites\n\n- Copilot");
+        var published = WrapWithFrontmatter("## Prerequisites\n\n- Copilot");
+
+        var report = _detector.DetectDrift("azure-storage", generated, published, GeneratedPath, PublishedUrl);
+
+        report.SkillName.Should().Be("azure-storage");
+        report.GeneratedPath.Should().Be(GeneratedPath);
+        report.PublishedUrl.Should().Be(PublishedUrl);
+        report.DetectedAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+}

--- a/skills-generation/SkillsGen.Core/Models/DriftItem.cs
+++ b/skills-generation/SkillsGen.Core/Models/DriftItem.cs
@@ -1,0 +1,19 @@
+namespace SkillsGen.Core.Models;
+
+public enum DriftSeverity { Info, Warning, Error }
+public enum DriftCategory { GenerationBug, SourceDataGap, ContentPrStale }
+
+public record DriftItem(
+    string SkillName,
+    string Section,
+    DriftSeverity Severity,
+    DriftCategory Category,
+    string Description,
+    string? SuggestedFix);
+
+public record DriftReport(
+    string SkillName,
+    string GeneratedPath,
+    string PublishedUrl,
+    List<DriftItem> Items,
+    DateTime DetectedAtUtc);

--- a/skills-generation/SkillsGen.Core/Models/SkillInventoryEntry.cs
+++ b/skills-generation/SkillsGen.Core/Models/SkillInventoryEntry.cs
@@ -1,3 +1,3 @@
 namespace SkillsGen.Core.Models;
 
-public record SkillInventoryEntry(string Name, string DisplayName, string Category);
+public record SkillInventoryEntry(string Name, string DisplayName, string Category, string? Slug = null);

--- a/skills-generation/SkillsGen.Core/Validation/DriftDetector.cs
+++ b/skills-generation/SkillsGen.Core/Validation/DriftDetector.cs
@@ -1,0 +1,240 @@
+using System.Text.RegularExpressions;
+using SkillsGen.Core.Models;
+
+namespace SkillsGen.Core.Validation;
+
+public partial class DriftDetector : IDriftDetector
+{
+    // Sections that the template is expected to produce
+    private static readonly HashSet<string> KnownTemplateSections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "prerequisites",
+        "when to use",
+        "when to use this skill",
+        "mcp tools",
+        "example prompts",
+        "what it provides",
+        "related content",
+    };
+
+    public DriftReport DetectDrift(
+        string skillName,
+        string generatedContent,
+        string publishedContent,
+        string generatedPath,
+        string publishedUrl)
+    {
+        var items = new List<DriftItem>();
+
+        if (string.IsNullOrWhiteSpace(generatedContent))
+        {
+            items.Add(new DriftItem(skillName, "(entire page)", DriftSeverity.Error,
+                DriftCategory.GenerationBug,
+                "Generated content is empty",
+                "Check generator pipeline — no output was produced"));
+            return new DriftReport(skillName, generatedPath, publishedUrl, items, DateTime.UtcNow);
+        }
+
+        if (string.IsNullOrWhiteSpace(publishedContent))
+        {
+            items.Add(new DriftItem(skillName, "(entire page)", DriftSeverity.Info,
+                DriftCategory.ContentPrStale,
+                "Published content is empty or not yet available",
+                "Content PR needs to be created and merged"));
+            return new DriftReport(skillName, generatedPath, publishedUrl, items, DateTime.UtcNow);
+        }
+
+        var generatedSections = ExtractSections(generatedContent);
+        var publishedSections = ExtractSections(publishedContent);
+
+        // 1. Missing sections: published has it, generated doesn't
+        foreach (var (name, _) in publishedSections)
+        {
+            if (!SectionExistsNormalized(generatedSections, name))
+            {
+                items.Add(new DriftItem(skillName, name, DriftSeverity.Error,
+                    CategorizeSection(name),
+                    $"Section '{name}' exists in published but missing from generated",
+                    SuggestFix(name, "missing-from-generated")));
+            }
+        }
+
+        // 2. Extra sections: generated has it, published doesn't
+        foreach (var (name, _) in generatedSections)
+        {
+            if (!SectionExistsNormalized(publishedSections, name))
+            {
+                items.Add(new DriftItem(skillName, name, DriftSeverity.Info,
+                    DriftCategory.ContentPrStale,
+                    $"Section '{name}' exists in generated but not in published",
+                    "Content PR needs update — regenerate and publish"));
+            }
+        }
+
+        // 3. Content differences in shared sections
+        foreach (var (name, genContent) in generatedSections)
+        {
+            var pubContent = FindSectionNormalized(publishedSections, name);
+            if (pubContent is not null)
+            {
+                CompareContent(skillName, name, genContent, pubContent, items);
+            }
+        }
+
+        return new DriftReport(skillName, generatedPath, publishedUrl, items, DateTime.UtcNow);
+    }
+
+    internal static Dictionary<string, string> ExtractSections(string content)
+    {
+        // Strip frontmatter
+        var body = StripFrontmatter(content);
+
+        var sections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var matches = H2Regex().Matches(body);
+
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var sectionName = matches[i].Groups[1].Value.Trim();
+            var startIndex = matches[i].Index + matches[i].Length;
+            var endIndex = i + 1 < matches.Count ? matches[i + 1].Index : body.Length;
+            var sectionContent = body[startIndex..endIndex].Trim();
+            sections[sectionName] = sectionContent;
+        }
+
+        return sections;
+    }
+
+    internal static void CompareContent(
+        string skillName,
+        string sectionName,
+        string generatedContent,
+        string publishedContent,
+        List<DriftItem> items)
+    {
+        // Bullet count comparison
+        var genBullets = CountBullets(generatedContent);
+        var pubBullets = CountBullets(publishedContent);
+        if (pubBullets > genBullets && genBullets >= 0)
+        {
+            var category = pubBullets > genBullets
+                ? DriftCategory.SourceDataGap
+                : DriftCategory.ContentPrStale;
+            items.Add(new DriftItem(skillName, sectionName, DriftSeverity.Warning,
+                category,
+                $"Bullet count differs: generated has {genBullets}, published has {pubBullets}",
+                $"Review source SKILL.md for additional items in '{sectionName}'"));
+        }
+
+        // Table presence comparison
+        var genHasTable = ContainsTable(generatedContent);
+        var pubHasTable = ContainsTable(publishedContent);
+        if (pubHasTable && !genHasTable)
+        {
+            items.Add(new DriftItem(skillName, sectionName, DriftSeverity.Warning,
+                DriftCategory.GenerationBug,
+                $"Published has a table in '{sectionName}' but generated does not",
+                "Check template — may need table rendering support for this section"));
+        }
+        else if (genHasTable && !pubHasTable)
+        {
+            items.Add(new DriftItem(skillName, sectionName, DriftSeverity.Info,
+                DriftCategory.ContentPrStale,
+                $"Generated has a table in '{sectionName}' but published does not",
+                "Content PR needs update — regenerate and publish"));
+        }
+
+        // Word count comparison (>50% delta = Warning)
+        var genWords = CountWords(generatedContent);
+        var pubWords = CountWords(publishedContent);
+        if (genWords > 0 && pubWords > 0)
+        {
+            var maxWords = Math.Max(genWords, pubWords);
+            var minWords = Math.Min(genWords, pubWords);
+            var delta = (double)(maxWords - minWords) / maxWords;
+            if (delta > 0.50)
+            {
+                items.Add(new DriftItem(skillName, sectionName, DriftSeverity.Warning,
+                    DriftCategory.SourceDataGap,
+                    $"Word count differs significantly: generated has {genWords} words, published has {pubWords} words ({delta:P0} delta)",
+                    $"Review content in '{sectionName}' for completeness"));
+            }
+        }
+    }
+
+    internal static DriftCategory CategorizeSection(string sectionName)
+    {
+        var normalized = NormalizeSectionName(sectionName);
+        return KnownTemplateSections.Any(known => NormalizeSectionName(known) == normalized)
+            ? DriftCategory.GenerationBug
+            : DriftCategory.SourceDataGap;
+    }
+
+    internal static string SuggestFix(string sectionName, string driftType)
+    {
+        if (driftType == "missing-from-generated")
+        {
+            var normalized = NormalizeSectionName(sectionName);
+            var isKnown = KnownTemplateSections.Any(known => NormalizeSectionName(known) == normalized);
+            return isKnown
+                ? $"Check template rendering for '{sectionName}' — may be conditional on data that's missing from source SKILL.md"
+                : "Add section to source SKILL.md at microsoft/azure-skills or add template support";
+        }
+
+        return $"Review content differences in '{sectionName}'";
+    }
+
+    private static string NormalizeSectionName(string name)
+    {
+        // Lowercase, strip trailing qualifiers like "this skill"
+        var normalized = name.Trim().ToLowerInvariant();
+        normalized = Regex.Replace(normalized, @"\s+this\s+skill$", "");
+        normalized = Regex.Replace(normalized, @"\s+", " ");
+        return normalized;
+    }
+
+    private static bool SectionExistsNormalized(Dictionary<string, string> sections, string name)
+    {
+        var normalized = NormalizeSectionName(name);
+        return sections.Keys.Any(k => NormalizeSectionName(k) == normalized);
+    }
+
+    private static string? FindSectionNormalized(Dictionary<string, string> sections, string name)
+    {
+        var normalized = NormalizeSectionName(name);
+        var key = sections.Keys.FirstOrDefault(k => NormalizeSectionName(k) == normalized);
+        return key is not null ? sections[key] : null;
+    }
+
+    private static string StripFrontmatter(string content)
+    {
+        return FrontmatterRegex().Replace(content, "").TrimStart();
+    }
+
+    private static int CountBullets(string content)
+    {
+        return BulletRegex().Matches(content).Count;
+    }
+
+    private static bool ContainsTable(string content)
+    {
+        return TableSeparatorRegex().IsMatch(content);
+    }
+
+    private static int CountWords(string text)
+    {
+        var cleaned = Regex.Replace(text, @"[#*|`\[\]\(\)\-]", " ");
+        return cleaned.Split([' ', '\n', '\r', '\t'], StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+
+    [GeneratedRegex(@"^---\s*\n.*?\n---\s*\n?", RegexOptions.Singleline)]
+    private static partial Regex FrontmatterRegex();
+
+    [GeneratedRegex(@"^##\s+(.+)$", RegexOptions.Multiline)]
+    private static partial Regex H2Regex();
+
+    [GeneratedRegex(@"^\s*[-*]\s+", RegexOptions.Multiline)]
+    private static partial Regex BulletRegex();
+
+    [GeneratedRegex(@"\|[-:]+\|", RegexOptions.None)]
+    private static partial Regex TableSeparatorRegex();
+}

--- a/skills-generation/SkillsGen.Core/Validation/IDriftDetector.cs
+++ b/skills-generation/SkillsGen.Core/Validation/IDriftDetector.cs
@@ -1,0 +1,8 @@
+namespace SkillsGen.Core.Validation;
+
+using SkillsGen.Core.Models;
+
+public interface IDriftDetector
+{
+    DriftReport DetectDrift(string skillName, string generatedContent, string publishedContent, string generatedPath, string publishedUrl);
+}

--- a/skills-generation/scripts/detect-drift.ps1
+++ b/skills-generation/scripts/detect-drift.ps1
@@ -1,0 +1,306 @@
+<#
+.SYNOPSIS
+    Detects drift between generated skill pages and published content on learn.microsoft.com.
+
+.DESCRIPTION
+    Fetches published skill pages, compares them section-by-section against generated output,
+    and produces a markdown drift report.
+
+.PARAMETER GeneratedDir
+    Path to the directory containing generated skill page markdown files.
+
+.PARAMETER InventoryPath
+    Path to skills-inventory.json.
+
+.PARAMETER ReportPath
+    Output path for the drift report markdown file. Defaults to ./drift-report.md.
+
+.PARAMETER SkipFetch
+    Use cached published files instead of fetching from learn.microsoft.com.
+#>
+param(
+    [string]$GeneratedDir,
+    [string]$InventoryPath,
+    [string]$ReportPath = "./drift-report.md",
+    [switch]$SkipFetch
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = $PSScriptRoot
+$defaultGenDir = Join-Path (Split-Path $scriptDir -Parent) "generated"
+$defaultInventory = Join-Path (Split-Path $scriptDir -Parent) "data" "skills-inventory.json"
+
+if (-not $GeneratedDir) { $GeneratedDir = $defaultGenDir }
+if (-not $InventoryPath) { $InventoryPath = $defaultInventory }
+
+$cacheDir = Join-Path $scriptDir "published-cache"
+if (-not (Test-Path $cacheDir)) { New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null }
+
+# --- Helpers ---
+
+function Strip-HtmlTags([string]$html) {
+    # Extract content inside <main> if present
+    if ($html -match '(?s)<main[^>]*>(.*?)</main>') {
+        $html = $Matches[1]
+    }
+    # Convert common HTML to markdown-ish text
+    $html = $html -replace '(?s)<script[^>]*>.*?</script>', ''
+    $html = $html -replace '(?s)<style[^>]*>.*?</style>', ''
+    $html = $html -replace '<br\s*/?>', "`n"
+    $html = $html -replace '</p>', "`n`n"
+    $html = $html -replace '</li>', "`n"
+    $html = $html -replace '<li[^>]*>', '- '
+    $html = $html -replace '<h2[^>]*>', '## '
+    $html = $html -replace '</h2>', "`n"
+    $html = $html -replace '<h3[^>]*>', '### '
+    $html = $html -replace '</h3>', "`n"
+    $html = $html -replace '<[^>]+>', ''
+    $html = [System.Web.HttpUtility]::HtmlDecode($html)
+    return $html.Trim()
+}
+
+function Extract-Sections([string]$content) {
+    # Strip frontmatter
+    $content = $content -replace '(?s)^---\s*\n.*?\n---\s*\n?', ''
+    $sections = @{}
+    $pattern = '(?m)^##\s+(.+)$'
+    $matches = [regex]::Matches($content, $pattern)
+    for ($i = 0; $i -lt $matches.Count; $i++) {
+        $name = $matches[$i].Groups[1].Value.Trim()
+        $start = $matches[$i].Index + $matches[$i].Length
+        $end = if ($i + 1 -lt $matches.Count) { $matches[$i + 1].Index } else { $content.Length }
+        $body = $content.Substring($start, $end - $start).Trim()
+        $sections[$name] = $body
+    }
+    return $sections
+}
+
+function Normalize-SectionName([string]$name) {
+    $n = $name.Trim().ToLowerInvariant()
+    $n = $n -replace '\s+this\s+skill$', ''
+    $n = $n -replace '\s+', ' '
+    return $n
+}
+
+function Count-Bullets([string]$text) {
+    return ([regex]::Matches($text, '(?m)^\s*[-*]\s+')).Count
+}
+
+function Count-Words([string]$text) {
+    $cleaned = $text -replace '[#*|`\[\]\(\)\-]', ' '
+    return ($cleaned -split '\s+' | Where-Object { $_ }).Count
+}
+
+function Has-Table([string]$text) {
+    return $text -match '\|[-:]+\|'
+}
+
+# --- Main ---
+
+Add-Type -AssemblyName System.Web
+
+if (-not (Test-Path $InventoryPath)) {
+    Write-Error "Inventory file not found: $InventoryPath"
+    exit 1
+}
+
+$inventory = Get-Content $InventoryPath -Raw | ConvertFrom-Json
+$skills = $inventory.skills
+
+$baseUrl = "https://learn.microsoft.com/en-us/azure/developer/azure-skills/skills"
+$allDriftItems = @()
+$errorCount = 0
+
+foreach ($skill in $skills) {
+    $name = $skill.name
+    $slug = if ($skill.slug) { $skill.slug } else { $name }
+    $publishedUrl = "$baseUrl/$slug"
+
+    Write-Host "Processing: $name (slug: $slug)" -ForegroundColor Cyan
+
+    # Find generated file
+    $genFile = Get-ChildItem -Path $GeneratedDir -Filter "$name.md" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $genFile) {
+        $allDriftItems += [PSCustomObject]@{
+            Skill       = $name
+            Section     = "(entire page)"
+            Severity    = "Error"
+            Category    = "GenerationBug"
+            Description = "Generated file not found for '$name'"
+            Fix         = "Run generator for this skill"
+        }
+        $errorCount++
+        continue
+    }
+
+    $generatedContent = Get-Content $genFile.FullName -Raw
+
+    # Fetch or load cached published content
+    $cacheFile = Join-Path $cacheDir "$slug.md"
+    if ($SkipFetch -and (Test-Path $cacheFile)) {
+        $publishedContent = Get-Content $cacheFile -Raw
+        Write-Host "  Using cached: $cacheFile" -ForegroundColor DarkGray
+    }
+    else {
+        try {
+            $response = Invoke-WebRequest -Uri $publishedUrl -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
+            $publishedContent = Strip-HtmlTags $response.Content
+            Set-Content -Path $cacheFile -Value $publishedContent -Encoding UTF8
+            Write-Host "  Fetched and cached: $publishedUrl" -ForegroundColor Green
+        }
+        catch {
+            Write-Warning "  Failed to fetch $publishedUrl : $_"
+            $allDriftItems += [PSCustomObject]@{
+                Skill       = $name
+                Section     = "(entire page)"
+                Severity    = "Info"
+                Category    = "ContentPrStale"
+                Description = "Could not fetch published page: $publishedUrl"
+                Fix         = "Page may not be published yet"
+            }
+            continue
+        }
+    }
+
+    # Extract and compare sections
+    $genSections = Extract-Sections $generatedContent
+    $pubSections = Extract-Sections $publishedContent
+
+    # Missing from generated
+    foreach ($pubKey in $pubSections.Keys) {
+        $normalized = Normalize-SectionName $pubKey
+        $found = $genSections.Keys | Where-Object { (Normalize-SectionName $_) -eq $normalized }
+        if (-not $found) {
+            $severity = "Error"
+            $category = "GenerationBug"
+            $allDriftItems += [PSCustomObject]@{
+                Skill       = $name
+                Section     = $pubKey
+                Severity    = $severity
+                Category    = $category
+                Description = "Section '$pubKey' in published but missing from generated"
+                Fix         = "Check template or source SKILL.md"
+            }
+            $errorCount++
+        }
+    }
+
+    # Extra in generated
+    foreach ($genKey in $genSections.Keys) {
+        $normalized = Normalize-SectionName $genKey
+        $found = $pubSections.Keys | Where-Object { (Normalize-SectionName $_) -eq $normalized }
+        if (-not $found) {
+            $allDriftItems += [PSCustomObject]@{
+                Skill       = $name
+                Section     = $genKey
+                Severity    = "Info"
+                Category    = "ContentPrStale"
+                Description = "Section '$genKey' in generated but not in published"
+                Fix         = "Content PR needs update"
+            }
+        }
+    }
+
+    # Content differences in shared sections
+    foreach ($genKey in $genSections.Keys) {
+        $normalized = Normalize-SectionName $genKey
+        $pubMatch = $pubSections.Keys | Where-Object { (Normalize-SectionName $_) -eq $normalized } | Select-Object -First 1
+        if ($pubMatch) {
+            $genBody = $genSections[$genKey]
+            $pubBody = $pubSections[$pubMatch]
+
+            $genBullets = Count-Bullets $genBody
+            $pubBullets = Count-Bullets $pubBody
+            if ($pubBullets -gt $genBullets -and $genBullets -ge 0) {
+                $allDriftItems += [PSCustomObject]@{
+                    Skill       = $name
+                    Section     = $genKey
+                    Severity    = "Warning"
+                    Category    = "SourceDataGap"
+                    Description = "Bullet count: generated=$genBullets, published=$pubBullets"
+                    Fix         = "Review source SKILL.md for additional items"
+                }
+            }
+
+            $genTable = Has-Table $genBody
+            $pubTable = Has-Table $pubBody
+            if ($pubTable -and -not $genTable) {
+                $allDriftItems += [PSCustomObject]@{
+                    Skill       = $name
+                    Section     = $genKey
+                    Severity    = "Warning"
+                    Category    = "GenerationBug"
+                    Description = "Published has table, generated does not"
+                    Fix         = "Check template table rendering"
+                }
+            }
+
+            $genWords = Count-Words $genBody
+            $pubWords = Count-Words $pubBody
+            if ($genWords -gt 0 -and $pubWords -gt 0) {
+                $maxW = [Math]::Max($genWords, $pubWords)
+                $minW = [Math]::Min($genWords, $pubWords)
+                $delta = ($maxW - $minW) / $maxW
+                if ($delta -gt 0.50) {
+                    $allDriftItems += [PSCustomObject]@{
+                        Skill       = $name
+                        Section     = $genKey
+                        Severity    = "Warning"
+                        Category    = "SourceDataGap"
+                        Description = "Word count: generated=$genWords, published=$pubWords ($([math]::Round($delta * 100))% delta)"
+                        Fix         = "Review content for completeness"
+                    }
+                }
+            }
+        }
+    }
+}
+
+# --- Generate Report ---
+
+$reportLines = @()
+$reportLines += "# Drift Detection Report"
+$reportLines += ""
+$reportLines += "Generated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss UTC')"
+$reportLines += ""
+
+$errors = ($allDriftItems | Where-Object { $_.Severity -eq "Error" }).Count
+$warnings = ($allDriftItems | Where-Object { $_.Severity -eq "Warning" }).Count
+$infos = ($allDriftItems | Where-Object { $_.Severity -eq "Info" }).Count
+
+$reportLines += "## Summary"
+$reportLines += ""
+$reportLines += "| Severity | Count |"
+$reportLines += "|----------|-------|"
+$reportLines += "| Error    | $errors |"
+$reportLines += "| Warning  | $warnings |"
+$reportLines += "| Info     | $infos |"
+$reportLines += "| **Total** | **$($allDriftItems.Count)** |"
+$reportLines += ""
+
+if ($allDriftItems.Count -gt 0) {
+    $reportLines += "## Details"
+    $reportLines += ""
+    $reportLines += "| Skill | Section | Severity | Category | Description | Fix |"
+    $reportLines += "|-------|---------|----------|----------|-------------|-----|"
+    foreach ($item in $allDriftItems | Sort-Object -Property @{Expression={switch($_.Severity){"Error"{0}"Warning"{1}"Info"{2}}}}) {
+        $reportLines += "| $($item.Skill) | $($item.Section) | $($item.Severity) | $($item.Category) | $($item.Description) | $($item.Fix) |"
+    }
+    $reportLines += ""
+}
+
+if ($allDriftItems.Count -eq 0) {
+    $reportLines += "> No drift detected. Generated content matches published content."
+    $reportLines += ""
+}
+
+$reportContent = $reportLines -join "`n"
+Set-Content -Path $ReportPath -Value $reportContent -Encoding UTF8
+Write-Host ""
+Write-Host "Drift report written to: $ReportPath" -ForegroundColor Green
+Write-Host "  Errors: $errors | Warnings: $warnings | Info: $infos" -ForegroundColor $(if ($errors -gt 0) { "Red" } else { "Green" })
+
+if ($errorCount -gt 0) {
+    exit 1
+}
+exit 0


### PR DESCRIPTION
Implements #445. Adds DriftDetector.cs for section-by-section comparison of generated vs published skill pages, with severity/category classification and fix suggestions.

## Changes
- **DriftDetector.cs** — Section-by-section comparison logic (missing/extra sections, bullet counts, table presence, word count deltas)
- **DriftItem.cs** — Models: DriftItem, DriftReport with DriftSeverity and DriftCategory enums
- **IDriftDetector.cs** — Interface for dependency injection
- **SkillInventoryEntry.cs** — Added optional Slug field for URL resolution
- **skills-inventory.json** — Added slugs for azure-aigateway and appinsights-instrumentation
- **detect-drift.ps1** — Standalone PowerShell script with HTML→markdown conversion, caching, and markdown report output
- **DriftDetectorTests.cs** — 14 unit tests covering all comparison scenarios

## Testing
- 255 tests pass (14 new), 0 warnings in Release build
- Depends on #442 for slug mapping (included inline)