### PR TITLE
fix: adaptive H2/H3 tool counting in post-assembly validator

### DIFF
--- a/mcp-tools/scripts/Validate-ToolFamily-PostAssembly.Tests.ps1
+++ b/mcp-tools/scripts/Validate-ToolFamily-PostAssembly.Tests.ps1
@@ -1,0 +1,369 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Pester tests for adaptive H2/H3 tool counting in Validate-ToolFamily-PostAssembly.ps1
+#>
+
+BeforeAll {
+    # Dot-source the shared functions used by the validator
+    $scriptRoot = $PSScriptRoot
+    . "$scriptRoot\Shared-Functions.ps1"
+
+    # Extract functions from the validator script for unit testing
+    $validatorScript = Get-Content "$scriptRoot\Validate-ToolFamily-PostAssembly.ps1" -Raw
+    $functionsToExtract = @(
+        'Remove-Markup',
+        'Convert-ToSlug',
+        'Convert-CommandToToolKey',
+        'Get-McpCliCommands',
+        'Get-FrontmatterValue',
+        'Get-SectionParameterRows',
+        'Get-ArticleSections'
+    )
+    foreach ($funcName in $functionsToExtract) {
+        $pattern = "(?ms)^function $funcName \{.*?^\}"
+        $match = [regex]::Match($validatorScript, $pattern)
+        if ($match.Success) {
+            Invoke-Expression $match.Value
+        }
+    }
+}
+
+Describe 'Get-ArticleSections - Adaptive H2/H3 Tool Detection' {
+
+    Context 'Multi-resource namespace (azurebackup pattern)' {
+        It 'Should count 16 H3 tools across 9 H2 resource groups' {
+            # Simulate azurebackup pattern: H2 groups with H3 tool sub-sections
+            $article = @"
+---
+title: Azure Backup tools
+tool_count: 16
+---
+
+## Vault Management
+
+### list vaults
+
+<!-- @mcpcli azurebackup list-vaults -->
+
+Example prompts include:
+- List all recovery services vaults
+
+### create vault
+
+<!-- @mcpcli azurebackup create-vault -->
+
+Example prompts include:
+- Create a new backup vault
+
+## Protected Items
+
+### list protected items
+
+<!-- @mcpcli azurebackup list-protected-items -->
+
+Example prompts include:
+- Show all protected items
+
+### backup now
+
+<!-- @mcpcli azurebackup backup-now -->
+
+Example prompts include:
+- Run a backup now for my VM
+
+## Policy Management
+
+### list policies
+
+<!-- @mcpcli azurebackup list-policies -->
+
+Example prompts include:
+- List backup policies
+
+### create policy
+
+<!-- @mcpcli azurebackup create-policy -->
+
+Example prompts include:
+- Create a new backup policy
+
+## Job Monitoring
+
+### list jobs
+
+<!-- @mcpcli azurebackup list-jobs -->
+
+Example prompts include:
+- Show recent backup jobs
+
+### get job
+
+<!-- @mcpcli azurebackup get-job -->
+
+Example prompts include:
+- Get details of a backup job
+
+## Recovery Points
+
+### list recovery points
+
+<!-- @mcpcli azurebackup list-recovery-points -->
+
+Example prompts include:
+- List recovery points for my VM
+
+### restore
+
+<!-- @mcpcli azurebackup restore -->
+
+Example prompts include:
+- Restore a VM from backup
+
+## Disaster Recovery
+
+### enable replication
+
+<!-- @mcpcli azurebackup enable-replication -->
+
+Example prompts include:
+- Enable disaster recovery replication
+
+### failover
+
+<!-- @mcpcli azurebackup failover -->
+
+Example prompts include:
+- Initiate a failover
+
+## Governance
+
+### list compliance
+
+<!-- @mcpcli azurebackup list-compliance -->
+
+Example prompts include:
+- Show backup compliance status
+
+### configure alerts
+
+<!-- @mcpcli azurebackup configure-alerts -->
+
+Example prompts include:
+- Configure backup alerts
+
+## Resource Groups
+
+### list resource groups
+
+<!-- @mcpcli azurebackup list-resource-groups -->
+
+Example prompts include:
+- List resource groups with backup resources
+
+## Reports
+
+### generate report
+
+<!-- @mcpcli azurebackup generate-report -->
+
+Example prompts include:
+- Generate a backup report
+
+## Related content
+
+See also Azure Backup documentation.
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'azurebackup'
+            $result.Sections.Count | Should -Be 16
+            $result.DetectionMode | Should -Be 'multi-resource'
+        }
+    }
+
+    Context 'Single-resource namespace (flat H2 tools)' {
+        It 'Should count H2 sections as tools with no regression' {
+            $article = @"
+---
+title: Azure SQL tools
+tool_count: 3
+---
+
+## list databases
+
+<!-- @mcpcli sql list-databases -->
+
+Example prompts include:
+- List all SQL databases
+
+## get database
+
+<!-- @mcpcli sql get-database -->
+
+Example prompts include:
+- Get details of my SQL database
+
+## create database
+
+<!-- @mcpcli sql create-database -->
+
+Example prompts include:
+- Create a new SQL database
+
+## Related content
+
+See also Azure SQL documentation.
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'sql'
+            $result.Sections.Count | Should -Be 3
+            $result.DetectionMode | Should -Be 'single-resource'
+        }
+
+        It 'Should preserve tool keys for single-resource tools' {
+            $article = @"
+---
+title: Azure Compute tools
+tool_count: 2
+---
+
+## list vms
+
+<!-- @mcpcli compute list-vms -->
+
+Example prompts include:
+- List all virtual machines
+
+## create vm
+
+<!-- @mcpcli compute create-vm -->
+
+Example prompts include:
+- Create a new virtual machine
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'compute'
+            $result.Sections[0].ToolKey | Should -Be 'list-vms'
+            $result.Sections[1].ToolKey | Should -Be 'create-vm'
+        }
+    }
+
+    Context 'Mixed content - H3s that are NOT tools should be excluded' {
+        It 'Should exclude Overview, Prerequisites, Parameters, Examples, Remarks, Related H3s' {
+            $article = @"
+---
+title: Azure Storage tools
+tool_count: 2
+---
+
+## Blob Operations
+
+### Overview
+
+This section covers blob operations.
+
+### upload blob
+
+<!-- @mcpcli storage upload-blob -->
+
+Example prompts include:
+- Upload a file to blob storage
+
+### Parameters
+
+Common parameters for blob operations.
+
+### download blob
+
+<!-- @mcpcli storage download-blob -->
+
+Example prompts include:
+- Download a blob
+
+### Examples
+
+Here are additional examples.
+
+### Remarks
+
+Note about usage.
+
+### Prerequisites
+
+You need a storage account.
+
+### Related
+
+See blob documentation.
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'storage'
+            $result.Sections.Count | Should -Be 2
+            $result.Sections[0].Heading | Should -Be 'upload blob'
+            $result.Sections[1].Heading | Should -Be 'download blob'
+        }
+    }
+
+    Context 'Edge case - Empty H2 section with no H3s' {
+        It 'Should count empty H2 as a tool (single-resource behavior)' {
+            $article = @"
+---
+title: Azure Redis tools
+tool_count: 2
+---
+
+## list caches
+
+<!-- @mcpcli redis list-caches -->
+
+Example prompts include:
+- List Redis caches
+
+## flush cache
+
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'redis'
+            $result.Sections.Count | Should -Be 2
+            $result.Sections[1].Heading | Should -Be 'flush cache'
+        }
+    }
+
+    Context 'Edge case - Mixed H2 behavior (some with H3, some without)' {
+        It 'Should handle H2s with H3 tools alongside H2s without H3s' {
+            $article = @"
+---
+title: Azure Mixed tools
+tool_count: 3
+---
+
+## Resource Group
+
+### list items
+
+<!-- @mcpcli mixed list-items -->
+
+Example prompts include:
+- List items
+
+### delete item
+
+<!-- @mcpcli mixed delete-item -->
+
+Example prompts include:
+- Delete an item
+
+## standalone tool
+
+<!-- @mcpcli mixed standalone-tool -->
+
+Example prompts include:
+- Run the standalone tool
+"@
+
+            $result = Get-ArticleSections -ArticleContent $article -NamespaceName 'mixed'
+            $result.Sections.Count | Should -Be 3
+            $result.DetectionMode | Should -Be 'multi-resource'
+        }
+    }
+}

