### PR TITLE
fix: Add explicit Encoding.UTF8 to all file write calls in mcp-tools

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner/Services/CriticalFailureRecorder.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/CriticalFailureRecorder.cs
@@ -3,6 +3,7 @@ using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Steps;
 using PipelineRunner.Validation;
+using System.Text;
 
 namespace PipelineRunner.Services;
 
@@ -63,7 +64,7 @@ public static class CriticalFailureRecorder
                     result.ProcessInvocations,
                     result.ValidatorResults);
 
-                File.WriteAllText(filePath, JsonSerializer.Serialize(payload, JsonOptions));
+                File.WriteAllText(filePath, JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8);
                 persisted.Add(new CriticalFailureRecordReference(
                     failure.ArtifactType,
                     failure.ArtifactName,

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -4,6 +4,7 @@ using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using Shared;
+using System.Text;
 
 namespace PipelineRunner.Steps;
 
@@ -410,7 +411,7 @@ public sealed class BootstrapStep : StepDefinition
         {
             var outputPath = Path.Combine(outputDirectory, outputFileName);
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            await File.WriteAllTextAsync(outputPath, result.StandardOutput.Trim(), cancellationToken);
+            await File.WriteAllTextAsync(outputPath, result.StandardOutput.Trim(), Encoding.UTF8, cancellationToken);
         }
 
         return result;
@@ -448,7 +449,7 @@ public sealed class BootstrapStep : StepDefinition
             cancellationToken.ThrowIfCancellationRequested();
             context.Reports.Info($"Fetching {displayName} from {remoteUrl}");
             var content = await SharedHttpClient.GetStringAsync(remoteUrl, cancellationToken);
-            await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+            await File.WriteAllTextAsync(tempPath, content, Encoding.UTF8, cancellationToken);
             context.Reports.Info($"Fetched {displayName} ({content.Length:N0} bytes)");
             return tempPath;
         }
@@ -525,7 +526,7 @@ public sealed class BootstrapStep : StepDefinition
 
             var h2Path = Path.Combine(h2Dir, $"{nsName}.json");
             var json = JsonSerializer.Serialize(headings, new JsonSerializerOptions { WriteIndented = true });
-            await File.WriteAllTextAsync(h2Path, json);
+            await File.WriteAllTextAsync(h2Path, json, Encoding.UTF8);
             totalHeadings += headings.Count;
         }
 

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
@@ -311,7 +311,7 @@ public static class DocumentationGenerator
         // Generate in common-general directory
         var commonGeneralDir = Path.Combine(Path.GetDirectoryName(outputDir) ?? outputDir, "common-general");
         var outputFile = Path.Combine(commonGeneralDir, "common-tools.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         Console.WriteLine($"Generated common tools page: common-general/common-tools.md");
     }
 
@@ -356,7 +356,7 @@ public static class DocumentationGenerator
         // Generate in common-general directory
         var commonGeneralDir = Path.Combine(Path.GetDirectoryName(outputDir) ?? outputDir, "common-general");
         var outputFile = Path.Combine(commonGeneralDir, "index.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         Console.WriteLine($"Generated index page: common-general/index.md");
     }
 
@@ -384,7 +384,7 @@ public static class DocumentationGenerator
         // Generate in common-general directory
         var commonGeneralDir = Path.Combine(Path.GetDirectoryName(outputDir) ?? outputDir, "common-general");
         var outputFile = Path.Combine(commonGeneralDir, "azmcp-commands.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         Console.WriteLine($"Generated commands page: common-general/azmcp-commands.md");
     }
 
@@ -549,7 +549,7 @@ public static class DocumentationGenerator
             var result = await HandlebarsTemplateEngine.ProcessTemplateAsync(templateFile, pageData);
 
             var outputFile = Path.Combine(outputDir, "tool-annotations.md");
-            await File.WriteAllTextAsync(outputFile, result);
+            await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
             Console.WriteLine($"Generated tool annotations summary: tool-annotations.md (in {outputDir})");
         }
         catch (Exception ex)
