### PR TITLE
fix(skills): pass GITHUB_TOKEN to GitHubSkillFetcher

### DIFF
--- a/skills-generation/SkillsGen.Cli/Program.cs
+++ b/skills-generation/SkillsGen.Cli/Program.cs
@@ -154,7 +154,8 @@ static SkillPipelineOrchestrator BuildOrchestrator(
     // --- Build components ---
     // Fetcher
     ISkillSourceFetcher fetcher = source == "github"
-        ? new GitHubSkillFetcher(new HttpClient(), loggerFactory.CreateLogger<GitHubSkillFetcher>())
+        ? new GitHubSkillFetcher(new HttpClient(), loggerFactory.CreateLogger<GitHubSkillFetcher>(),
+            token: Environment.GetEnvironmentVariable("GITHUB_TOKEN"))
         : new LocalSkillFetcher(sourcePath, loggerFactory.CreateLogger<LocalSkillFetcher>(), testsPath);
 
     // Parsers


### PR DESCRIPTION
## Summary
Fixes GitHub API rate limiting in skills generation CLI by passing GITHUB_TOKEN environment variable to the GitHubSkillFetcher.

**Problem:** Unauthenticated GitHub API calls hit 60 req/hr rate limit, causing skill fetching to fail.
**Fix:** Read GITHUB_TOKEN from environment and pass to fetcher constructor.

## Related work (already on main)
- \50e36a\ — Parser fixes for workflow headings (#6), description markers (#7)
- \