### PR TITLE
feat(stitcher): deterministic alphabetical tool ordering (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Deterministic alphabetical tool ordering in stitcher** — Tools now appear in alphabetical order (case-insensitive) within tool family pages, with stable tie-breakers for full determinism. Same inputs always produce byte-for-byte identical output regardless of input order. Multi-resource families sort tools within each resource group while preserving group order. (#501)
 - **Branch-aware content generation (`--mcp-branch`)** — The pipeline now fetches upstream files (`azmcp-commands.md`, `e2eTestPrompts.md`) from a configurable branch of `microsoft/mcp`. Default: `release/azure/2.x`. Override via `--mcp-branch <branch>` CLI flag or `MCP_BRANCH` environment variable. Local fallback preserved for offline use. (#387)
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Deterministic alphabetical tool ordering in stitcher** — Tools now appear in alphabetical order (case-insensitive) within tool family pages, with stable tie-breakers for full determinism. Same inputs always produce byte-for-byte identical output regardless of input order. Multi-resource families sort tools within each resource group while preserving group order. (#501)
+- **Alphabetical tool ordering in stitcher** — Tools within tool family pages are now sorted alphabetically by display heading (case-insensitive, with FileName tie-breaker) during stitching. Multi-resource families sort tools within each resource group while preserving group arrival order. This normalizes output for varying input permutations. (#501)
 - **Branch-aware content generation (`--mcp-branch`)** — The pipeline now fetches upstream files (`azmcp-commands.md`, `e2eTestPrompts.md`) from a configurable branch of `microsoft/mcp`. Default: `release/azure/2.x`. Override via `--mcp-branch <branch>` CLI flag or `MCP_BRANCH` environment variable. Local fallback preserved for offline use. (#387)
 - **Vale CLI prose linter for docs-generation** — Integrated Vale with Microsoft style rules into the docs-generation pipeline. Includes `.vale.ini` config, `lint-vale.sh`/`lint-vale.ps1` scripts, Pester tests, and a non-blocking CI job in `build-and-test.yml`. Suppresses same false positives as skills-generation (FirstPerson, Dashes, Quotes, HeadingAcronyms). (#368)
 - Azure Skills documentation generation pipeline (`skills-generation/`) — generates customer-facing docs for 24 Azure Skills (#365)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/StitcherAlphabeticalOrderTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/StitcherAlphabeticalOrderTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests verifying that the stitcher outputs tools in alphabetical order (#501).
+/// </summary>
+public class StitcherAlphabeticalOrderTests
+{
+    private static FamilyContent CreateFamilyWithTools(params (string name, string content)[] tools)
+    {
+        return new FamilyContent
+        {
+            FamilyName = "test",
+            Metadata = "---\ntitle: Test\n---\n\n# Test\n\nIntro paragraph.",
+            Tools = tools.Select(t => new ToolContent
+            {
+                ToolName = t.name,
+                FileName = $"{t.name.Replace(" ", "-")}.md",
+                FamilyName = "test",
+                Content = t.content
+            }).ToList(),
+            RelatedContent = "## Related content"
+        };
+    }
+
+    [Fact]
+    public void Stitch_SingleResource_ToolsAppearInAlphabeticalOrder()
+    {
+        // Arrange: tools in reverse alphabetical order
+        var content = CreateFamilyWithTools(
+            ("zoo list", "## Zoo list\n\nLists zoo items."),
+            ("alpha create", "## Alpha create\n\nCreates alpha items."),
+            ("middle get", "## Middle get\n\nGets middle items."));
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var result = stitcher.Stitch(content);
+
+        // Assert: tools should appear alphabetically
+        var alphaPos = result.IndexOf("## Alpha create");
+        var middlePos = result.IndexOf("## Middle get");
+        var zooPos = result.IndexOf("## Zoo list");
+
+        Assert.True(alphaPos < middlePos, "Alpha should appear before Middle");
+        Assert.True(middlePos < zooPos, "Middle should appear before Zoo");
+    }
+
+    [Fact]
+    public void Stitch_SingleResource_CaseInsensitiveOrdering()
+    {
+        // Arrange: mixed case tool names
+        var content = CreateFamilyWithTools(
+            ("Zebra list", "## Zebra list\n\nDesc."),
+            ("apple create", "## apple create\n\nDesc."),
+            ("Banana get", "## Banana get\n\nDesc."));
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var result = stitcher.Stitch(content);
+
+        // Assert: case-insensitive alphabetical order
+        var applePos = result.IndexOf("## apple create");
+        var bananaPos = result.IndexOf("## Banana get");
+        var zebraPos = result.IndexOf("## Zebra list");
+
+        Assert.True(applePos < bananaPos, "apple should appear before Banana (case-insensitive)");
+        Assert.True(bananaPos < zebraPos, "Banana should appear before Zebra");
+    }
+
+    [Fact]
+    public void Stitch_SingleResource_IdenticalOutputOnRepeatedRuns()
+    {
+        // Arrange
+        var content = CreateFamilyWithTools(
+            ("zoo list", "## Zoo list\n\nDesc."),
+            ("alpha create", "## Alpha create\n\nDesc."),
+            ("middle get", "## Middle get\n\nDesc."));
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act: run multiple times
+        var result1 = stitcher.Stitch(content);
+        var result2 = stitcher.Stitch(content);
+        var result3 = stitcher.Stitch(content);
+
+        // Assert: byte-for-byte identical
+        Assert.Equal(result1, result2);
+        Assert.Equal(result2, result3);
+    }
+
+    [Fact]
+    public void Stitch_SingleResource_DifferentInputOrderSameOutput()
+    {
+        // Arrange: same tools in different input orders
+        var tools = new[]
+        {
+            ("alpha create", "## Alpha create\n\nDesc."),
+            ("middle get", "## Middle get\n\nDesc."),
+            ("zoo list", "## Zoo list\n\nDesc.")
+        };
+
+        var contentForward = CreateFamilyWithTools(tools);
+        var contentReversed = CreateFamilyWithTools(tools.Reverse().ToArray());
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var resultForward = stitcher.Stitch(contentForward);
+        var resultReversed = stitcher.Stitch(contentReversed);
+
+        // Assert: same output regardless of input order
+        Assert.Equal(resultForward, resultReversed);
+    }
+
+    [Fact]
+    public void Stitch_MultiResource_ToolsSortedWithinEachGroup()
+    {
+        // Arrange: multi-resource family with unsorted tools within groups
+        // Use body text markers to detect order since headings get reformatted
+        var content = new FamilyContent
+        {
+            FamilyName = "compute",
+            Metadata = "---\ntitle: Test\n---\n\n# Test\n\nIntro paragraph.",
+            Tools =
+            [
+                new ToolContent { ToolName = "vm delete", FileName = "vm-delete.md", FamilyName = "compute", Content = "## VM delete\n\nDELETE_MARKER content.", Command = "compute vm delete", ResourceType = "vm" },
+                new ToolContent { ToolName = "vm create", FileName = "vm-create.md", FamilyName = "compute", Content = "## VM create\n\nCREATE_MARKER content.", Command = "compute vm create", ResourceType = "vm" },
+                new ToolContent { ToolName = "disk list", FileName = "disk-list.md", FamilyName = "compute", Content = "## Disk list\n\nLIST_MARKER content.", Command = "compute disk list", ResourceType = "disk" },
+                new ToolContent { ToolName = "disk create", FileName = "disk-create.md", FamilyName = "compute", Content = "## Disk create\n\nDISK_CREATE_MARKER content.", Command = "compute disk create", ResourceType = "disk" }
+            ],
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var result = stitcher.Stitch(content);
+
+        // Assert: within the VM group, "vm create" before "vm delete" (sorted alphabetically)
+        var createPos = result.IndexOf("CREATE_MARKER");
+        var deletePos = result.IndexOf("DELETE_MARKER");
+        Assert.True(createPos < deletePos, "vm create should appear before vm delete within the VM group");
+
+        // Assert: within the Disk group, "disk create" before "disk list" (sorted alphabetically)
+        var diskCreatePos = result.IndexOf("DISK_CREATE_MARKER");
+        var diskListPos = result.IndexOf("LIST_MARKER");
+        Assert.True(diskCreatePos < diskListPos, "disk create should appear before disk list within the Disk group");
+    }
+
+    [Fact]
+    public void Stitch_MultiResource_GroupOrderPreserved()
+    {
+        // Arrange: resource groups arrive in specific order (vm first, then disk)
+        // Group order should be preserved (not re-sorted)
+        var content = new FamilyContent
+        {
+            FamilyName = "compute",
+            Metadata = "---\ntitle: Test\n---\n\n# Test\n\nIntro paragraph.",
+            Tools =
+            [
+                new ToolContent { ToolName = "vm list", FileName = "vm-list.md", FamilyName = "compute", Content = "## VM list\n\nLists VMs.", Command = "compute vm list", ResourceType = "vm" },
+                new ToolContent { ToolName = "disk list", FileName = "disk-list.md", FamilyName = "compute", Content = "## Disk list\n\nLists disks.", Command = "compute disk list", ResourceType = "disk" }
+            ],
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var result = stitcher.Stitch(content);
+
+        // Assert: VM group appears before Disk group (arrival order preserved)
+        var vmGroupPos = result.IndexOf("## VM");
+        var diskGroupPos = result.IndexOf("## Disk");
+        Assert.True(vmGroupPos < diskGroupPos, "Resource group order should be preserved from input");
+    }
+
+    [Fact]
+    public void Stitch_SingleResource_TieBreakOnFileName()
+    {
+        // Arrange: tools with same name (case-insensitive) but different filenames
+        var content = new FamilyContent
+        {
+            FamilyName = "test",
+            Metadata = "---\ntitle: Test\n---\n\n# Test\n\nIntro paragraph.",
+            Tools =
+            [
+                new ToolContent { ToolName = "list", FileName = "b-list.md", FamilyName = "test", Content = "## List B\n\nFrom B." },
+                new ToolContent { ToolName = "list", FileName = "a-list.md", FamilyName = "test", Content = "## List A\n\nFrom A." }
+            ],
+            RelatedContent = "## Related content"
+        };
+
+        var stitcher = new FamilyFileStitcher();
+
+        // Act
+        var result = stitcher.Stitch(content);
+
+        // Assert: tie-break by filename — a-list.md before b-list.md
+        var posA = result.IndexOf("## List A");
+        var posB = result.IndexOf("## List B");
+        Assert.True(posA < posB, "When ToolNames match, should tie-break by FileName");
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -47,8 +47,11 @@ public class FamilyFileStitcher
         }
         else
         {
-            // Single-resource: keep current behavior (H2 per tool)
-            foreach (var tool in familyContent.Tools)
+            // Single-resource: H2 per tool, sorted alphabetically (#501)
+            foreach (var tool in familyContent.Tools
+                .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+                .ThenBy(t => t.FileName, StringComparer.Ordinal))
             {
                 sb.AppendLine(tool.Content);
                 sb.AppendLine();
@@ -155,7 +158,11 @@ public class FamilyFileStitcher
             sb.AppendLine($"## {displayName}");
             sb.AppendLine();
 
-            foreach (var tool in groupTools)
+            // Sort tools alphabetically within each resource group (#501)
+            foreach (var tool in groupTools
+                .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+                .ThenBy(t => t.FileName, StringComparer.Ordinal))
             {
                 // #416: Reformat H2 heading to "Resource type: action" format before demoting
                 var reformattedContent = ReformatToolHeadingForMultiResource(tool);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -47,7 +47,9 @@ public class FamilyFileStitcher
         }
         else
         {
-            // Single-resource: H2 per tool, sorted alphabetically (#501)
+            // Sort tools by ToolName (the generated display heading, e.g. "VM create")
+            // for consistent presentation order. ToolReader may pre-sort by resource/verb,
+            // but stitcher enforces final alphabetical order as the presentation authority. (#501)
             foreach (var tool in familyContent.Tools
                 .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(t => t.ToolName, StringComparer.Ordinal)
@@ -158,7 +160,8 @@ public class FamilyFileStitcher
             sb.AppendLine($"## {displayName}");
             sb.AppendLine();
 
-            // Sort tools alphabetically within each resource group (#501)
+            // Sort tools by ToolName within each resource group for consistent
+            // presentation. Group order (first-seen) is preserved. (#501)
             foreach (var tool in groupTools
                 .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(t => t.ToolName, StringComparer.Ordinal)


### PR DESCRIPTION
## Summary

Adds alphabetical sorting by display heading (ToolName) in the stitcher for tool family pages. This ensures consistent presentation order regardless of upstream tool arrival order.

**What changed:**
- Single-resource pages: tools sorted alphabetically by ToolName (case-insensitive), with FileName as tie-breaker
- Multi-resource pages: tools sorted within each resource group (group arrival order is preserved)
- The stitcher was already deterministic (no AI) — this PR adds **ordering normalization** so different input permutations produce the same output

**What did NOT change:**
- Post-processing transforms (16 deterministic text processors) remain as-is
- Resource group ordering in multi-resource mode is still first-seen order
- ToolReader's upstream sort contract is not modified

**Sort key choice:** ToolName is the generated display heading (e.g. "VM create", "disk list"). This was chosen because it represents what readers see in the final H2 headings. Future work could centralize ordering policy between ToolReader and stitcher.

## Testing

- 7 new tests covering: basic order, case-insensitivity, repeatability, input-order-independence, within-group sorting, group preservation, and tie-breaking
- All 677 tests in ToolFamilyCleanup.Tests pass
- 0 build errors

## Related

- Closes #501
- Note: #493 and #494 are separate issues (H2/H3 structure and token truncation respectively) — not addressed by this PR