@@ -715,7 +715,7 @@ public static class DocumentationGenerator
         report.AppendLine("}");
         report.AppendLine("```");
         
-        await File.WriteAllTextAsync(reportPath, report.ToString());
+        await File.WriteAllTextAsync(reportPath, report.ToString(, Encoding.UTF8));
         Console.WriteLine($"\n📋 Generated missing mappings report: {reportPath}");
         Console.WriteLine($"   Found {missingMappings.Count} area(s) without brand mapping or compound word definition");
     }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
@@ -715,7 +715,7 @@ public static class DocumentationGenerator
         report.AppendLine("}");
         report.AppendLine("```");
         
-        await File.WriteAllTextAsync(reportPath, report.ToString(, Encoding.UTF8));
+        await File.WriteAllTextAsync(reportPath, report.ToString(), Encoding.UTF8);
         Console.WriteLine($"\n📋 Generated missing mappings report: {reportPath}");
         Console.WriteLine($"   Found {missingMappings.Count} area(s) without brand mapping or compound word definition");
     }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/AnnotationGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/AnnotationGenerator.cs
@@ -10,6 +10,7 @@ using CSharpGenerator.Models;
 using Shared;
 using TemplateEngine;
 using static CSharpGenerator.Generators.FrontmatterUtility;
+using System.Text;
 
 namespace CSharpGenerator.Generators;
 
@@ -151,7 +152,7 @@ public class AnnotationGenerator
                     data.Version,
                     fileName);
                 var result = frontmatter + templateResult;
-                await File.WriteAllTextAsync(outputFile, result);
+                await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
                 tool.HasAnnotation = true;
             }
             
@@ -224,7 +225,7 @@ public class AnnotationGenerator
 
             var result = await HandlebarsTemplateEngine.ProcessTemplateAsync(templateFile, pageData);
             var outputFile = Path.Combine(outputDir, "tool-annotations.md");
-            await File.WriteAllTextAsync(outputFile, result);
+            await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
             
             LogFileHelper.WriteDebug($"Generated tool annotations summary at {outputFile}");
         }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
@@ -9,6 +9,7 @@ using CSharpGenerator.Models;
 using Shared;
 using TemplateEngine;
 using ToolFamilyCleanup.Services;
+using System.Text;
 
 namespace CSharpGenerator.Generators;
 
@@ -130,7 +131,7 @@ public class PageGenerator
 
             var result = await HandlebarsTemplateEngine.ProcessTemplateAsync(templateFile, areaPageData);
 
-            await File.WriteAllTextAsync(outputFile, result);
+            await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
             LogFileHelper.WriteDebug($"Generated area page: {fileName}");
         }
         catch (Exception ex)
@@ -167,7 +168,7 @@ public class PageGenerator
         var commonGeneralDir = Path.Combine(outputDir, "common-general");
         Directory.CreateDirectory(commonGeneralDir);
         var outputFile = Path.Combine(commonGeneralDir, "common-tools.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         LogFileHelper.WriteDebug("Generated common tools page: common-general/common-tools.md");
     }
 
@@ -194,7 +195,7 @@ public class PageGenerator
         var commonGeneralDir = Path.Combine(outputDir, "common-general");
         Directory.CreateDirectory(commonGeneralDir);
         var outputFile = Path.Combine(commonGeneralDir, "index.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         LogFileHelper.WriteDebug("Generated index page: common-general/index.md");
     }
 
@@ -226,7 +227,7 @@ public class PageGenerator
         var commonGeneralDir = Path.Combine(outputDir, "common-general");
         Directory.CreateDirectory(commonGeneralDir);
         var outputFile = Path.Combine(commonGeneralDir, "azmcp-commands.md");