--- a/mcp-tools/scripts/Validate-ToolFamily-PostAssembly.ps1
+++ b/mcp-tools/scripts/Validate-ToolFamily-PostAssembly.ps1
@@ -405,6 +405,9 @@ function Get-ArticleSections {
         [string]$NamespaceName
     )
 
+    # H3 headings that are structural (not tools) and should be excluded
+    $excludedH3Names = @('Overview', 'Prerequisites', 'Parameters', 'Examples', 'Remarks', 'Related')
+
     $normalized = $ArticleContent -replace "`r`n", "`n"
     $frontmatterMatch = [regex]::Match($normalized, '(?s)^---\n(.*?)\n---\n?')
     if (-not $frontmatterMatch.Success) {
@@ -415,6 +418,7 @@ function Get-ArticleSections {
     $body = $normalized.Substring($frontmatterMatch.Length)
     $headingMatches = [regex]::Matches($body, '(?m)^##\s+(.*)$')
     $sections = New-Object System.Collections.Generic.List[object]
+    $detectionMode = 'single-resource'
 
     for ($index = 0; $index -lt $headingMatches.Count; $index++) {
         $heading = $headingMatches[$index].Groups[1].Value.Trim()
@@ -426,82 +430,189 @@ function Get-ArticleSections {
             continue
         }
 
-        $sectionLines = $sectionText -split "`n"
-        $commands = @(Get-McpCliCommands $sectionText)
-        $toolKey = if ($commands.Count -gt 0) {
-            Convert-CommandToToolKey -CommandText $commands[0] -NamespaceName $NamespaceName
-        } else {
-            Convert-ToSlug $heading
-        }
+        # Adaptive H3 detection: check for H3 sub-headings within this H2
+        $h3Matches = [regex]::Matches($sectionText, '(?m)^###\s+(.*)$')
+        $toolH3s = @($h3Matches | Where-Object {
+            $h3Name = $_.Groups[1].Value.Trim()
+            $h3Name -notin $excludedH3Names
+        })
 
-        $markerLineIndices = New-Object System.Collections.Generic.List[int]
-        $exampleHeaderIndex = -1
-        $tableStartIndex = -1
-        $alternateExampleHeader = $null
+        if ($toolH3s.Count -gt 0) {
+            # Multi-resource mode: H2 is a resource group, H3s are tools
+            $detectionMode = 'multi-resource'
+            Write-Verbose "H2 '$heading': multi-resource mode - $($toolH3s.Count) H3 tool(s) detected"
 
-        for ($lineIndex = 0; $lineIndex -lt $sectionLines.Count; $lineIndex++) {
-            $trimmed = $sectionLines[$lineIndex].Trim()
-            if ($trimmed -match '^<!--\s*@mcpcli\s+') {
-                $markerLineIndices.Add($lineIndex)
-            }
-            if ($trimmed -eq 'Example prompts include:') {
-                $exampleHeaderIndex = $lineIndex
-            }
-            if ($tableStartIndex -lt 0 -and $trimmed.StartsWith('|')) {
-                $tableStartIndex = $lineIndex
-            }
-            if (-not $alternateExampleHeader -and $trimmed -match '^(?i)(example prompts|example commands|usage examples|examples|try this|to .* use commands like):') {
-                $alternateExampleHeader = $trimmed
-            }
-        }
+            foreach ($h3Match in $toolH3s) {
+                $h3Heading = $h3Match.Groups[1].Value.Trim()
+                $h3StartIndex = $h3Match.Index
+                # Find end of this H3: next H3 or end of H2 section
+                $h3EndIndex = $sectionText.Length
+                $allH3InSection = [regex]::Matches($sectionText, '(?m)^###\s+(.*)$')
+                for ($h3i = 0; $h3i -lt $allH3InSection.Count; $h3i++) {
+                    if ($allH3InSection[$h3i].Index -eq $h3StartIndex -and $h3i -lt $allH3InSection.Count - 1) {
+                        $h3EndIndex = $allH3InSection[$h3i + 1].Index
+                        break
+                    }
+                }
+                $h3Text = $sectionText.Substring($h3StartIndex, $h3EndIndex - $h3StartIndex).TrimEnd()
 
-        $examplePrompts = New-Object System.Collections.Generic.List[string]
-        if ($exampleHeaderIndex -ge 0) {
-            $currentPrompt = $null
-            for ($lineIndex = $exampleHeaderIndex + 1; $lineIndex -lt $sectionLines.Count; $lineIndex++) {
-                $trimmed = $sectionLines[$lineIndex].Trim()
-                if ($trimmed.StartsWith('|') -or $trimmed -match '^\[Tool annotation hints\]' -or $trimmed -match '^Destructive:' -or $trimmed -match '^<!--\s*@mcpcli\s+') {
-                    break
+                $h3Lines = $h3Text -split "`n"
+                $commands = @(Get-McpCliCommands $h3Text)
+                $toolKey = if ($commands.Count -gt 0) {
+                    Convert-CommandToToolKey -CommandText $commands[0] -NamespaceName $NamespaceName
+                } else {
+                    Convert-ToSlug $h3Heading
                 }
 
-                if ($trimmed -match '^-\s+') {
+                $markerLineIndices = New-Object System.Collections.Generic.List[int]
+                $exampleHeaderIndex = -1
+                $tableStartIndex = -1
+                $alternateExampleHeader = $null
+
+                for ($lineIndex = 0; $lineIndex -lt $h3Lines.Count; $lineIndex++) {
+                    $trimmed = $h3Lines[$lineIndex].Trim()
+                    if ($trimmed -match '^<!--\s*@mcpcli\s+') {
+                        $markerLineIndices.Add($lineIndex)
+                    }
+                    if ($trimmed -eq 'Example prompts include:') {
+                        $exampleHeaderIndex = $lineIndex
+                    }
+                    if ($tableStartIndex -lt 0 -and $trimmed.StartsWith('|')) {
+                        $tableStartIndex = $lineIndex
+                    }
+                    if (-not $alternateExampleHeader -and $trimmed -match '^(?i)(example prompts|example commands|usage examples|examples|try this|to .* use commands like):') {
+                        $alternateExampleHeader = $trimmed
+                    }
+                }
+
+                $examplePrompts = New-Object System.Collections.Generic.List[string]
+                if ($exampleHeaderIndex -ge 0) {
+                    $currentPrompt = $null
+                    for ($lineIndex = $exampleHeaderIndex + 1; $lineIndex -lt $h3Lines.Count; $lineIndex++) {
+                        $trimmed = $h3Lines[$lineIndex].Trim()
+                        if ($trimmed.StartsWith('|') -or $trimmed -match '^\[Tool annotation hints\]' -or $trimmed -match '^Destructive:' -or $trimmed -match '^<!--\s*@mcpcli\s+') {
+                            break
+                        }
+
+                        if ($trimmed -match '^-\s+') {
+                            if ($currentPrompt) {
+                                $examplePrompts.Add($currentPrompt)
+                            }
+                            $currentPrompt = ($trimmed -replace '^-\s+', '').Trim()
+                            continue
+                        }
+
+                        if ($currentPrompt -and -not [string]::IsNullOrWhiteSpace($trimmed)) {
+                            $currentPrompt = "$currentPrompt $trimmed"
+                        }
+                    }
+
                     if ($currentPrompt) {
                         $examplePrompts.Add($currentPrompt)
                     }
-                    $currentPrompt = ($trimmed -replace '^-\s+', '').Trim()
-                    continue
                 }
 
-                if ($currentPrompt -and -not [string]::IsNullOrWhiteSpace($trimmed)) {
-                    $currentPrompt = "$currentPrompt $trimmed"
+                $parameterRows = Get-SectionParameterRows $h3Lines
+                $requiredParameters = @($parameterRows | Where-Object { $_.IsRequired } | Select-Object -ExpandProperty ParameterName)
+
+                $sections.Add([pscustomobject]@{
+                    Heading = $h3Heading
+                    ToolKey = $toolKey
+                    Commands = $commands
+                    MarkerCount = $markerLineIndices.Count
+                    MarkerLineIndices = @($markerLineIndices)
+                    ExampleHeaderIndex = $exampleHeaderIndex
+                    TableStartIndex = $tableStartIndex
+                    AlternateExampleHeader = $alternateExampleHeader
+                    ExamplePrompts = @($examplePrompts)
+                    RequiredParameters = @($requiredParameters)
+                    ParentGroup = $heading
+                })
+            }
+        } else {
+            # Single-resource mode: H2 is a tool itself
+            Write-Verbose "H2 '$heading': single-resource mode - treating H2 as tool"
+
+            $sectionLines = $sectionText -split "`n"
+            $commands = @(Get-McpCliCommands $sectionText)
+            $toolKey = if ($commands.Count -gt 0) {
+                Convert-CommandToToolKey -CommandText $commands[0] -NamespaceName $NamespaceName
+            } else {
+                Convert-ToSlug $heading
+            }
+
+            $markerLineIndices = New-Object System.Collections.Generic.List[int]
+            $exampleHeaderIndex = -1
+            $tableStartIndex = -1
+            $alternateExampleHeader = $null
+
+            for ($lineIndex = 0; $lineIndex -lt $sectionLines.Count; $lineIndex++) {
+                $trimmed = $sectionLines[$lineIndex].Trim()
+                if ($trimmed -match '^<!--\s*@mcpcli\s+') {
+                    $markerLineIndices.Add($lineIndex)
+                }
+                if ($trimmed -eq 'Example prompts include:') {
+                    $exampleHeaderIndex = $lineIndex
+                }
+                if ($tableStartIndex -lt 0 -and $trimmed.StartsWith('|')) {
+                    $tableStartIndex = $lineIndex
+                }
+                if (-not $alternateExampleHeader -and $trimmed -match '^(?i)(example prompts|example commands|usage examples|examples|try this|to .* use commands like):') {
+                    $alternateExampleHeader = $trimmed
                 }
             }
 
-            if ($currentPrompt) {
-                $examplePrompts.Add($currentPrompt)
+            $examplePrompts = New-Object System.Collections.Generic.List[string]
+            if ($exampleHeaderIndex -ge 0) {
+                $currentPrompt = $null
+                for ($lineIndex = $exampleHeaderIndex + 1; $lineIndex -lt $sectionLines.Count; $lineIndex++) {
+                    $trimmed = $sectionLines[$lineIndex].Trim()
+                    if ($trimmed.StartsWith('|') -or $trimmed -match '^\[Tool annotation hints\]' -or $trimmed -match '^Destructive:' -or $trimmed -match '^<!--\s*@mcpcli\s+') {
+                        break
+                    }
+
+                    if ($trimmed -match '^-\s+') {
+                        if ($currentPrompt) {
+                            $examplePrompts.Add($currentPrompt)
+                        }
+                        $currentPrompt = ($trimmed -replace '^-\s+', '').Trim()
+                        continue
+                    }
+
+                    if ($currentPrompt -and -not [string]::IsNullOrWhiteSpace($trimmed)) {
+                        $currentPrompt = "$currentPrompt $trimmed"
+                    }
+                }
+
+                if ($currentPrompt) {
+                    $examplePrompts.Add($currentPrompt)
+                }
             }
+
+            $parameterRows = Get-SectionParameterRows $sectionLines
+            $requiredParameters = @($parameterRows | Where-Object { $_.IsRequired } | Select-Object -ExpandProperty ParameterName)
+
+            $sections.Add([pscustomobject]@{
+                Heading = $heading
+                ToolKey = $toolKey
+                Commands = $commands
+                MarkerCount = $markerLineIndices.Count
+                MarkerLineIndices = @($markerLineIndices)
+                ExampleHeaderIndex = $exampleHeaderIndex
+                TableStartIndex = $tableStartIndex
+                AlternateExampleHeader = $alternateExampleHeader
+                ExamplePrompts = @($examplePrompts)
+                RequiredParameters = @($requiredParameters)
+            })
         }
-
-        $parameterRows = Get-SectionParameterRows $sectionLines
-        $requiredParameters = @($parameterRows | Where-Object { $_.IsRequired } | Select-Object -ExpandProperty ParameterName)
-
-        $sections.Add([pscustomobject]@{
-            Heading = $heading
-            ToolKey = $toolKey
-            Commands = $commands
-            MarkerCount = $markerLineIndices.Count
-            MarkerLineIndices = @($markerLineIndices)
-            ExampleHeaderIndex = $exampleHeaderIndex
-            TableStartIndex = $tableStartIndex
-            AlternateExampleHeader = $alternateExampleHeader
-            ExamplePrompts = @($examplePrompts)
-            RequiredParameters = @($requiredParameters)
-        })
     }
+
+    Write-Verbose "Detection mode: $detectionMode | Total tools found: $($sections.Count)"
 
     return [pscustomobject]@{
         Frontmatter = $frontmatter
         Sections = [object[]]$sections.ToArray()
+        DetectionMode = $detectionMode
     }
 }
 
@@ -695,7 +806,7 @@ try {
     $reportLines = New-Object System.Collections.Generic.List[string]
     $reportLines.Add("=== Tool Family Validation: $namespaceLower ===")
     $reportLines.Add("Tool files found: $toolFileCount")
-    $reportLines.Add("Article H2 sections: $articleSectionCount")
+    $reportLines.Add("Article tool sections: $articleSectionCount (detection: $($article.DetectionMode))")
     $reportLines.Add("Frontmatter tool_count: $(if ($null -ne $frontmatterToolCount) { $frontmatterToolCount } else { 'missing' })")
     if ($toolFileCount -eq $articleSectionCount -and $null -ne $frontmatterToolCount -and $frontmatterToolCount -eq $toolFileCount) {
         $reportLines.Add('✅ Tool count integrity: PASS')


### PR DESCRIPTION
Fixes #493

## Summary
Post-assembly validator now supports multi-resource namespaces that use H2 resource groups with H3 tool headings.

## Changes
- Updated Get-ArticleSections logic with adaptive H3 detection
- Added filtering for non-tool H3 sections (Overview, Prerequisites, Parameters, Examples, Remarks, Related)
- Added verbose logging for detection path (multi-resource vs single-resource mode)
- Added Pester test coverage (6 tests)

## Testing
- Multi-resource (azurebackup pattern): 16 tools across 9 groups :white_check_mark:
- Single-resource: no regression :white_check_mark:
- Mixed content with excluded H3s :white_check_mark:
- Edge cases (empty H2, mixed H2 behavior) :white_check_mark: