### PR TITLE
fix: add per-tool AI timeout and fallback in Step 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-tool AI timeout and fallback in Step 3** — The AI improvement phase now applies a configurable per-tool timeout (default: 5 minutes) via `CancellationToken`. When a tool's AI call hangs or fails, the pipeline saves the original composed content as fallback and continues processing remaining tools. Previously, a single hanging Azure OpenAI call would freeze the entire pipeline indefinitely, preventing Step 4 (cleanup/stitching) from ever running. External (caller) cancellation is properly distinguished from per-tool timeout and propagated immediately. (#507)
+
 ### Added
 
 - **Alphabetical tool ordering in stitcher** — Tools within tool family pages are now sorted alphabetically by display heading (case-insensitive, with FileName tie-breaker) during stitching. Multi-resource families sort tools within each resource group while preserving group arrival order. This normalizes output for varying input permutations. (#501)

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/AiTimeoutFallbackTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/AiTimeoutFallbackTests.cs
@@ -108,7 +108,7 @@ public class AiTimeoutFallbackTests : IDisposable
             await service.GenerateImprovedToolFilesAsync(
                 _inputDir, _outputDir, maxTokens: 1000,
                 perToolTimeout: TimeSpan.FromMinutes(5),
-                externalCt: cts.Token));
+                pipelineCancellationToken: cts.Token));
     }
 
     // ── AI exception falls back to original ──

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/AiTimeoutFallbackTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/AiTimeoutFallbackTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using GenerativeAI;
+using Microsoft.Extensions.AI;
+using ToolGeneration_Improved.Services;
+
+namespace ToolGeneration_Improved.Tests;
+
+/// <summary>
+/// Tests for per-tool timeout, cancellation, and AI-failure fallback behavior.
+/// </summary>
+public class AiTimeoutFallbackTests : IDisposable
+{
+    private readonly string _inputDir;
+    private readonly string _outputDir;
+
+    public AiTimeoutFallbackTests()
+    {
+        _inputDir = Path.Combine(Path.GetTempPath(), $"timeout-test-in-{Guid.NewGuid():N}");
+        _outputDir = Path.Combine(Path.GetTempPath(), $"timeout-test-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_inputDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_inputDir)) Directory.Delete(_inputDir, true);
+        if (Directory.Exists(_outputDir)) Directory.Delete(_outputDir, true);
+    }
+
+    private static string CreateToolContent(string toolName = "test-tool")
+    {
+        return $"""
+            ---
+            title: {toolName}
+            ---
+            # {toolName}
+
+            This tool does something.
+
+            Example prompts include:
+            - "Do the thing"
+
+            Required parameters:
+            | Name | Description |
+            |------|-------------|
+            | --name | The name |
+            """;
+    }
+
+    // ── Per-tool timeout falls back to original ──
+
+    [Fact]
+    public async Task TimedOutTool_SavesOriginalContent()
+    {
+        var originalContent = CreateToolContent("slow-tool");
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "slow-tool.md"), originalContent);
+
+        // AI client that hangs forever
+        var hangingClient = new GenerativeAIClient(new HangingChatClient());
+        var service = new ImprovedToolGeneratorService(hangingClient, "system", "{0}");
+
+        var result = await service.GenerateImprovedToolFilesAsync(
+            _inputDir, _outputDir, maxTokens: 1000,
+            perToolTimeout: TimeSpan.FromMilliseconds(200));
+
+        // Should have saved the original content as fallback
+        var outputPath = Path.Combine(_outputDir, "slow-tool.md");
+        Assert.True(File.Exists(outputPath), "Output file should exist even when AI times out");
+
+        var savedContent = await File.ReadAllTextAsync(outputPath);
+        Assert.Equal(originalContent, savedContent);
+    }
+
+    [Fact]
+    public async Task TimedOutTool_ContinuesProcessingRemainingTools()
+    {
+        // First tool: hangs; Second tool: succeeds
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "a-hanging-tool.md"), CreateToolContent("a-hanging"));
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "b-fast-tool.md"), CreateToolContent("b-fast"));
+
+        var selectiveClient = new GenerativeAIClient(new SelectiveHangChatClient("a-hanging"));
+        var service = new ImprovedToolGeneratorService(selectiveClient, "system", "{0}");
+
+        var result = await service.GenerateImprovedToolFilesAsync(
+            _inputDir, _outputDir, maxTokens: 1000,
+            perToolTimeout: TimeSpan.FromMilliseconds(200));
+
+        // Both files should exist in output
+        Assert.True(File.Exists(Path.Combine(_outputDir, "a-hanging-tool.md")), "Timed-out tool should still produce output");
+        Assert.True(File.Exists(Path.Combine(_outputDir, "b-fast-tool.md")), "Fast tool should produce output");
+    }
+
+    // ── External cancellation propagates ──
+
+    [Fact]
+    public async Task ExternalCancellation_PropagatesImmediately()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "tool.md"), CreateToolContent());
+
+        var hangingClient = new GenerativeAIClient(new HangingChatClient());
+        var service = new ImprovedToolGeneratorService(hangingClient, "system", "{0}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await service.GenerateImprovedToolFilesAsync(
+                _inputDir, _outputDir, maxTokens: 1000,
+                perToolTimeout: TimeSpan.FromMinutes(5),
+                externalCt: cts.Token));
+    }
+
+    // ── AI exception falls back to original ──
+
+    [Fact]
+    public async Task AiException_SavesOriginalContent()
+    {
+        var originalContent = CreateToolContent("error-tool");
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "error-tool.md"), originalContent);
+
+        var throwingClient = new GenerativeAIClient(new ThrowingChatClient());
+        var service = new ImprovedToolGeneratorService(throwingClient, "system", "{0}");
+
+        var result = await service.GenerateImprovedToolFilesAsync(
+            _inputDir, _outputDir, maxTokens: 1000);
+
+        var outputPath = Path.Combine(_outputDir, "error-tool.md");
+        Assert.True(File.Exists(outputPath), "Output file should exist even when AI throws");
+
+        var savedContent = await File.ReadAllTextAsync(outputPath);
+        Assert.Equal(originalContent, savedContent);
+    }
+
+    [Fact]
+    public async Task AiException_ReturnsZero_NotError()
+    {
+        // AI failures with fallback should not be counted as hard errors
+        await File.WriteAllTextAsync(Path.Combine(_inputDir, "error-tool.md"), CreateToolContent());
+
+        var throwingClient = new GenerativeAIClient(new ThrowingChatClient());
+        var service = new ImprovedToolGeneratorService(throwingClient, "system", "{0}");
+
+        var result = await service.GenerateImprovedToolFilesAsync(
+            _inputDir, _outputDir, maxTokens: 1000);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task DefaultPerToolTimeout_IsFiveMinutes()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(5), ImprovedToolGeneratorService.DefaultPerToolTimeout);
+    }
+
+    // ── Stub chat clients ──
+
+    /// <summary>Chat client that never returns (simulates Azure OpenAI hang).</summary>
+    private sealed class HangingChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("test-hanging");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            return Task.Delay(Timeout.Infinite, cancellationToken)
+                .ContinueWith<ChatResponse>(_ => throw new OperationCanceledException(), cancellationToken);
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>Chat client that hangs for tools whose content contains a trigger string, succeeds for others.</summary>
+    private sealed class SelectiveHangChatClient : IChatClient
+    {
+        private readonly string _hangTrigger;
+        public SelectiveHangChatClient(string hangTrigger) => _hangTrigger = hangTrigger;
+        public ChatClientMetadata Metadata => new("test-selective");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var userMsg = chatMessages.LastOrDefault(m => m.Role == ChatRole.User)?.Text ?? "";
+            if (userMsg.Contains(_hangTrigger))
+            {
+                return Task.Delay(Timeout.Infinite, cancellationToken)
+                    .ContinueWith<ChatResponse>(_ => throw new OperationCanceledException(), cancellationToken);
+            }
+
+            var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, userMsg))
+            {
+                FinishReason = ChatFinishReason.Stop
+            };
+            return Task.FromResult(response);
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>Chat client that throws an HttpRequestException (simulates server error).</summary>
+    private sealed class ThrowingChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("test-throwing");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new HttpRequestException("502 Bad Gateway");
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Program.cs
@@ -75,7 +75,8 @@ internal class Program
             var result = await generator.GenerateImprovedToolFilesAsync(
                 composedToolsDir,
                 outputDir,
-                maxTokens);
+                maxTokens,
+                externalCt: default);
 
             Console.WriteLine();
             Console.WriteLine(result == 0 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Program.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Program.cs
@@ -76,7 +76,7 @@ internal class Program
                 composedToolsDir,
                 outputDir,
                 maxTokens,
-                externalCt: default);
+                pipelineCancellationToken: default);
 
             Console.WriteLine();
             Console.WriteLine(result == 0 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
@@ -66,10 +66,17 @@ public class ImprovedToolGeneratorService
     /// <summary>
     /// Generates improved tool files using AI to apply Microsoft content guidelines
     /// </summary>
+    /// <summary>
+    /// Default per-tool AI call timeout. Each tool gets this much time before falling back to composed content.
+    /// </summary>
+    internal static readonly TimeSpan DefaultPerToolTimeout = TimeSpan.FromMinutes(5);
+
     public async Task<int> GenerateImprovedToolFilesAsync(
         string composedToolsDir,
         string outputDir,
-        int maxTokens = 8000)
+        int maxTokens = 8000,
+        TimeSpan? perToolTimeout = null,
+        CancellationToken externalCt = default)
     {
         Console.WriteLine("\n┌─────────────────────────────────────────────┐");
         Console.WriteLine("│  Generating AI-Improved Tool Files         │");
@@ -82,9 +89,12 @@ public class ImprovedToolGeneratorService
             return 1;
         }
 