-        await File.WriteAllTextAsync(outputFile, result);
+        await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
         LogFileHelper.WriteDebug("Generated commands page: common-general/azmcp-commands.md");
     }
 

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
@@ -11,6 +11,7 @@ using Shared;
 using TemplateEngine;
 using ToolFamilyCleanup.Services;
 using static CSharpGenerator.Generators.FrontmatterUtility;
+using System.Text;
 
 namespace CSharpGenerator.Generators;
 
@@ -98,14 +99,15 @@ public class ParameterGenerator
                     data.Version,
                     fileName);
                 var result = frontmatter + templateResult;
-                await File.WriteAllTextAsync(outputFile, result);
+                await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
                 await File.WriteAllTextAsync(
                     manifestOutputFile,
                     JsonSerializer.Serialize(parameterManifest, new JsonSerializerOptions
                     {
                         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                         WriteIndented = true
-                    }));
+                    }),
+                    Encoding.UTF8);
                 tool.HasParameters = true;
             }
             

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Program.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Shared;
 using CSharpGenerator.Models;
 using TemplateEngine;
+using System.Text;
 
 namespace CSharpGenerator;
 
@@ -113,7 +114,7 @@ internal class Program
          }
 
          // Write output
-         await File.WriteAllTextAsync(outputFile, result);
+         await File.WriteAllTextAsync(outputFile, result, Encoding.UTF8);
 
          Console.WriteLine($"Generated: {outputFile}");
          return 0;

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools/Services/RawToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools/Services/RawToolGeneratorService.cs
@@ -79,7 +79,7 @@ public class RawToolGeneratorService
                 var content = GenerateRawToolContent(rawToolData);
 
                 var outputPath = Path.Combine(outputDir, fileName);
-                await File.WriteAllTextAsync(outputPath, content);
+                await File.WriteAllTextAsync(outputPath, content, Encoding.UTF8);
                 
                 generatedCount++;
                 

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings/Program.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using GenerativeAI;
 using Shared;
+using System.Text;
 
 namespace BrandMapperValidator;
 
@@ -360,7 +361,7 @@ internal class Program
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
 
-        await File.WriteAllTextAsync(outputPath, json);
+        await File.WriteAllTextAsync(outputPath, json, Encoding.UTF8);
         Console.WriteLine($"Suggestions saved to: {Path.GetFullPath(outputPath)}");
     }
 }

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser/Serialization/CommandDocumentSerializer.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser/Serialization/CommandDocumentSerializer.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AzmcpCommandParser.Models;
+using System.Text;
 
 namespace AzmcpCommandParser.Serialization;
 
@@ -35,7 +36,7 @@ public static class CommandDocumentSerializer
             Directory.CreateDirectory(dir);
 
         var json = Serialize(document, options);
-        File.WriteAllText(filePath, json);
+        File.WriteAllText(filePath, json, Encoding.UTF8);
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/Program.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -81,7 +82,7 @@ internal static class Program
             try
             {
                 var markdown = await httpClient.GetStringAsync(effectiveUrl);
-                await File.WriteAllTextAsync(localPath, markdown);
+                await File.WriteAllTextAsync(localPath, markdown, Encoding.UTF8);
                 Console.WriteLine($"Saved to:    {localPath}");
             }
             catch (HttpRequestException ex)
@@ -108,7 +109,7 @@ internal static class Program
             {
                 Directory.CreateDirectory(outputDir);
             }
-            await File.WriteAllTextAsync(fullOutputPath, output);
+            await File.WriteAllTextAsync(fullOutputPath, output, Encoding.UTF8);
             Console.WriteLine($"✅ Written to {fullOutputPath}");
         }
         else

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Models;
 using DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Services;
+using System.Text;
 
 namespace DocGeneration.Steps.Bootstrap.ToolMetadataEnricher;
 
@@ -99,7 +100,7 @@ internal static class Program
             }
 
             var outputJson = JsonSerializer.Serialize(enrichedOutput, JsonOptions);
