### PR TITLE
Security: Replace plain-text API key with Key Vault secret (#516)

### DIFF
--- a/infra/KEYVAULT-MIGRATION.md
+++ b/infra/KEYVAULT-MIGRATION.md
@@ -1,0 +1,16 @@
+# Key Vault Migration Guide
+
+## Migrating from FOUNDRY_API_KEY env var to Key Vault
+
+### What changed
+The infrastructure no longer outputs FOUNDRY_API_KEY as a plain-text Bicep output.
+The API key is now stored in Azure Key Vault. Applications retrieve it via DefaultAzureCredential.
+
+### How to migrate
+1. No code changes needed if you use DefaultAzureCredential.
+2. New env vars from azd up: FOUNDRY_USE_DEFAULT_CREDENTIAL=true, KEYVAULT_URI, KEYVAULT_SECRET_NAME
+3. Assign Key Vault Secrets User RBAC role to the consuming identity.
+4. Fallback: local FOUNDRY_API_KEY env var still works for development.
+
+### SECONDARY_FOUNDRY_API_KEY removal
+This was only a Bicep output. No app code, workflow, or script consumed it. Removal is safe.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -56,19 +56,32 @@ module openAiSecondary 'modules/openai.bicep' = {
   }
 }
 
+// ── Key Vault — Secure secret storage for API keys ──────────────────────────────
+
+module keyVault 'modules/keyvault.bicep' = {
+  name: 'keyvault'
+  scope: rg
+  params: {
+    name: 'kv-${environmentName}'
+    location: location
+    openAiResourceId: openAiPrimary.outputs.id
+  }
+}
+
 // ── Outputs (map to .env variables) — default to primary ────────────────────────
 
-output FOUNDRY_API_KEY string = openAiPrimary.outputs.apiKey
 output FOUNDRY_ENDPOINT string = openAiPrimary.outputs.endpoint
 output FOUNDRY_INSTANCE string = openAiPrimary.outputs.name
 output FOUNDRY_MODEL_NAME string = gpt5MiniDeploymentName
 output FOUNDRY_MODEL_API_VERSION string = openAiApiVersion
+output FOUNDRY_USE_DEFAULT_CREDENTIAL string = 'true'
 output TOOL_FAMILY_CLEANUP_FOUNDRY_MODEL_NAME string = gpt5MiniDeploymentName
 output TOOL_FAMILY_CLEANUP_FOUNDRY_MODEL_API_VERSION string = openAiApiVersion
 output ENDPOINT string = openAiPrimary.outputs.endpoint
+output KEYVAULT_URI string = keyVault.outputs.vaultUri
+output KEYVAULT_SECRET_NAME string = keyVault.outputs.secretName
 
 // ── Secondary outputs (for manual .env override or failover) ────────────────────
 
-output SECONDARY_FOUNDRY_API_KEY string = openAiSecondary.outputs.apiKey
 output SECONDARY_FOUNDRY_ENDPOINT string = openAiSecondary.outputs.endpoint
 output SECONDARY_FOUNDRY_INSTANCE string = openAiSecondary.outputs.name

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -1,0 +1,51 @@
+@description('Name of the Key Vault resource.')
+param name string
+
+@description('Location for the resource.')
+param location string
+
+@description('Resource ID of the Azure AI Services account whose key will be stored.')
+param openAiResourceId string
+
+@description('Name of the secret that stores the API key.')
+param secretName string = 'foundry-api-key'
+
+// ── Key Vault ────────────────────────────────────────────────────────────────────
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    enablePurgeProtection: true
+  }
+}
+
+// ── Reference the OpenAI resource to retrieve its key ────────────────────────────
+
+resource openAi 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = {
+  name: last(split(openAiResourceId, '/'))
+}
+
+// ── Store API key as a secret ────────────────────────────────────────────────────
+
+resource apiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: secretName
+  properties: {
+    value: openAi.listKeys().key1
+  }
+}
+
+// ── Outputs (safe — no secret values exposed) ────────────────────────────────────
+
+output vaultUri string = keyVault.properties.vaultUri
+output vaultName string = keyVault.name
+output secretName string = apiKeySecret.name

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -23,12 +23,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     tenantId: subscription().tenantId
     enableRbacAuthorization: true
     enableSoftDelete: true
