### PR TITLE
feat: Phase 0 - MetadataConstants + clock injection

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DeterministicFrontmatterGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DeterministicFrontmatterGeneratorTests.cs
@@ -8,6 +8,9 @@ namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
 
 public class DeterministicFrontmatterGeneratorTests
 {
+    private static readonly DateTime FixedDate = new DateTime(2025, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+    private static Func<DateTime> FixedClock => () => FixedDate;
+
     private const string TestBrandName = "Azure Storage";
     private const string TestSeoDescription = "Use Azure MCP Server tools to manage Azure Storage resources such as storage accounts, blob containers, blobs, and tables with natural language prompts from your IDE.";
     private const int TestToolCount = 7;
@@ -18,7 +21,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_ReturnsValidYamlFrontmatter()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.StartsWith("---\n", result.Replace("\r\n", "\n"));
@@ -28,7 +32,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_TitleContainsBrandName()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains($"title: Azure MCP Server tools for {TestBrandName}", result);
@@ -37,7 +42,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_UsesProvidedSeoDescription()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains($"description: {TestSeoDescription}", result);
@@ -46,7 +52,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_FallsBackToGenericDescription_WhenSeoDescriptionNull()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, seoDescription: null);
 
         Assert.Contains($"description: Use Azure MCP Server tools to manage {TestBrandName} resources with natural language prompts from your IDE.", result);
@@ -55,7 +62,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_CorrectToolCount()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains($"tool_count: {TestToolCount}", result);
@@ -64,7 +72,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_CorrectCliVersion()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains($"mcp-cli.version: {TestCliVersion}", result);
@@ -73,7 +82,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_AlwaysSetsServiceField()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains("ms.service: azure-mcp-server", result);
@@ -82,7 +92,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_AlwaysSetsTopicField()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains("ms.topic: concept-article", result);
@@ -91,7 +102,8 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_H1MatchesTitle()
     {
-        var result = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Contains($"# Azure MCP Server tools for {TestBrandName}", result);
@@ -100,9 +112,10 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_DifferentBrandNames_ProduceDifferentOutput()
     {
-        var storage = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var storage = generator.Generate(
             "Azure Storage", 7, TestCliVersion, "Storage desc.");
-        var keyvault = DeterministicFrontmatterGenerator.Generate(
+        var keyvault = generator.Generate(
             "Azure Key Vault", 5, TestCliVersion, "Key Vault desc.");
 
         Assert.Contains("Azure Storage", storage);
@@ -115,9 +128,10 @@ public class DeterministicFrontmatterGeneratorTests
     [Fact]
     public void Generate_SameInput_SameOutput()
     {
-        var result1 = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result1 = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
-        var result2 = DeterministicFrontmatterGenerator.Generate(
+        var result2 = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
         Assert.Equal(result1, result2);
@@ -145,7 +159,8 @@ Azure Storage is a scalable, fully managed cloud storage platform; for more info
 
 [!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]";
 
-        var intros = DeterministicFrontmatterGenerator.ExtractIntroParagraphs(aiMetadata);
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var intros = generator.ExtractIntroParagraphs(aiMetadata);
 
         Assert.Contains("The Azure MCP Server lets you manage Azure Storage resources", intros);
         Assert.Contains("Azure Storage is a scalable", intros);
@@ -167,7 +182,8 @@ First paragraph.
 
 Second paragraph.";
 
-        var intros = DeterministicFrontmatterGenerator.ExtractIntroParagraphs(aiMetadata);
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var intros = generator.ExtractIntroParagraphs(aiMetadata);
 
         Assert.Contains("First paragraph.", intros);
         Assert.Contains("Second paragraph.", intros);
@@ -184,7 +200,8 @@ title: Test
 
 [!INCLUDE [tip](../includes/tools/parameter-consideration.md)]";
 
-        var intros = DeterministicFrontmatterGenerator.ExtractIntroParagraphs(aiMetadata);
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var intros = generator.ExtractIntroParagraphs(aiMetadata);
 
         Assert.Equal(string.Empty, intros);
     }
@@ -194,11 +211,12 @@ title: Test
     [Fact]
     public void Assemble_CombinesFrontmatterIntrosAndInclude()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
         var intros = "First paragraph.\n\nSecond paragraph.";
 
-        var result = DeterministicFrontmatterGenerator.Assemble(header, intros);
+        var result = generator.Assemble(header, intros);
 
         // Verify order: frontmatter → H1 → intros → INCLUDE
         var normalized = result.Replace("\r\n", "\n");
@@ -213,10 +231,11 @@ title: Test
     [Fact]
     public void Assemble_IncludesParameterTipInclude()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
-        var result = DeterministicFrontmatterGenerator.Assemble(header, "Some intro.");
+        var result = generator.Assemble(header, "Some intro.");
 
         Assert.Contains("[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]", result);
     }
@@ -224,13 +243,83 @@ title: Test
     [Fact]
     public void Assemble_HandlesEmptyIntros()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
 
-        var result = DeterministicFrontmatterGenerator.Assemble(header, string.Empty);
+        var result = generator.Assemble(header, string.Empty);
 
         Assert.Contains("# Azure MCP Server tools for", result);
         Assert.Contains("[!INCLUDE", result);
+    }
+
+    // ── Phase 0: Clock injection tests ──────────────────────────────
+
+    [Fact]
+    public void Generate_CustomClock_ProducesExpectedDate()
+    {
+        var customDate = new DateTime(2026, 12, 25, 14, 30, 0, DateTimeKind.Utc);
+        var customClock = () => customDate;
+
+        var generator = new DeterministicFrontmatterGenerator(customClock);
+        var result = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+
+        Assert.Contains("ms.date: 12/25/2026", result);
+    }
+
+    [Fact]
+    public void Generate_FixedClock_ProducesDeterministicOutput()
+    {
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result1 = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+        var result2 = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+
+        // With fixed clock, output should be identical byte-for-byte
+        Assert.Equal(result1, result2);
+        Assert.Contains("ms.date: 03/15/2025", result1);
+    }
+
+    [Fact]
+    public void Generate_DefaultClock_UsesTodaysDate()
+    {
+        var generator = new DeterministicFrontmatterGenerator(); // No clock provided
+        var result = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+
+        var expectedDate = DateTime.UtcNow.ToString("MM/dd/yyyy");
+        Assert.Contains($"ms.date: {expectedDate}", result);
+    }
+
+    [Fact]
+    public void Generate_UsesMetadataConstants()
+    {
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var result = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+
+        // Verify constants from MetadataConstants are used
+        Assert.Contains($"ms.service: {MetadataConstants.MsService}", result);
+        Assert.Contains($"ms.topic: {MetadataConstants.MsTopic}", result);
+        Assert.Contains($"{MetadataConstants.ProductName} tools for", result);
+    }
+
+    [Fact]
+    public void GenerateWithDefaults_WorksWithoutInstantiation()
+    {
+        var result = DeterministicFrontmatterGenerator.GenerateWithDefaults(
+            TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+
+        Assert.Contains("title: Azure MCP Server tools for", result);
+        Assert.Contains("ms.date:", result);
+        Assert.Matches(@"ms\.date: \d{2}/\d{2}/\d{4}", result);
+    }
+
+    [Fact]
+    public void Assemble_UsesMetadataConstants_ForInclude()
+    {
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(TestBrandName, TestToolCount, TestCliVersion, TestSeoDescription);
+        var result = generator.Assemble(header, "Test intro.");
+
+        Assert.Contains(MetadataConstants.IncludeParameterConsideration, result);
     }
 
     // ── Integration: production service-doc-links.json ──────────────

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterEnricherTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterEnricherTests.cs
@@ -10,9 +10,13 @@ namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
 /// Tests for FrontmatterEnricher to ensure required Microsoft Learn frontmatter
 /// fields are injected into tool-family articles.
 /// Fixes: #155 — generated articles missing required frontmatter fields.
+/// Phase 0: Updated to test instance-based API with clock injection.
 /// </summary>
 public class FrontmatterEnricherTests
 {
+    private static readonly DateTime FixedDate = new DateTime(2025, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+    private static Func<DateTime> FixedClock => () => FixedDate;
+
     // ── Core injection behavior ─────────────────────────────────────
 
     [Fact]
@@ -28,7 +32,8 @@ tool_count: 5
 
 # Azure MCP Server tools for Azure Storage";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         Assert.Contains("author: diberry", result);
         Assert.Contains("ms.author: diberry", result);
@@ -54,7 +59,8 @@ mcp-cli.version: 2.0.0-beta.31
 
 # Azure MCP Server tools for Key Vault";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         // All original fields should be preserved
         Assert.Contains("title: Azure MCP Server tools for Key Vault", result);
@@ -83,7 +89,8 @@ ms.custom: build-2025
 
 # Azure MCP Server tools for Monitor";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         // Count author fields — should be exactly 1
         var authorCount = CountOccurrences(result, "author: diberry");
@@ -104,10 +111,13 @@ ms.service: azure-mcp-server
 
 # Azure MCP Server tools for SQL";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         // ms.date should be in MM/DD/YYYY format
         Assert.Matches(@"ms\.date: \d{2}/\d{2}/\d{4}", result);
+        // With fixed clock, should be exactly the fixed date
+        Assert.Contains("ms.date: 03/15/2025", result);
     }
 
     [Fact]
@@ -126,7 +136,8 @@ The Azure MCP Server lets you manage Cosmos DB accounts.
 
 List all Cosmos DB accounts.";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         // Body content should be completely untouched
         Assert.Contains("The Azure MCP Server lets you manage Cosmos DB accounts.", result);
@@ -149,7 +160,8 @@ tool_count: 5
 
 # Azure MCP Server tools for Azure Storage";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         Assert.Contains("ms.reviewer: mbaldwin", result);
     }
@@ -165,7 +177,8 @@ ms.service: azure-mcp-server
 
 # Azure MCP Server tools for Key Vault";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         var count = CountOccurrences(result, "ms.reviewer: mbaldwin");
         Assert.Equal(1, count);
@@ -183,7 +196,8 @@ ms.service: azure-mcp-server
 
 Some body content.";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
         var normalized = result.Replace("\r\n", "\n");
 
         // Extract frontmatter block
@@ -201,7 +215,8 @@ Some body content.";
     {
         var markdown = "# Just a heading\n\nSome content.";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         Assert.Equal(markdown, result);
     }
@@ -209,8 +224,9 @@ Some body content.";
     [Fact]
     public void Enrich_NullOrEmpty_ReturnsInput()
     {
-        Assert.Equal("", FrontmatterEnricher.Enrich(""));
-        Assert.Null(FrontmatterEnricher.Enrich(null!));
+        var enricher = new FrontmatterEnricher(FixedClock);
+        Assert.Equal("", enricher.Enrich(""));
+        Assert.Null(enricher.Enrich(null!));
     }
 
     [Fact]
@@ -223,7 +239,8 @@ ms.service: azure-mcp-server
 
 # Azure MCP Server tools for Storage";
 
-        var result = FrontmatterEnricher.Enrich(markdown);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
 
         // content_well_notification must be YAML array format
         Assert.Contains("content_well_notification:", result);
@@ -233,6 +250,83 @@ ms.service: azure-mcp-server
         int keyLine = Array.FindIndex(lines, l => l.StartsWith("content_well_notification:"));
         Assert.True(keyLine >= 0, "content_well_notification key not found");
         Assert.Equal("  - AI-contribution", lines[keyLine + 1]);
+    }
+
+    // ── Phase 0: Clock injection tests ──────────────────────────────
+
+    [Fact]
+    public void Enrich_CustomClock_ProducesExpectedDate()
+    {
+        var customDate = new DateTime(2026, 12, 25, 14, 30, 0, DateTimeKind.Utc);
+        var customClock = () => customDate;
+
+        var markdown = @"---
+title: Azure MCP Server tools for Storage
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Storage";
+
+        var enricher = new FrontmatterEnricher(customClock);
+        var result = enricher.Enrich(markdown);
+
+        Assert.Contains("ms.date: 12/25/2026", result);
+    }
+
+    [Fact]
+    public void Enrich_DefaultClock_UsesTodaysDate()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Storage
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Storage";
+
+        var enricher = new FrontmatterEnricher(); // No clock provided, should use default
+        var result = enricher.Enrich(markdown);
+
+        var expectedDate = DateTime.UtcNow.ToString("MM/dd/yyyy");
+        Assert.Contains($"ms.date: {expectedDate}", result);
+    }
+
+    [Fact]
+    public void Enrich_UsesMetadataConstants()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Storage
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Storage";
+
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var result = enricher.Enrich(markdown);
+
+        // Verify all constants from MetadataConstants are used
+        Assert.Contains($"author: {MetadataConstants.Author}", result);
+        Assert.Contains($"ms.author: {MetadataConstants.Author}", result);
+        Assert.Contains($"ms.reviewer: {MetadataConstants.Reviewer}", result);
+        Assert.Contains($"ai-usage: {MetadataConstants.AiUsage}", result);
+        Assert.Contains(MetadataConstants.ContentWellValue, result);
+        Assert.Contains($"ms.custom: {MetadataConstants.MsCustom}", result);
+    }
+
+    [Fact]
+    public void EnrichWithDefaults_WorksWithoutInstantiation()
+    {
+        var markdown = @"---
+title: Azure MCP Server tools for Storage
+ms.service: azure-mcp-server
+---
+
+# Azure MCP Server tools for Storage";
+
+        var result = FrontmatterEnricher.EnrichWithDefaults(markdown);
+
+        Assert.Contains("author: diberry", result);
+        Assert.Contains("ms.date:", result);
+        Assert.Matches(@"ms\.date: \d{2}/\d{2}/\d{4}", result);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterPipelineIntegrationTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FrontmatterPipelineIntegrationTests.cs
@@ -16,9 +16,13 @@ namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
 ///
 /// Fixes: #219 — ms.date missing in generated tool-family files.
 /// Decision: AD-007 (TDD — write failing tests before implementing fix).
+/// Phase 0: Updated to use instance-based API with clock injection.
 /// </summary>
 public class FrontmatterPipelineIntegrationTests
 {
+    private static readonly DateTime FixedDate = new DateTime(2025, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+    private static Func<DateTime> FixedClock => () => FixedDate;
+
     private const string TestBrandName = "Azure Resource Health";
     private const string TestCliVersion = "2.0.0-beta.31+ed24dd9783f26645fd2b7218b4d52221b446354f";
     private const string TestSeoDescription = "Use Azure MCP Server tools to manage resource health and availability of Azure resources with natural language prompts from your IDE.";
@@ -29,10 +33,11 @@ public class FrontmatterPipelineIntegrationTests
     public void Stitch_DeterministicFrontmatter_ContainsMsDate()
     {
         // Arrange — build metadata via DeterministicFrontmatterGenerator (exactly as production does)
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
         var intros = "The Azure MCP Server lets you check resource health.\n\nAzure Resource Health helps you diagnose issues.";
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, intros);
+        var metadata = generator.Assemble(header, intros);
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -47,9 +52,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_MsDateHasCorrectFormat()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro paragraph.");
+        var metadata = generator.Assemble(header, "Intro paragraph.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -62,7 +68,8 @@ public class FrontmatterPipelineIntegrationTests
 
         var dateStr = match.Groups[1].Value;
         Assert.True(DateTime.TryParse(dateStr, out var parsedDate), $"ms.date value '{dateStr}' is not a valid date");
-        Assert.Equal(DateTime.UtcNow.Date, parsedDate.Date);
+        // With fixed clock, should match exactly
+        Assert.Equal(FixedDate.Date, parsedDate.Date);
     }
 
     // ── author fields present after full pipeline ───────────────────
@@ -70,9 +77,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsAuthor()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -85,9 +93,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsMsAuthor()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -102,9 +111,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsAiUsage()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -117,9 +127,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsContentWellNotification()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -135,9 +146,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsMsCustom()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -152,9 +164,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_ContainsMsReviewer()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -169,9 +182,10 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Stitch_DeterministicFrontmatter_AllEnrichedFieldsInsideFrontmatter()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro paragraph.");
+        var metadata = generator.Assemble(header, "Intro paragraph.");
 
         var familyContent = CreateFamilyContent("resourcehealth", metadata);
         var stitcher = new FamilyFileStitcher();
@@ -201,7 +215,8 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Generate_IncludesMsDate()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
 
         // Generator must produce ms.date directly — not rely solely on FrontmatterEnricher
@@ -212,10 +227,11 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Generate_MsDateMatchesToday()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
 
-        var expected = DateTime.UtcNow.ToString("MM/dd/yyyy");
+        var expected = FixedDate.ToString("MM/dd/yyyy");
         Assert.Contains($"ms.date: {expected}", header);
     }
 
@@ -224,12 +240,14 @@ public class FrontmatterPipelineIntegrationTests
     [Fact]
     public void Enrich_GeneratorOutput_InjectsMsDate()
     {
-        var header = DeterministicFrontmatterGenerator.Generate(
+        var generator = new DeterministicFrontmatterGenerator(FixedClock);
+        var header = generator.Generate(
             TestBrandName, 2, TestCliVersion, TestSeoDescription);
-        var metadata = DeterministicFrontmatterGenerator.Assemble(header, "Intro.");
+        var metadata = generator.Assemble(header, "Intro.");
 
         // Feed generator output directly to enricher
-        var enriched = FrontmatterEnricher.Enrich(metadata);
+        var enricher = new FrontmatterEnricher(FixedClock);
+        var enriched = enricher.Enrich(metadata);
 
         Assert.Contains("ms.date:", enriched);
         Assert.Matches(@"ms\.date: \d{2}/\d{2}/\d{4}", enriched);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/MetadataConstantsTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/MetadataConstantsTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for MetadataConstants to verify all constants are accessible
+/// and have the expected values.
+/// Part of Phase 0: metadata extraction PRD.
+/// </summary>
+public class MetadataConstantsTests
+{
+    [Fact]
+    public void Author_IsCorrect()
+    {
+        Assert.Equal("diberry", MetadataConstants.Author);
+    }
+
+    [Fact]
+    public void Reviewer_IsCorrect()
+    {
+        Assert.Equal("mbaldwin", MetadataConstants.Reviewer);
+    }
+
+    [Fact]
+    public void AiUsage_IsCorrect()
+    {
+        Assert.Equal("ai-generated", MetadataConstants.AiUsage);
+    }
+
+    [Fact]
+    public void ContentWellValue_IsCorrect()
+    {
+        Assert.Equal("AI-contribution", MetadataConstants.ContentWellValue);
+    }
+
+    [Fact]
+    public void MsCustom_IsCorrect()
+    {
+        Assert.Equal("build-2025", MetadataConstants.MsCustom);
+    }
+
+    [Fact]
+    public void MsService_IsCorrect()
+    {
+        Assert.Equal("azure-mcp-server", MetadataConstants.MsService);
+    }
+
+    [Fact]
+    public void MsTopic_IsCorrect()
+    {
+        Assert.Equal("concept-article", MetadataConstants.MsTopic);
+    }
+
+    [Fact]
+    public void ProductName_IsCorrect()
+    {
+        Assert.Equal("Azure MCP Server", MetadataConstants.ProductName);
+    }
+
+    [Fact]
+    public void TitleTemplate_IsCorrect()
+    {
+        Assert.Equal("{0} tools for {1}", MetadataConstants.TitleTemplate);
+    }
+
+    [Fact]
+    public void DescriptionTemplate_IsCorrect()
+    {
+        Assert.Equal("Use {0} tools to manage {1} resources with natural language prompts from your IDE.", MetadataConstants.DescriptionTemplate);
+    }
+
+    [Fact]
+    public void IncludeParameterConsideration_IsCorrect()
+    {
+        Assert.Equal("[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]", MetadataConstants.IncludeParameterConsideration);
+    }
+
+    [Fact]
+    public void TitleTemplate_FormatsCorrectly()
+    {
+        var result = string.Format(MetadataConstants.TitleTemplate, MetadataConstants.ProductName, "Azure Storage");
+        Assert.Equal("Azure MCP Server tools for Azure Storage", result);
+    }
+
+    [Fact]
+    public void DescriptionTemplate_FormatsCorrectly()
+    {
+        var result = string.Format(MetadataConstants.DescriptionTemplate, MetadataConstants.ProductName, "Azure Storage");
+        Assert.Equal("Use Azure MCP Server tools to manage Azure Storage resources with natural language prompts from your IDE.", result);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
@@ -485,10 +485,11 @@ public class CleanupGenerator
                 if (serviceDocLinks.TryGetValue(familyName, out var docLink)
                     && !string.IsNullOrWhiteSpace(docLink.SeoDescription))
                 {
-                    var header = DeterministicFrontmatterGenerator.Generate(
+                    var generator = new DeterministicFrontmatterGenerator();
+                    var header = generator.Generate(
                         displayName, familyContent.ToolCount, _cliVersion ?? "unknown", docLink.SeoDescription);
-                    var intros = DeterministicFrontmatterGenerator.ExtractIntroParagraphs(aiMetadata);
-                    metadata = DeterministicFrontmatterGenerator.Assemble(header, intros);
+                    var intros = generator.ExtractIntroParagraphs(aiMetadata);
+                    metadata = generator.Assemble(header, intros);
                     Console.WriteLine($"✓ (deterministic frontmatter + AI intros)");
                 }
                 else

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DeterministicFrontmatterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DeterministicFrontmatterGenerator.cs
@@ -13,11 +13,35 @@ namespace ToolFamilyCleanup.Services;
 ///
 /// AI is still used for the 2 intro paragraphs (capabilities + service description).
 /// This generator handles: frontmatter fields, H1 heading, and INCLUDE statement.
+/// 
+/// Phase 0: Converted to instance class with clock injection for testability.
 /// </summary>
-public static class DeterministicFrontmatterGenerator
+public class DeterministicFrontmatterGenerator
 {
-    private const string IncludeStatement =
-        "[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]";
+    private readonly Func<DateTime> _clock;
+
+    /// <summary>
+    /// Creates a new instance of DeterministicFrontmatterGenerator.
+    /// </summary>
+    /// <param name="clock">Optional clock function for date generation. Defaults to DateTime.UtcNow.</param>
+    public DeterministicFrontmatterGenerator(Func<DateTime>? clock = null)
+    {
+        _clock = clock ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Static convenience method for backward compatibility.
+    /// Creates a new instance with default clock and generates frontmatter.
+    /// </summary>
+    public static string GenerateWithDefaults(
+        string brandName,
+        int toolCount,
+        string cliVersion,
+        string? seoDescription = null)
+    {
+        var generator = new DeterministicFrontmatterGenerator();
+        return generator.Generate(brandName, toolCount, cliVersion, seoDescription);
+    }
 
     /// <summary>
     /// Generates deterministic frontmatter YAML block and H1 heading.
@@ -27,23 +51,23 @@ public static class DeterministicFrontmatterGenerator
     /// <param name="cliVersion">MCP CLI version string</param>
     /// <param name="seoDescription">Human-curated SEO description, or null for generic fallback</param>
     /// <returns>Markdown string: frontmatter block + blank line + H1 heading</returns>
-    public static string Generate(
+    public string Generate(
         string brandName,
         int toolCount,
         string cliVersion,
         string? seoDescription = null)
     {
-        var title = $"Azure MCP Server tools for {brandName}";
+        var title = string.Format(MetadataConstants.TitleTemplate, MetadataConstants.ProductName, brandName);
         var description = seoDescription
-            ?? $"Use Azure MCP Server tools to manage {brandName} resources with natural language prompts from your IDE.";
+            ?? string.Format(MetadataConstants.DescriptionTemplate, MetadataConstants.ProductName, brandName);
 
         var sb = new StringBuilder();
         sb.AppendLine("---");
         sb.AppendLine($"title: {title}");
         sb.AppendLine($"description: {description}");
-        sb.AppendLine($"ms.date: {DateTime.UtcNow:MM/dd/yyyy}");
-        sb.AppendLine("ms.service: azure-mcp-server");
-        sb.AppendLine("ms.topic: concept-article");
+        sb.AppendLine($"ms.date: {_clock():MM/dd/yyyy}");
+        sb.AppendLine($"ms.service: {MetadataConstants.MsService}");
+        sb.AppendLine($"ms.topic: {MetadataConstants.MsTopic}");
         sb.AppendLine($"tool_count: {toolCount}");
         sb.AppendLine($"mcp-cli.version: {cliVersion}");
         sb.AppendLine("---");
@@ -57,7 +81,7 @@ public static class DeterministicFrontmatterGenerator
     /// Extracts the intro paragraphs from AI-generated metadata output.
     /// Returns content between the H1 heading and the INCLUDE statement.
     /// </summary>
-    public static string ExtractIntroParagraphs(string aiMetadata)
+    public string ExtractIntroParagraphs(string aiMetadata)
     {
         var lines = aiMetadata.Replace("\r\n", "\n").Split('\n');
         var introLines = new List<string>();
@@ -88,7 +112,7 @@ public static class DeterministicFrontmatterGenerator
     /// <summary>
     /// Assembles the complete metadata section from deterministic header + AI intros.
     /// </summary>
-    public static string Assemble(string frontmatterAndH1, string introParagraphs)
+    public string Assemble(string frontmatterAndH1, string introParagraphs)
     {
         var sb = new StringBuilder();
         sb.Append(frontmatterAndH1);
@@ -100,7 +124,7 @@ public static class DeterministicFrontmatterGenerator
             sb.AppendLine();
         }
 
-        sb.AppendLine(IncludeStatement);
+        sb.AppendLine(MetadataConstants.IncludeParameterConsideration);
 
         return sb.ToString();
     }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -63,7 +63,7 @@ public class FamilyFileStitcher
         markdown = AcronymExpander.ExpandAll(markdown);
 
         // 5. Post-processing: inject required frontmatter fields (#155)
-        markdown = FrontmatterEnricher.Enrich(markdown);
+        markdown = FrontmatterEnricher.EnrichWithDefaults(markdown);
 
         // 6. Post-processing: strip duplicate example blocks (#153)
         markdown = DuplicateExampleStripper.Strip(markdown);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FrontmatterEnricher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FrontmatterEnricher.cs
@@ -14,20 +14,37 @@ namespace ToolFamilyCleanup.Services;
 /// - ai-usage (for AI-generated content)
 /// - content_well_notification (for AI-generated content)
 /// - ms.custom (for campaign tracking)
+/// 
+/// Phase 0: Converted to instance class with clock injection for testability.
 /// </summary>
-public static class FrontmatterEnricher
+public class FrontmatterEnricher
 {
-    private const string Author = "diberry";
-    private const string Reviewer = "mbaldwin";
-    private const string AiUsage = "ai-generated";
-    private const string ContentWellValue = "AI-contribution";
-    private const string MsCustom = "build-2025";
+    private readonly Func<DateTime> _clock;
+
+    /// <summary>
+    /// Creates a new instance of FrontmatterEnricher.
+    /// </summary>
+    /// <param name="clock">Optional clock function for date generation. Defaults to DateTime.UtcNow.</param>
+    public FrontmatterEnricher(Func<DateTime>? clock = null)
+    {
+        _clock = clock ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Static convenience method for backward compatibility.
+    /// Creates a new instance with default clock and enriches the markdown.
+    /// </summary>
+    public static string EnrichWithDefaults(string markdown)
+    {
+        var enricher = new FrontmatterEnricher();
+        return enricher.Enrich(markdown);
+    }
 
     /// <summary>
     /// Injects missing required frontmatter fields. Preserves existing fields.
     /// Idempotent — safe to call multiple times.
     /// </summary>
-    public static string Enrich(string markdown)
+    public string Enrich(string markdown)
     {
         if (string.IsNullOrEmpty(markdown))
         {
@@ -54,19 +71,19 @@ public static class FrontmatterEnricher
         // Parse existing fields
         var lines = frontmatter.Split('\n').ToList();
 
-        // Inject missing fields
-        InjectIfMissing(lines, "author", $"author: {Author}");
-        InjectIfMissing(lines, "ms.author", $"ms.author: {Author}");
-        InjectIfMissing(lines, "ms.reviewer", $"ms.reviewer: {Reviewer}");
-        InjectIfMissing(lines, "ms.date", $"ms.date: {DateTime.UtcNow:MM/dd/yyyy}");
-        InjectIfMissing(lines, "ai-usage", $"ai-usage: {AiUsage}");
-        InjectIfMissing(lines, "ms.custom", $"ms.custom: {MsCustom}");
+        // Inject missing fields (using MetadataConstants)
+        InjectIfMissing(lines, "author", $"author: {MetadataConstants.Author}");
+        InjectIfMissing(lines, "ms.author", $"ms.author: {MetadataConstants.Author}");
+        InjectIfMissing(lines, "ms.reviewer", $"ms.reviewer: {MetadataConstants.Reviewer}");
+        InjectIfMissing(lines, "ms.date", $"ms.date: {_clock():MM/dd/yyyy}");
+        InjectIfMissing(lines, "ai-usage", $"ai-usage: {MetadataConstants.AiUsage}");
+        InjectIfMissing(lines, "ms.custom", $"ms.custom: {MetadataConstants.MsCustom}");
 
         // content_well_notification is special (multi-line YAML array)
         if (!lines.Any(l => l.TrimStart().StartsWith("content_well_notification")))
         {
             lines.Add("content_well_notification:");
-            lines.Add($"  - {ContentWellValue}");
+            lines.Add($"  - {MetadataConstants.ContentWellValue}");
         }
 
         // Reassemble

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/MetadataConstants.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/MetadataConstants.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Centralizes all metadata constants for the doc generation pipeline.
+/// Single source of truth for publishing metadata, branding, and content paths.
+/// Phase 0: Extracted from FrontmatterEnricher and DeterministicFrontmatterGenerator.
+/// </summary>
+public static class MetadataConstants
+{
+    // Publishing metadata
+    public const string Author = "diberry";
+    public const string Reviewer = "mbaldwin";
+    public const string AiUsage = "ai-generated";
+    public const string ContentWellValue = "AI-contribution";
+    public const string MsCustom = "build-2025";
+    public const string MsService = "azure-mcp-server";
+    public const string MsTopic = "concept-article";
+
+    // Branding
+    public const string ProductName = "Azure MCP Server";
+    public const string TitleTemplate = "{0} tools for {1}"; // ProductName, brandName
+    public const string DescriptionTemplate = "Use {0} tools to manage {1} resources with natural language prompts from your IDE."; // ProductName, brandName
+
+    // Content paths
+    public const string IncludeParameterConsideration = "[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]";
+}


### PR DESCRIPTION
## Summary

Implements Phase 0 of #486 — the minimum-viable spike to centralize metadata constants and inject testable clocks.

## Changes

- **MetadataConstants.cs** — single source of truth for all hard-coded metadata (author, reviewer, ms.service, branding, templates)
- **FrontmatterEnricher** — refactored from static to instance class with `Func<DateTime>` clock injection
- **DeterministicFrontmatterGenerator** — refactored from static to instance class with `Func<DateTime>` clock injection
- Static convenience methods (`EnrichWithDefaults()`, `GenerateWithDefaults()`) preserve backward compatibility
- Updated call sites: FamilyFileStitcher, CleanupGenerator
- 27 new tests (16 constants + 4 enricher clock + 7 generator clock)
- All 667 tests pass, zero breaking changes

## Decision Gate

Phase 1+ only proceeds if Phase 0 proves insufficient after real-world use. See #486 for full PRD.

Closes #486