-            await File.WriteAllTextAsync(outputFullPath, outputJson);
+            await File.WriteAllTextAsync(outputFullPath, outputJson, Encoding.UTF8);
 
             var metadata = enrichedOutput.EnrichmentMetadata;
             Console.WriteLine($"Total tools: {metadata.TotalTools}");

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/Program.cs
@@ -255,7 +255,7 @@ internal static class Program
                         + $"\n"
                         + $"To fix: Add this tool to the upstream e2eTestPrompts.md in the microsoft/mcp repo,\n"
                         + $"then re-run E2eTestPromptParser to regenerate parsed.json.\n";
-                    await File.WriteAllTextAsync(errorFilePath, errorContent);
+                    await File.WriteAllTextAsync(errorFilePath, errorContent, Encoding.UTF8);
                 }
             }
 
@@ -292,14 +292,14 @@ internal static class Program
             var inputPromptPath = Path.Combine(outputDir, "example-prompts-prompts", inputPromptFileName);
             var inputContent = ExamplePromptGeneratorStandalone.Utilities.FrontmatterUtility.GenerateInputPromptFrontmatter(
                 tool.Command, version, inputPromptFileName, userPrompt);
-            await File.WriteAllTextAsync(inputPromptPath, inputContent);
+            await File.WriteAllTextAsync(inputPromptPath, inputContent, Encoding.UTF8);
 
             // Save raw AI response (extract just the JSON for clarity)
             var rawOutputFileName = ToolFileNameBuilder.BuildRawOutputFileName(
                 tool.Command, nameContext);
             var rawOutputPath = Path.Combine(outputDir, "example-prompts-raw-output", rawOutputFileName);
             var jsonOnlyContent = ExtractJsonFromResponse(rawResponse);
-            await File.WriteAllTextAsync(rawOutputPath, jsonOnlyContent);
+            await File.WriteAllTextAsync(rawOutputPath, jsonOnlyContent, Encoding.UTF8);
 
             if (promptsResponse == null || promptsResponse.Prompts.Count == 0)
             {
@@ -360,7 +360,7 @@ internal static class Program
                 exampleContent = sb.ToString();
             }
 
-            await File.WriteAllTextAsync(examplePromptPath, exampleContent);
+            await File.WriteAllTextAsync(examplePromptPath, exampleContent, Encoding.UTF8);
             var modeLabel = DeterministicExamplePromptGenerator.IsEligible(tool, hasE2ePrompts) ? "deterministic" : "AI";
             Console.WriteLine($"  ✅ {tool.Command,-50} → {examplePromptFileName} ({modeLabel})");
         }

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/Program.cs
@@ -498,7 +498,7 @@ internal static class Program
     private static async Task WriteValidationFileAsync(string validationDir, string baseName, string content)
     {
         var validationPath = Path.Combine(validationDir, $"{baseName}-validation.md");
-        await File.WriteAllTextAsync(validationPath, content);
+        await File.WriteAllTextAsync(validationPath, content, Encoding.UTF8);
     }
 
     private static void WriteValidationSummary(int totalTools, int validated, int valid, int invalid, int skipped, List<string> invalidTools)

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -9,6 +9,7 @@ using TemplateEngine;
 using Shared;
 using Azure.Mcp.TextTransformation.Models;
 using Azure.Mcp.TextTransformation.Services;
+using System.Text;
 
 namespace HorizontalArticleGenerator.Generators;
 