+        var timeout = perToolTimeout ?? DefaultPerToolTimeout;
+
         Console.WriteLine($"  Composed Tools Directory: {composedToolsDir}");
         Console.WriteLine($"  Output Directory: {outputDir}");
         Console.WriteLine($"  Max Tokens: {maxTokens}");
+        Console.WriteLine($"  Per-Tool Timeout: {timeout.TotalMinutes:F0} minutes");
         Console.WriteLine();
 
         // Ensure output directory exists
@@ -108,6 +118,7 @@ public class ImprovedToolGeneratorService
         int successCount = 0;
         int skippedCount = 0;
         int errorCount = 0;
+        int timedOutCount = 0;
 
         for (int i = 0; i < composedFiles.Length; i++)
         {
@@ -117,10 +128,19 @@ public class ImprovedToolGeneratorService
 
             try
             {
+                // Check if external cancellation was requested before starting this tool
+                externalCt.ThrowIfCancellationRequested();
+
                 Console.Write($"  {progress} Processing {fileName}...");
 
                 // Load composed file content
-                var originalContent = await File.ReadAllTextAsync(composedFilePath);
+                var originalContent = await File.ReadAllTextAsync(composedFilePath, externalCt);
+
+                // Create a per-tool timeout linked to external cancellation
+                using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+                toolCts.CancelAfter(timeout);
+                var toolCt = toolCts.Token;
+
                 var requiredParameters = ExtractRequiredParameters(originalContent);
 
                 // Freeze example prompt sections before any other protection
@@ -136,11 +156,12 @@ public class ImprovedToolGeneratorService
                 var userPrompt = string.Format(_userPromptTemplate, protectedContent);
                 userPrompt = AppendRequiredParameterPreservationInstruction(userPrompt, requiredParameters);
 
-                // Call AI to improve the content
+                // Call AI to improve the content with per-tool timeout
                 var improvedContent = await _aiClient.GetChatCompletionAsync(
                     _systemPrompt,
                     userPrompt,
-                    maxTokens);
+                    maxTokens,
+                    toolCt);
 
                 // Restore protected labels and normalize formatting
                 var restoredContent = RestoreTemplateLabels(improvedContent, labelMap);
@@ -184,45 +205,54 @@ public class ImprovedToolGeneratorService
                 successCount++;
                 Console.WriteLine(" ✓");
             }