-    softDeleteRetentionInDays: 7
+    softDeleteRetentionInDays: 90
     enablePurgeProtection: true
   }
 }
 
 // ── Reference the OpenAI resource to retrieve its key ────────────────────────────
+// Dependency: openAiResourceId comes from openAiPrimary.outputs.id in main.bicep,
+// creating an implicit ARM deployment dependency (this module deploys after OpenAI).
 
 resource openAi 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = {
   name: last(split(openAiResourceId, '/'))

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -48,4 +48,3 @@ resource gpt5MiniDeployment 'Microsoft.CognitiveServices/accounts/deployments@20
 output endpoint string = openAi.properties.endpoint
 output name string = openAi.name
 output id string = openAi.id
-output apiKey string = openAi.listKeys().key1

--- a/infra/tests/validate-bicep.ps1
+++ b/infra/tests/validate-bicep.ps1
@@ -1,0 +1,45 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Validates all Bicep files compile without errors.
+.DESCRIPTION
+    Runs 'az bicep build' on each .bicep file under infra/ to catch syntax
+    and reference errors before deployment.
+#>
+
+$ErrorActionPreference = 'Stop'
+$infraDir = Split-Path -Parent $PSScriptRoot
+$bicepFiles = Get-ChildItem -Path $infraDir -Filter '*.bicep' -Recurse | Where-Object { $_.Name -notlike '*.test.bicep' }
+
+$failed = @()
+$passed = 0
+
+foreach ($file in $bicepFiles) {
+    Write-Host "Validating: $($file.FullName)" -ForegroundColor Cyan
+    try {
+        $output = az bicep build --file $file.FullName 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  FAILED" -ForegroundColor Red
+            Write-Host "  $output"
+            $failed += $file.FullName
+        } else {
+            Write-Host "  OK" -ForegroundColor Green
+            $passed++
+            # Clean up generated ARM template
+            $armFile = [System.IO.Path]::ChangeExtension($file.FullName, '.json')
+            if (Test-Path $armFile) { Remove-Item $armFile -Force }
+        }
+    } catch {
+        Write-Host "  ERROR: $_" -ForegroundColor Red
+        $failed += $file.FullName
+    }
+}
+
+Write-Host "`n--- Results ---"
+Write-Host "Passed: $passed" -ForegroundColor Green
+if ($failed.Count -gt 0) {
+    Write-Host "Failed: $($failed.Count)" -ForegroundColor Red
+    $failed | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "All Bicep files validated successfully." -ForegroundColor Green


### PR DESCRIPTION
## Summary
Replaces plain-text API key outputs with secure Key Vault secret storage.

## Changes
- **Added** `infra/modules/keyvault.bicep` — Key Vault module that stores the OpenAI API key as a secret
- **Updated** `infra/modules/openai.bicep` — Removed `output apiKey` (line 51)
- **Updated** `infra/main.bicep` — Removed `FOUNDRY_API_KEY` and `SECONDARY_FOUNDRY_API_KEY` outputs; added Key Vault module + `KEYVAULT_URI`/`KEYVAULT_SECRET_NAME`/`FOUNDRY_USE_DEFAULT_CREDENTIAL` outputs
- **Added** `infra/tests/validate-bicep.ps1` — Bicep compilation validation script

## Security Impact
- API keys no longer visible in ARM deployment history, CI/CD logs, or template exports
- App already supports `DefaultAzureCredential` fallback (`GenerativeAIClient.cs:61-63`)
- `FOUNDRY_USE_DEFAULT_CREDENTIAL=true` is now set by default in deployment outputs

## Validation
- `az bicep build --file infra/main.bicep` passes with exit code 0
- No application code changes needed

Closes #516