### PR TITLE
Fix #479: Count @mcpcli markers instead of H2s for integrity check

### DIFF
--- a/docs/prds/prd-479-integrity-check-count.md
+++ b/docs/prds/prd-479-integrity-check-count.md
@@ -1,0 +1,62 @@
+# PRD: Fix tool count integrity check (Issue #479)
+
+## Problem
+
+During beta.5 content generation, Step 4 failed for 3 namespaces (azurebackup,
+compute, storage) with "tool count integrity check" errors. The validator
+reported missing tools even though all tools were present in the generated
+output.
+
+## Root cause
+
+The validator counted H2 (`##`) headings in the tool-family article and compared
+that count to the number of tool files on disk. In the Azure MCP Server content
+model, **every tool is an H2 section** — but the article also contains non-tool
+H2 sections such as `## Related content`. These structural headings inflate the
+H2 count above the actual tool count, causing a false mismatch.
+
+For example, the `compute` tool-family article has 12 tools but 13 H2 headings
+because of the trailing `## Related content` section. The old validator saw
+13 ≠ 12 and flagged it as a failure.
+
+### What was NOT the problem
+
+The original issue text described the structure as "H2 category headings with H3
+tool sections underneath." That description was incorrect. Baseline files confirm
+that tools are always H2 headings — there is no H2-category / H3-tool nesting in
+the generated content. The mismatch was caused by non-tool H2s, not by a
+heading-level discrepancy.
+
+## Fix
+
+Replace the H2-heading count with a count of `<!-- @mcpcli ... -->` HTML comment
+markers. Each tool section contains exactly one `@mcpcli` marker, making it a
+reliable 1:1 proxy for the true tool count. Non-tool sections like
+`## Related content` do not contain these markers and are correctly excluded.
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `ToolFamilyPostAssemblyValidator.cs` | Compare `toolFileCount` against `mcpMarkerCount` (count of `@mcpcli` markers) instead of `articleSectionCount` (count of H2 headings). |
+| `ToolFamilyPostAssemblyValidator.cs` | Loosen `McpCliRegex` to allow optional leading whitespace (`^\s*<!--`). |
+| `ToolFamilyPostAssemblyValidatorTests.cs` | Add two tests: one for an article with a `## Related content` section that previously caused a false failure, and one confirming correct marker-count validation. |
+
+### Validation evidence
+
+| Namespace | H2 headings | @mcpcli markers | tool_count (frontmatter) | Tool files |
+|-----------|-------------|-----------------|--------------------------|------------|
+| azurebackup | 17 | 16 | 16 | 16 ✅ |
+| compute | 13 | 12 | 12 | 12 ✅ |
+| storage | 8 | 7 | 7 | 7 ✅ |
+
+In every case, the `@mcpcli` marker count matches both the frontmatter
+`tool_count` and the number of individual tool files on disk.
+
+## Status
+
+- [x] Code change implemented
+- [x] Unit tests added
+- [x] PRD rationale corrected (non-tool H2s, not H3 nesting)
+- [ ] PR merged
+- [ ] Published articles validated post-merge

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -343,6 +343,129 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_GroupedArticleWithH2CategoriesAndH3Tools_CountsMarkers()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-delete.md"), "compute delete");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), GroupedArticleWithCategories());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            if (!result.Success)
+            {
+                var warnings = string.Join("\n", result.Warnings);
+                throw new Exception($"Validation failed with warnings:\n{warnings}");
+            }
+
+            Assert.True(result.Success);
+            Assert.Empty(result.Warnings);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_GroupedArticleWithCorrectMarkerCount_PassesValidation()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), GroupedArticleWithCorrectCount());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            if (!result.Success)
+            {
+                var warnings = string.Join("\n", result.Warnings);
+                throw new Exception($"Validation failed with warnings:\n{warnings}");
+            }
+
+            Assert.True(result.Success);
+            Assert.Empty(result.Warnings);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static string GroupedArticleWithCategories()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 3
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List all virtual machines
+        | Parameter | Required |
+        | --- | --- |
+        | subscription | No |
+
+        ## Show virtual machine
+        <!-- @mcpcli compute show -->
+        Example prompts include:
+        - Show the VM named 'vm-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+
+        ## Delete virtual machine
+        <!-- @mcpcli compute delete -->
+        Example prompts include:
+        - Delete the VM named 'vm-test'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string GroupedArticleWithCorrectCount()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 2
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List all virtual machines
+        | Parameter | Required |
+        | --- | --- |
+        | subscription | No |
+
+        ## Show virtual machine
+        <!-- @mcpcli compute show -->
+        Example prompts include:
+        - Show the VM named 'vm-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+
+        ## Related content
+        - Link
+        """;
+
+    [Fact]
     public async Task ValidateAsync_MissingToolFromArticle_ListsToolNameInError()
     {
         var testRoot = CreateTestRoot();

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -13,7 +13,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
     private static readonly Regex FrontmatterRegex = new(@"^---\s*\n(.*?)\n---\s*\n?", RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex HeadingRegex = new(@"(?m)^##\s+(.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex McpCliRegex = new(@"(?m)^<!--\s*@mcpcli\s+(.+?)\s*-->$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex McpCliRegex = new(@"(?m)^\s*<!--\s*@mcpcli\s+(.+?)\s*-->$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly BrandingRule[] BrandingRules =
     [
@@ -78,12 +78,15 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                 var toolFileLookup = GroupByToolKey(toolFiles);
                 var sectionLookup = GroupByToolKey(sections);
 
-                if (toolFileCount != articleSectionCount || frontmatterToolCount is null || frontmatterToolCount != toolFileCount)
+                var normalized = articleContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+                var mcpMarkerCount = McpCliRegex.Matches(normalized).Count;
+
+                if (toolFileCount != mcpMarkerCount || frontmatterToolCount is null || frontmatterToolCount != toolFileCount)
                 {
                     var details = new List<string>();
-                    if (toolFileCount != articleSectionCount)
+                    if (toolFileCount != mcpMarkerCount)
                     {
-                        details.Add($"tool files: {toolFileCount}, article sections: {articleSectionCount}");
+                        details.Add($"tool files: {toolFileCount}, @mcpcli markers: {mcpMarkerCount}");
                     }
                     if (frontmatterToolCount is null)
                     {


### PR DESCRIPTION
## Problem
The post-assembly integrity check counts ALL H2 headings, but non-tool H2s like '## Related content' inflate the count, causing false validation failures.

## Root Cause
Tools are H2 headings. But so are structural sections like 'Related content'. The validator compared tool file count against total H2 count — which doesn't match.

Note: The original issue incorrectly described the problem as 'H2 categories with H3 tools' — investigation confirmed tools are always H2s in both baselines and published articles.

## Fix
Count @mcpcli markers (the authoritative tool identifier) instead of H2 headings.

Closes #479