+            catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
+            {
+                // External (caller) cancellation — propagate immediately, don't swallow
+                Console.WriteLine($" ✗ Cancelled by caller");
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // Per-tool timeout — save original composed content as fallback
+                Console.WriteLine($" ⏱ Timed out after {timeout.TotalMinutes:F0}m — saving original");
+                timedOutCount++;
+                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
+            }
             catch (InvalidOperationException ex) when (ex.Message.Contains("truncated"))
             {
                 // Handle truncation error - save original instead
                 Console.WriteLine($" ⚠ Truncated - saving original");
                 Console.WriteLine($"      {ex.Message}");
-                
-                try
-                {
-                    var originalContent = await File.ReadAllTextAsync(composedFilePath);
-                    var outputPath = Path.Combine(outputDir, fileName);
-                    await File.WriteAllTextAsync(outputPath, originalContent, Encoding.UTF8);
-                    skippedCount++;
-                }
-                catch (Exception saveEx)
-                {
-                    Console.WriteLine($"      Error saving original: {saveEx.Message}");
-                    errorCount++;
-                }
+                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
+                skippedCount++;
             }
             catch (Exception ex)
             {
-                Console.WriteLine($" ✗");
-                Console.WriteLine($"      Error: {ex.Message}");
-                errorCount++;
+                // Any other AI failure — save original composed content as fallback
+                Console.WriteLine($" ⚠ AI error — saving original");
+                Console.WriteLine($"      {ex.GetType().Name}: {ex.Message}");
+                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
+                skippedCount++;
             }
 
             // Add a small delay between requests to avoid rate limiting
             if (i < composedFiles.Length - 1)
             {
-                await Task.Delay(100);
+                await Task.Delay(100, CancellationToken.None);
             }
         }
 
         Console.WriteLine();
         Console.WriteLine($"  ✓ Successfully improved {successCount} tool files");
         
