### PR TITLE
Migrate infrastructure from Azure OpenAI to Foundry (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Infrastructure migrated from Azure OpenAI to Azure AI Services** — Updated Bicep templates to use `kind: 'AIServices'` instead of `kind: 'OpenAI'` for Microsoft Foundry compatibility. Upgraded API version to `2025-06-01`. Changed resource naming from `oai-*` to `ai-*`. The SDK (Azure.AI.OpenAI) and environment variables (FOUNDRY_*) remain unchanged and are compatible with both Azure OpenAI and Foundry endpoints. (#506)
+
 ### Fixed
 
 - **Per-tool AI timeout and fallback in Step 3** — The AI improvement phase now applies a configurable per-tool timeout (default: 5 minutes) via `CancellationToken`. When a tool's AI call hangs or fails, the pipeline saves the original composed content as fallback and continues processing remaining tools. Previously, a single hanging Azure OpenAI call would freeze the entire pipeline indefinitely, preventing Step 4 (cleanup/stitching) from ever running. External (caller) cancellation is properly distinguished from per-tool timeout and propagated immediately. (#507)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Infrastructure migrated from Azure OpenAI to Azure AI Services** — Updated Bicep templates to use `kind: 'AIServices'` instead of `kind: 'OpenAI'` for Microsoft Foundry compatibility. Upgraded API version to `2025-06-01`. Changed resource naming from `oai-*` to `ai-*`. The SDK (Azure.AI.OpenAI) and environment variables (FOUNDRY_*) remain unchanged and are compatible with both Azure OpenAI and Foundry endpoints. (#506)
+- **Infrastructure migrated from Azure OpenAI to Azure AI Services** — Updated Bicep templates to use `kind: 'AIServices'` instead of `kind: 'OpenAI'` for Microsoft Foundry compatibility. Upgraded API version to `2025-06-01`. Resource names preserved as `oai-*` for deployment continuity (avoids destroy/recreate of existing Azure resources). The SDK (Azure.AI.OpenAI) and environment variables (FOUNDRY_*) remain unchanged and are compatible with both Azure OpenAI and Foundry endpoints. (#506)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ wait
 
 | Phase | Description | Typical output | AI Required |
 |------|-------------|----------------|-------------|
-| 0 | Typed bootstrap: validate Azure OpenAI config when needed, clean/create output folders, build the solution, extract MCP CLI metadata, validate brand mappings, and run shared parsers | `cli/`, `e2e-test-prompts/`, build artifacts, brand validation output | No |
+| 0 | Typed bootstrap: validate Azure AI Services config when needed, clean/create output folders, build the solution, extract MCP CLI metadata, validate brand mappings, and run shared parsers | `cli/`, `e2e-test-prompts/`, build artifacts, brand validation output | No |
 | 1 | Generate annotations, parameter files, and raw tool markdown | `annotations/`, `parameters/`, `tools-raw/` | No |
 | 2 | Generate example prompts for each tool | `example-prompts/`, `example-prompts-prompts/` | Yes |
 | 3 | Generate composed and AI-improved tool files | `tools/` | Yes |
@@ -75,7 +75,7 @@ wait
 | 5 | Generate GitHub Copilot skills relevance reports (supplementary, non-fatal) | `skills-relevance/{namespace}-skills-relevance.md` | No |
 | 6 | Generate horizontal articles | `horizontal-articles/horizontal-article-{namespace}.md` | Yes |
 
-**Note**: Steps 2, 3, 4, and 6 require Azure OpenAI credentials configured in `mcp-tools/.env`. See [mcp-tools/scripts/README.md](mcp-tools/scripts/README.md) for details.
+**Note**: Steps 2, 3, 4, and 6 require Azure AI Services (Foundry-compatible) credentials configured in `mcp-tools/.env`. See [mcp-tools/scripts/README.md](mcp-tools/scripts/README.md) for details.
 
 ## Key Paths
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,12 +30,13 @@ resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
 
 // ── Azure AI Services — Primary (location) ──────────────────────────────────────
 // Uses AIServices kind which supports Microsoft Foundry and Azure OpenAI
+// Resource name kept as 'oai-' prefix for deployment continuity (legacy naming)
 
 module openAiPrimary 'modules/openai.bicep' = {
   name: 'foundry-primary'
   scope: rg
   params: {
-    name: 'ai-${environmentName}'
+    name: 'oai-${environmentName}'
     location: location
     gpt5MiniDeploymentName: gpt5MiniDeploymentName
     gpt5MiniCapacity: gpt5MiniCapacity
@@ -48,7 +49,7 @@ module openAiSecondary 'modules/openai.bicep' = {
   name: 'foundry-secondary'
   scope: rg
   params: {
-    name: 'ai-${environmentName}-sec'
+    name: 'oai-${environmentName}-sec'
     location: secondaryLocation
     gpt5MiniDeploymentName: gpt5MiniDeploymentName
     gpt5MiniCapacity: gpt5MiniCapacity

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,10 +15,10 @@ param gpt5MiniDeploymentName string = 'gpt-5-mini'
 @description('Capacity (in thousands of tokens-per-minute) for GPT-5-mini deployment.')
 param gpt5MiniCapacity int = 50
 
-@description('Secondary location for OpenAI resources.')
+@description('Secondary location for AI Services resources.')
 param secondaryLocation string = 'swedencentral'
 
-@description('Azure OpenAI API version.')
+@description('Azure AI Services API version.')
 param openAiApiVersion string = '2025-03-01-preview'
 
 // ── Resource Group ──────────────────────────────────────────────────────────────
@@ -28,26 +28,27 @@ resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   location: location
 }
 
-// ── Azure OpenAI — Primary (location) ───────────────────────────────────────────
+// ── Azure AI Services — Primary (location) ──────────────────────────────────────
+// Uses AIServices kind which supports Microsoft Foundry and Azure OpenAI
 
 module openAiPrimary 'modules/openai.bicep' = {
-  name: 'openai-primary'
+  name: 'foundry-primary'
   scope: rg
   params: {
-    name: 'oai-${environmentName}'
+    name: 'ai-${environmentName}'
     location: location
     gpt5MiniDeploymentName: gpt5MiniDeploymentName
     gpt5MiniCapacity: gpt5MiniCapacity
   }
 }
 
-// ── Azure OpenAI — Secondary (swedencentral) ────────────────────────────────────
+// ── Azure AI Services — Secondary (swedencentral) ───────────────────────────────
 
 module openAiSecondary 'modules/openai.bicep' = {
-  name: 'openai-secondary'
+  name: 'foundry-secondary'
   scope: rg
   params: {
-    name: 'oai-${environmentName}-sec'
+    name: 'ai-${environmentName}-sec'
     location: secondaryLocation
     gpt5MiniDeploymentName: gpt5MiniDeploymentName
     gpt5MiniCapacity: gpt5MiniCapacity

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -1,4 +1,4 @@
-@description('Name of the Azure OpenAI resource.')
+@description('Name of the Azure AI Services resource.')
 param name string
 
 @description('Location for the resource.')
@@ -10,12 +10,12 @@ param gpt5MiniDeploymentName string
 @description('Capacity for GPT-5-mini deployment (thousands of TPM).')
 param gpt5MiniCapacity int
 
-// ── Azure OpenAI Account ────────────────────────────────────────────────────────
+// ── Azure AI Services Account (supports Foundry) ────────────────────────────────
 
-resource openAi 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+resource openAi 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: name
   location: location
-  kind: 'OpenAI'
+  kind: 'AIServices'
   sku: {
     name: 'S0'
   }
@@ -27,7 +27,7 @@ resource openAi 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
 
 // ── GPT-5-mini Deployment ────────────────────────────────────────────────────────
 
-resource gpt5MiniDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+resource gpt5MiniDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
   parent: openAi
   name: gpt5MiniDeploymentName
   sku: {


### PR DESCRIPTION
## Summary

Migrates Bicep infrastructure from Azure OpenAI to Azure AI Services (Microsoft Foundry-compatible).

## Key Changes

### Infrastructure (Bicep)
- ✅ Updated kind: 'OpenAI' → kind: 'AIServices' (supports Foundry)
- ✅ Upgraded API version: 2024-10-01 → 2025-06-01
- ✅ Module deployment names: openai-* → foundry-*
- ✅ **Resource names preserved**: 'oai-*' prefix kept for deployment continuity (no destroy/recreate)
- ✅ Comments updated to reflect Azure AI Services / Foundry terminology

### Documentation
- ✅ Updated README.md references from Azure OpenAI to Azure AI Services
- ✅ Updated CHANGELOG.md with migration details

### What Stayed the Same
- ✅ SDK: Azure.AI.OpenAI works with both Azure OpenAI and Foundry
- ✅ Environment variables: FOUNDRY_* prefix was already forward-looking
- ✅ Code: GenerativeAIClient abstraction supports both endpoint types
- ✅ **No breaking changes** — existing deployed resources are NOT affected

## Note on Resource Naming
The Azure resource names retain the legacy 'oai-' prefix intentionally. Renaming would destroy and recreate existing Azure resources on redeploy. The 'kind: AIServices' upgrade is non-destructive and enables Foundry support without affecting deployed infrastructure.