@@ -48,7 +49,7 @@ public class HorizontalArticleGenerator
             {
                 Console.WriteLine($"{progress} ✗ Failed to parse AI response for {staticData.ServiceBrandName}: {jsonEx.Message}");
                 var errorLog = Path.Combine(outputDir, $"error-{staticData.ServiceIdentifier}-airesponse.txt");
-                await File.WriteAllTextAsync(errorLog, $"Raw AI response:\n{aiResponse}\n\nError: {jsonEx.Message}\n{jsonEx.StackTrace}");
+                await File.WriteAllTextAsync(errorLog, $"Raw AI response:\n{aiResponse}\n\nError: {jsonEx.Message}\n{jsonEx.StackTrace}", Encoding.UTF8);
                 Console.WriteLine($"Raw AI response logged to: {errorLog}");
                 Console.WriteLine();
                 parseFailed = true;
@@ -102,7 +103,7 @@ public class HorizontalArticleGenerator
             Console.WriteLine($"{progress} ✗ Failed for {staticData.ServiceBrandName}: {ex.Message}");
             // Log detailed error
             var errorLog = Path.Combine(outputDir, $"error-{staticData.ServiceIdentifier}.txt");
-            await File.WriteAllTextAsync(errorLog, $"{ex.Message}\n\n{ex.StackTrace}");
+            await File.WriteAllTextAsync(errorLog, $"{ex.Message}\n\n{ex.StackTrace}", Encoding.UTF8);
             Console.WriteLine();
             return false;
         }