+        if (timedOutCount > 0)
+        {
+            Console.WriteLine($"  ⏱ Timed out {timedOutCount} files (original saved)");
+        }
+
         if (skippedCount > 0)
         {
-            Console.WriteLine($"  ⚠ Skipped {skippedCount} files (truncation - original saved)");
+            Console.WriteLine($"  ⚠ Skipped {skippedCount} files (AI error/truncation — original saved)");
         }
         
         if (errorCount > 0)
@@ -231,6 +261,23 @@ public class ImprovedToolGeneratorService
         }
 
         return errorCount > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Saves the original composed content as a fallback when AI improvement fails.
+    /// </summary>
+    private static async Task SaveOriginalAsFallback(string composedFilePath, string outputDir, string fileName)
+    {
+        try
+        {
+            var originalContent = await File.ReadAllTextAsync(composedFilePath);
+            var outputPath = Path.Combine(outputDir, fileName);
+            await File.WriteAllTextAsync(outputPath, originalContent, Encoding.UTF8);
+        }
+        catch (Exception saveEx)
+        {
+            Console.WriteLine($"      Error saving original: {saveEx.Message}");
+        }
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
@@ -126,88 +126,39 @@ public class ImprovedToolGeneratorService
             var fileName = Path.GetFileName(composedFilePath);
             var progress = $"[{i + 1}/{composedFiles.Length}]";
 
+            // Check if external cancellation was requested before starting this tool
+            externalCt.ThrowIfCancellationRequested();
+
+            Console.Write($"  {progress} Processing {fileName}...");
+
+            // Load composed file content (outside try — file read failures are hard errors)
+            var originalContent = await File.ReadAllTextAsync(composedFilePath, externalCt);
+
+            // Pre-processing (deterministic, should not fail — errors here are real bugs)
+            var requiredParameters = ExtractRequiredParameters(originalContent);
+            var frozenContent = ProtectExamplePromptSections(originalContent, out var sectionMap);
+            var mcpCliComment = ExtractMcpCliComment(originalContent);
+            var protectedContent = ProtectTemplateLabels(frozenContent, out var labelMap);
+            var userPrompt = string.Format(_userPromptTemplate, protectedContent);
+            userPrompt = AppendRequiredParameterPreservationInstruction(userPrompt, requiredParameters);
+
+            // AI call — this is the section that may hang/fail/timeout
+            string improvedContent;
             try
             {
-                // Check if external cancellation was requested before starting this tool
-                externalCt.ThrowIfCancellationRequested();
-
-                Console.Write($"  {progress} Processing {fileName}...");
-
-                // Load composed file content
-                var originalContent = await File.ReadAllTextAsync(composedFilePath, externalCt);
-
-                // Create a per-tool timeout linked to external cancellation
                 using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
                 toolCts.CancelAfter(timeout);
                 var toolCt = toolCts.Token;
 
-                var requiredParameters = ExtractRequiredParameters(originalContent);
-
-                // Freeze example prompt sections before any other protection
-                var frozenContent = ProtectExamplePromptSections(originalContent, out var sectionMap);
-
-                // Extract @mcpcli command comment before AI (AI sometimes strips it)
-                var mcpCliComment = ExtractMcpCliComment(originalContent);
-
-                // Protect handlebar template labels from AI modification
-                var protectedContent = ProtectTemplateLabels(frozenContent, out var labelMap);
-
-                // Generate user prompt with the content
-                var userPrompt = string.Format(_userPromptTemplate, protectedContent);
-                userPrompt = AppendRequiredParameterPreservationInstruction(userPrompt, requiredParameters);
-
-                // Call AI to improve the content with per-tool timeout
-                var improvedContent = await _aiClient.GetChatCompletionAsync(
+                improvedContent = await _aiClient.GetChatCompletionAsync(
                     _systemPrompt,
                     userPrompt,
                     maxTokens,
                     toolCt);
-
-                // Restore protected labels and normalize formatting
-                var restoredContent = RestoreTemplateLabels(improvedContent, labelMap);
-                restoredContent = NormalizeTemplateLabels(restoredContent);
-
-                // Restore frozen example prompt sections
-                restoredContent = RestoreExamplePromptSections(restoredContent, sectionMap);
-
-                // Restore @mcpcli command comment if AI stripped it
-                restoredContent = RestoreMcpCliComment(restoredContent, mcpCliComment);
-
-                // Validate no leaked placeholder tokens remain
-                var leakedTokens = ValidateRestoredContent(restoredContent);
-                if (leakedTokens.Count > 0)
-                {
-                    Console.WriteLine($" ⚠ Leaked tokens detected: {string.Join(", ", leakedTokens)}");
-                    Console.WriteLine($"      Falling back to original content");
-                    restoredContent = originalContent;
-                }
-                else if (requiredParameters.Count > 0)
-                {
-                    var missingRequiredParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
-                    if (missingRequiredParameters.Count > 0)
-                    {
-                        Console.WriteLine($" ⚠ Missing required parameters after AI: {string.Join(", ", missingRequiredParameters.Select(parameter => parameter.DisplayName))}");
-                        restoredContent = ReinjectMissingRequiredParameters(restoredContent, originalContent, missingRequiredParameters);
-
-                        var remainingMissingParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
-                        if (remainingMissingParameters.Count > 0)
-                        {
-                            Console.WriteLine($"      Reinjection incomplete; falling back to original content");
-                            restoredContent = originalContent;
-                        }
-                    }
-                }
-
-                // Save improved content
-                var outputPath = Path.Combine(outputDir, fileName);
-                await File.WriteAllTextAsync(outputPath, restoredContent, Encoding.UTF8);
-
-                successCount++;
-                Console.WriteLine(" ✓");
             }
             catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
             {
-                // External (caller) cancellation — propagate immediately, don't swallow
+                // External (caller) cancellation — propagate immediately
                 Console.WriteLine($" ✗ Cancelled by caller");
                 throw;
             }
@@ -216,24 +167,64 @@ public class ImprovedToolGeneratorService
                 // Per-tool timeout — save original composed content as fallback
                 Console.WriteLine($" ⏱ Timed out after {timeout.TotalMinutes:F0}m — saving original");
                 timedOutCount++;
-                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
+                await SaveFallbackContent(originalContent, outputDir, fileName);
+                continue;
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("truncated"))
             {
-                // Handle truncation error - save original instead
                 Console.WriteLine($" ⚠ Truncated - saving original");
                 Console.WriteLine($"      {ex.Message}");
-                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
                 skippedCount++;
+                await SaveFallbackContent(originalContent, outputDir, fileName);
+                continue;
             }
             catch (Exception ex)
             {
-                // Any other AI failure — save original composed content as fallback
+                // AI-specific failure (network, server error, etc.) — save original as fallback
                 Console.WriteLine($" ⚠ AI error — saving original");
                 Console.WriteLine($"      {ex.GetType().Name}: {ex.Message}");
-                await SaveOriginalAsFallback(composedFilePath, outputDir, fileName);
                 skippedCount++;
+                await SaveFallbackContent(originalContent, outputDir, fileName);
+                continue;
             }
+
+            // Post-processing (deterministic — errors here are real bugs, not swallowed)
+            var restoredContent = RestoreTemplateLabels(improvedContent, labelMap);
+            restoredContent = NormalizeTemplateLabels(restoredContent);
+            restoredContent = RestoreExamplePromptSections(restoredContent, sectionMap);
+            restoredContent = RestoreMcpCliComment(restoredContent, mcpCliComment);
+
+            // Validate no leaked placeholder tokens remain
+            var leakedTokens = ValidateRestoredContent(restoredContent);
+            if (leakedTokens.Count > 0)
+            {
+                Console.WriteLine($" ⚠ Leaked tokens detected: {string.Join(", ", leakedTokens)}");
+                Console.WriteLine($"      Falling back to original content");
+                restoredContent = originalContent;
+            }
+            else if (requiredParameters.Count > 0)
+            {
+                var missingRequiredParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
+                if (missingRequiredParameters.Count > 0)
+                {
+                    Console.WriteLine($" ⚠ Missing required parameters after AI: {string.Join(", ", missingRequiredParameters.Select(parameter => parameter.DisplayName))}");
+                    restoredContent = ReinjectMissingRequiredParameters(restoredContent, originalContent, missingRequiredParameters);
+
+                    var remainingMissingParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
+                    if (remainingMissingParameters.Count > 0)
+                    {
+                        Console.WriteLine($"      Reinjection incomplete; falling back to original content");
+                        restoredContent = originalContent;
+                    }
+                }
+            }
+
+            // Save improved content
+            var outputPath = Path.Combine(outputDir, fileName);
+            await File.WriteAllTextAsync(outputPath, restoredContent, Encoding.UTF8);
+
+            successCount++;
+            Console.WriteLine(" ✓");
 
             // Add a small delay between requests to avoid rate limiting
             if (i < composedFiles.Length - 1)
@@ -265,18 +256,18 @@ public class ImprovedToolGeneratorService
 
     /// <summary>
     /// Saves the original composed content as a fallback when AI improvement fails.
+    /// Uses already-loaded content to avoid re-reading the file.
     /// </summary>
-    private static async Task SaveOriginalAsFallback(string composedFilePath, string outputDir, string fileName)
+    private static async Task SaveFallbackContent(string originalContent, string outputDir, string fileName)
     {
         try
         {
-            var originalContent = await File.ReadAllTextAsync(composedFilePath);
             var outputPath = Path.Combine(outputDir, fileName);
             await File.WriteAllTextAsync(outputPath, originalContent, Encoding.UTF8);
         }
         catch (Exception saveEx)
         {
-            Console.WriteLine($"      Error saving original: {saveEx.Message}");
+            Console.WriteLine($"      Error saving fallback: {saveEx.Message}");
         }
     }
 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
@@ -76,7 +76,7 @@ public class ImprovedToolGeneratorService
         string outputDir,
         int maxTokens = 8000,
         TimeSpan? perToolTimeout = null,
-        CancellationToken externalCt = default)
+        CancellationToken pipelineCancellationToken = default)
     {
         Console.WriteLine("\n┌─────────────────────────────────────────────┐");
         Console.WriteLine("│  Generating AI-Improved Tool Files         │");
@@ -126,13 +126,13 @@ public class ImprovedToolGeneratorService
             var fileName = Path.GetFileName(composedFilePath);
             var progress = $"[{i + 1}/{composedFiles.Length}]";
 
-            // Check if external cancellation was requested before starting this tool
-            externalCt.ThrowIfCancellationRequested();
+            // Check if pipeline cancellation was requested before starting this tool
+            pipelineCancellationToken.ThrowIfCancellationRequested();
 
             Console.Write($"  {progress} Processing {fileName}...");
 
             // Load composed file content (outside try — file read failures are hard errors)
-            var originalContent = await File.ReadAllTextAsync(composedFilePath, externalCt);
+            var originalContent = await File.ReadAllTextAsync(composedFilePath, pipelineCancellationToken);
 
             // Pre-processing (deterministic, should not fail — errors here are real bugs)
             var requiredParameters = ExtractRequiredParameters(originalContent);
@@ -146,7 +146,7 @@ public class ImprovedToolGeneratorService
             string improvedContent;
             try
             {
-                using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+                using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(pipelineCancellationToken);
                 toolCts.CancelAfter(timeout);
                 var toolCt = toolCts.Token;
 
@@ -156,7 +156,7 @@ public class ImprovedToolGeneratorService
                     maxTokens,
                     toolCt);
             }
-            catch (OperationCanceledException) when (externalCt.IsCancellationRequested)
+            catch (OperationCanceledException) when (pipelineCancellationToken.IsCancellationRequested)
             {
                 // External (caller) cancellation — propagate immediately
                 Console.WriteLine($" ✗ Cancelled by caller");


### PR DESCRIPTION
Fixes #507

## Problem

Step 3 AI improvement phase hung indefinitely when Azure OpenAI did not respond — a single hanging API call froze the entire pipeline, preventing Step 4 (cleanup/stitching) from running.

## Root Cause

- `GetChatCompletionAsync()` accepts a `CancellationToken` but no caller passes one
- No per-tool timeout in the 16-tool improvement loop
- No fallback when AI fails — original composed content (which is perfectly usable) is discarded

## Fix

### `ImprovedToolGeneratorService.cs`
- Per-tool `CancellationTokenSource` with configurable timeout (default: 5 min)
- On timeout: save original composed content as fallback, continue to next tool
- On any AI error (HttpRequestException, etc.): same fallback behavior
- External (caller) cancellation: propagated immediately (not swallowed)
- Extracted `SaveOriginalAsFallback()` helper (DRY with existing truncation fallback)

### `AiTimeoutFallbackTests.cs` (6 new tests)
- Timed-out tool saves original content
- Pipeline continues after timeout (processes remaining tools)
- External cancellation propagates
- AI exception saves original content
- AI exception returns success (not hard error)
- Default timeout is 5 minutes

### Test Results
All 69 tests pass (63 existing + 6 new).

## What This Does NOT Change
- `GenerativeAIClient` shared behavior (future PR for shared hardening)
- Retry logic (still handles 429 only — expanding to 5xx is a separate PR)
- Other steps that use AI (Steps 2, 4, 6 unaffected)