@@ -440,7 +441,7 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
 
 {userPrompt}
 """;
-        await File.WriteAllTextAsync(promptFilePath, promptContent);
+        await File.WriteAllTextAsync(promptFilePath, promptContent, Encoding.UTF8);
 
         // Calculate token limit based on tool count
         var maxTokens = CalculateMaxTokens(staticData.Tools.Count);
@@ -640,7 +641,7 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
         var filename = $"horizontal-article-{templateData.ServiceIdentifier}.md";
         var outputPath = Path.Combine(_outputDir, filename);
         
-        await File.WriteAllTextAsync(outputPath, renderedContent);
+        await File.WriteAllTextAsync(outputPath, renderedContent, Encoding.UTF8);
     }
 
 }

--- a/mcp-tools/DocGeneration.Steps.SkillsRelevance/Output/SkillsJsonWriter.cs
+++ b/mcp-tools/DocGeneration.Steps.SkillsRelevance/Output/SkillsJsonWriter.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using SkillsRelevance.Models;
+using System.Text;
 
 namespace SkillsRelevance.Output;
 
@@ -57,7 +58,7 @@ public static class SkillsJsonWriter
         };
 
         var json = JsonSerializer.Serialize(output, JsonOptions);
-        await File.WriteAllTextAsync(filePath, json);
+        await File.WriteAllTextAsync(filePath, json, Encoding.UTF8);
         Console.WriteLine($"  ✅ {fileName} ({relevantSkills.Count} skills, JSON)");
     }
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using ToolFamilyCleanup.Models;
 using System.Text.Json;
 using Shared;
+using System.Text;
 
 namespace ToolFamilyCleanup.Services;
 
@@ -121,7 +122,7 @@ public class CleanupGenerator
                 // Save the prompt
                 var promptFileName = Path.GetFileNameWithoutExtension(fileName) + "-prompt.txt";
                 var promptPath = Path.Combine(promptsDir, promptFileName);
-                await File.WriteAllTextAsync(promptPath, $"SYSTEM PROMPT:\n{_systemPrompt}\n\n---\n\nUSER PROMPT:\n{userPrompt}");
+                await File.WriteAllTextAsync(promptPath, $"SYSTEM PROMPT:\n{_systemPrompt}\n\n---\n\nUSER PROMPT:\n{userPrompt}", Encoding.UTF8);
                 
                 // Call LLM to get cleaned markdown (using dynamic max tokens)
                 string cleanedMarkdown;
@@ -146,7 +147,8 @@ public class CleanupGenerator
                         $"1. Check if tool count was detected (should show in console)\n" +
                         $"2. Increase MIN_MAX_TOKENS in CleanupGenerator.cs (currently {MIN_MAX_TOKENS})\n" +
                         $"3. Increase tokens per tool (currently 1000 per tool)\n" +
-                        $"4. Reduce prompt sizes if they exceed 2000 words\n");
+                        $"4. Reduce prompt sizes if they exceed 2000 words\n",
+                        Encoding.UTF8);
                     
                     failCount++;
                     continue;
@@ -158,7 +160,7 @@ public class CleanupGenerator
                     Console.WriteLine($"{progress} ⚠ Warning: LLM output may not be valid markdown for {fileName}");
                     // Log the invalid output
                     var errorPath = Path.Combine(cleanupDir, Path.GetFileNameWithoutExtension(fileName) + "-error.txt");
-                    await File.WriteAllTextAsync(errorPath, $"Invalid markdown output:\n\n{cleanedMarkdown}");
+                    await File.WriteAllTextAsync(errorPath, $"Invalid markdown output:\n\n{cleanedMarkdown}", Encoding.UTF8);
                     failCount++;
                     continue;
                 }
@@ -169,7 +171,7 @@ public class CleanupGenerator
                 
                 // Save cleaned markdown
                 var outputPath = Path.Combine(cleanupDir, fileName);
-                await File.WriteAllTextAsync(outputPath, extractedMarkdown);
+                await File.WriteAllTextAsync(outputPath, extractedMarkdown, Encoding.UTF8);
                 
                 Console.WriteLine($"{progress} ✓ Successfully cleaned {fileName}");
                 successCount++;
@@ -498,7 +500,7 @@ public class CleanupGenerator
                 
                 // Save metadata
                 var metadataPath = Path.Combine(metadataDir, $"{outputFileName}-metadata.md");
-                await File.WriteAllTextAsync(metadataPath, metadata);
+                await File.WriteAllTextAsync(metadataPath, metadata, Encoding.UTF8);
 
                 // Phase 3: Generate related content (deterministic — no AI call, #163)
                 Console.Write($"{progress}   Phase 3: Generating related content... ");
@@ -507,7 +509,7 @@ public class CleanupGenerator
                 
                 // Save related content
                 var relatedPath = Path.Combine(relatedDir, $"{outputFileName}-related.md");
-                await File.WriteAllTextAsync(relatedPath, relatedContent);
+                await File.WriteAllTextAsync(relatedPath, relatedContent, Encoding.UTF8);
                 Console.WriteLine($"✓ (deterministic)");
 
                 // Phase 3.5: Pre-stitch H2 count validation

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -222,6 +222,6 @@ public class FamilyFileStitcher
     public async Task StitchAndSaveAsync(FamilyContent familyContent, string outputPath)
     {
         var markdown = Stitch(familyContent);
-        await File.WriteAllTextAsync(outputPath, markdown);
+        await File.WriteAllTextAsync(outputPath, markdown, Encoding.UTF8);
     }
 }

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Composition/Services/ComposedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Composition/Services/ComposedToolGeneratorService.cs
@@ -163,7 +163,7 @@ public class ComposedToolGeneratorService
 
                 // Write composed file
                 var outputPath = Path.Combine(outputDir, fileName);
-                await File.WriteAllTextAsync(outputPath, composedContent);
+                await File.WriteAllTextAsync(outputPath, composedContent, Encoding.UTF8);
                 
                 successCount++;
                 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
@@ -5,6 +5,7 @@ using GenerativeAI;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ToolGeneration_Improved.Models;
+using System.Text;
 
 namespace ToolGeneration_Improved.Services;
 
@@ -178,7 +179,7 @@ public class ImprovedToolGeneratorService
 
                 // Save improved content
                 var outputPath = Path.Combine(outputDir, fileName);
-                await File.WriteAllTextAsync(outputPath, restoredContent);
+                await File.WriteAllTextAsync(outputPath, restoredContent, Encoding.UTF8);
 
                 successCount++;
                 Console.WriteLine(" ✓");
@@ -193,7 +194,7 @@ public class ImprovedToolGeneratorService
                 {
                     var originalContent = await File.ReadAllTextAsync(composedFilePath);
                     var outputPath = Path.Combine(outputDir, fileName);
-                    await File.WriteAllTextAsync(outputPath, originalContent);
+                    await File.WriteAllTextAsync(outputPath, originalContent, Encoding.UTF8);
                     skippedCount++;
                 }
                 catch (Exception saveEx)

--- a/mcp-tools/DocGeneration.Tools.Fingerprint/Program.cs
+++ b/mcp-tools/DocGeneration.Tools.Fingerprint/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text;
 
 namespace DocGeneration.Tools.Fingerprint;
 
@@ -75,7 +76,7 @@ internal static class Program
 
         outputPath ??= Path.Combine(repoRoot, "fingerprint-baseline.json");
         var json = JsonSerializer.Serialize(snapshot, JsonOptions);
-        File.WriteAllText(outputPath, json);
+        File.WriteAllText(outputPath, json, Encoding.UTF8);
 
         Console.WriteLine($"✅ Snapshot saved to: {outputPath}");
         Console.WriteLine($"   Namespaces: {snapshot.Namespaces.Count}");
@@ -142,7 +143,7 @@ internal static class Program
 
         if (outputPath is not null)
         {
-            File.WriteAllText(outputPath, report);
+            File.WriteAllText(outputPath, report, Encoding.UTF8);
             Console.WriteLine($"✅ Diff report saved to: {outputPath}");
         }
         else

--- a/mcp-tools/DocGeneration.Tools.PostProcessVerifier/Program.cs
+++ b/mcp-tools/DocGeneration.Tools.PostProcessVerifier/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using ToolFamilyCleanup.Services;
+using System.Text;
 
 namespace DocGeneration.Tools.PostProcessVerifier;
 
@@ -141,7 +142,7 @@ internal static class Program
 
             // Write .after file (never overwrite original)
             var afterPath = filePath + ".after";
-            File.WriteAllText(afterPath, current);
+            File.WriteAllText(afterPath, current, Encoding.UTF8);
             Console.WriteLine($"  Written:  {Path.GetFileName(afterPath)}");
         }
         else

--- a/mcp-tools/DocGeneration.Utilities.ToolMetadataExtractor/Program.cs
+++ b/mcp-tools/DocGeneration.Utilities.ToolMetadataExtractor/Program.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using ToolMetadataExtractor.Services;
+using System.Text;
 
 namespace ToolMetadataExtractor;
 
@@ -85,7 +86,7 @@ internal class Program
                     
                     if (outputFile != null)
                     {
-                        await File.WriteAllTextAsync(outputFile.FullName, json);
+                        await File.WriteAllTextAsync(outputFile.FullName, json, Encoding.UTF8);
                         logger.LogInformation("Metadata written to {OutputFile}", outputFile.FullName);
                     }
                     else


### PR DESCRIPTION
## Summary

Adds explicit `Encoding.UTF8` parameter to all `File.WriteAllText` and `File.WriteAllTextAsync` calls in `mcp-tools/` that previously relied on the .NET default encoding.

## Motivation

While .NET defaults to UTF-8 for `WriteAllText`, relying on implicit defaults is fragile. Explicit encoding:
- Prevents encoding corruption across different runtime configurations
- Makes the encoding intent clear in code review
- Follows defensive coding practices for a documentation generation pipeline where output correctness is critical

## Changes

- **23 files modified** across the `mcp-tools/` directory
- Added `Encoding.UTF8` parameter to approximately 50 `WriteAllText`/`WriteAllTextAsync` calls
- Added `using System.Text;` directive to 17 files that did not already have it
- **No logic changes** -- encoding parameter additions only

## Files already correct (not modified)

These files already had explicit `Encoding.UTF8` and were verified unchanged:
- `SkillsMarkdownWriter.cs` (lines 106, 137)
- `HtmlReporter.cs` (line 16)
- `MarkdownReporter.cs` (line 16)

## Testing

This is a surgical encoding-only change. The `Encoding.UTF8` parameter matches .NET's existing default behavior, so no functional change is expected. Verified:
- No double-encoding on any call
- No `Encoding.UTF8` accidentally placed inside string literals or wrong function calls
- All `using System.Text;` directives placed correctly in the import block