### PR TITLE
Extract ToolOrderingPolicy + fix multi-resource sort key (#503, #504)

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolOrderingPolicyTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolOrderingPolicyTests.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// Tests for ToolOrderingPolicy — centralized ordering logic for single-resource
+/// and multi-resource families (#503, #504).
+/// </summary>
+public class ToolOrderingPolicyTests
+{
+    #region Single-Resource Ordering
+
+    [Fact]
+    public void OrderForSingleResource_SortsAlphabeticallyByToolName()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("vm delete", "compute vm delete", "vm-delete.md"),
+            MakeTool("disk list", "compute disk list", "disk-list.md"),
+            MakeTool("vm create", "compute vm create", "vm-create.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForSingleResource(tools).ToList();
+
+        Assert.Equal("disk list", ordered[0].ToolName);
+        Assert.Equal("vm create", ordered[1].ToolName);
+        Assert.Equal("vm delete", ordered[2].ToolName);
+    }
+
+    [Fact]
+    public void OrderForSingleResource_CaseInsensitive()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Zebra list", "ns zebra list", "zebra.md"),
+            MakeTool("apple create", "ns apple create", "apple.md"),
+            MakeTool("Banana get", "ns banana get", "banana.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForSingleResource(tools).ToList();
+
+        Assert.Equal("apple create", ordered[0].ToolName);
+        Assert.Equal("Banana get", ordered[1].ToolName);
+        Assert.Equal("Zebra list", ordered[2].ToolName);
+    }
+
+    [Fact]
+    public void OrderForSingleResource_TieBreakByFileName()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("list", "ns list", "b-list.md"),
+            MakeTool("list", "ns list", "a-list.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForSingleResource(tools).ToList();
+
+        Assert.Equal("a-list.md", ordered[0].FileName);
+        Assert.Equal("b-list.md", ordered[1].FileName);
+    }
+
+    [Fact]
+    public void OrderForSingleResource_EmptyList_ReturnsEmpty()
+    {
+        var ordered = ToolOrderingPolicy.OrderForSingleResource(Array.Empty<ToolContent>()).ToList();
+        Assert.Empty(ordered);
+    }
+
+    [Fact]
+    public void OrderForSingleResource_SingleTool_ReturnsThatTool()
+    {
+        var tools = new List<ToolContent> { MakeTool("only tool", "ns only", "only.md") };
+
+        var ordered = ToolOrderingPolicy.OrderForSingleResource(tools).ToList();
+
+        Assert.Single(ordered);
+        Assert.Equal("only tool", ordered[0].ToolName);
+    }
+
+    #endregion
+
+    #region Multi-Resource Ordering
+
+    [Fact]
+    public void OrderForMultiResource_SortsByActionVerb()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("VM delete", "compute vm delete", "vm-delete.md"),
+            MakeTool("VM create", "compute vm create", "vm-create.md"),
+            MakeTool("VM list", "compute vm list", "vm-list.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        // Sorted by action verb: create, delete, list
+        Assert.Equal("compute vm create", ordered[0].Command);
+        Assert.Equal("compute vm delete", ordered[1].Command);
+        Assert.Equal("compute vm list", ordered[2].Command);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_ActionVerbNotToolName()
+    {
+        // ToolName may differ from the action verb (e.g., after heading rewrite)
+        // Sort must use action verb from command, not ToolName
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Managed disk: list", "compute disk list", "disk-list.md"),
+            MakeTool("Managed disk: create", "compute disk create", "disk-create.md"),
+            MakeTool("Managed disk: delete", "compute disk delete", "disk-delete.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        // Sorted by action verb (create, delete, list) NOT by ToolName
+        Assert.Equal("compute disk create", ordered[0].Command);
+        Assert.Equal("compute disk delete", ordered[1].Command);
+        Assert.Equal("compute disk list", ordered[2].Command);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_SameActionVerb_TieBreakByFileName()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("disk b list", "compute disk-b list", "disk-b-list.md"),
+            MakeTool("disk a list", "compute disk-a list", "disk-a-list.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        Assert.Equal("disk-a-list.md", ordered[0].FileName);
+        Assert.Equal("disk-b-list.md", ordered[1].FileName);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_EmptyList_ReturnsEmpty()
+    {
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(Array.Empty<ToolContent>()).ToList();
+        Assert.Empty(ordered);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_SingleTool_ReturnsThatTool()
+    {
+        var tools = new List<ToolContent> { MakeTool("vm create", "compute vm create", "vm-create.md") };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        Assert.Single(ordered);
+        Assert.Equal("vm create", ordered[0].ToolName);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_NullCommand_SortsToFront()
+    {
+        var tools = new List<ToolContent>
+        {
+            MakeTool("vm list", "compute vm list", "vm-list.md"),
+            MakeTool("unknown", null, "unknown.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        // Null command extracts empty verb which sorts before "list"
+        Assert.Equal("unknown.md", ordered[0].FileName);
+        Assert.Equal("vm-list.md", ordered[1].FileName);
+    }
+
+    [Fact]
+    public void OrderForMultiResource_ConsistentResultsWhenToolNameDiffersFromDisplayHeading()
+    {
+        // Simulates the real bug: ToolName="VM create" but display heading becomes "VM: create"
+        // after ReformatToolHeadingForMultiResource. The sort must produce consistent
+        // ordering regardless of ToolName value.
+        var tools = new List<ToolContent>
+        {
+            MakeTool("Create virtual machine", "compute vm create", "vm-create.md"),
+            MakeTool("Delete virtual machine", "compute vm delete", "vm-delete.md"),
+            MakeTool("List virtual machines", "compute vm list", "vm-list.md"),
+        };
+
+        var orderedRun1 = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+        var orderedRun2 = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        // Verify order by action verb (create < delete < list) even though
+        // ToolNames would sort differently (Create < Delete < List happens to match,
+        // but the mechanism is verb-based)
+        Assert.Equal("compute vm create", orderedRun1[0].Command);
+        Assert.Equal("compute vm delete", orderedRun1[1].Command);
+        Assert.Equal("compute vm list", orderedRun1[2].Command);
+
+        // Deterministic across runs
+        for (int i = 0; i < orderedRun1.Count; i++)
+        {
+            Assert.Equal(orderedRun1[i].Command, orderedRun2[i].Command);
+        }
+    }
+
+    [Fact]
+    public void OrderForMultiResource_RealWorldToolNames_CorrectOrder()
+    {
+        // Real-world scenario: compute family with mixed resources
+        var tools = new List<ToolContent>
+        {
+            MakeTool("VMSS update", "compute vmss update", "vmss-update.md"),
+            MakeTool("disk create", "compute disk create", "disk-create.md"),
+            MakeTool("vm delete", "compute vm delete", "vm-delete.md"),
+            MakeTool("disk list", "compute disk list", "disk-list.md"),
+            MakeTool("vm create", "compute vm create", "vm-create.md"),
+        };
+
+        var ordered = ToolOrderingPolicy.OrderForMultiResource(tools).ToList();
+
+        // All sorted by action verb: create, create, delete, list, update
+        Assert.Equal("compute disk create", ordered[0].Command);
+        Assert.Equal("compute vm create", ordered[1].Command);
+        Assert.Equal("compute vm delete", ordered[2].Command);
+        Assert.Equal("compute disk list", ordered[3].Command);
+        Assert.Equal("compute vmss update", ordered[4].Command);
+    }
+
+    #endregion
+
+    #region ExtractActionVerb
+
+    [Theory]
+    [InlineData("compute disk create", "create")]
+    [InlineData("compute vm delete", "delete")]
+    [InlineData("storage blob list", "list")]
+    [InlineData("foundry agent thread create", "create")]
+    [InlineData("advisor list", "list")]
+    public void ExtractActionVerb_ReturnsLastSegment(string command, string expected)
+    {
+        var result = ToolOrderingPolicy.ExtractActionVerb(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ExtractActionVerb_NullOrEmpty_ReturnsEmpty(string? command)
+    {
+        var result = ToolOrderingPolicy.ExtractActionVerb(command);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ExtractActionVerb_SingleSegment_ReturnsThatSegment()
+    {
+        var result = ToolOrderingPolicy.ExtractActionVerb("list");
+        Assert.Equal("list", result);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static ToolContent MakeTool(string toolName, string? command, string fileName)
+    {
+        return new ToolContent
+        {
+            ToolName = toolName,
+            FileName = fileName,
+            FamilyName = "test",
+            Content = $"## {toolName}\n\nSome content.",
+            Command = command,
+            ResourceType = command != null ? ToolReader.GetResourceType(command) : string.Empty
+        };
+    }
+
+    #endregion
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolOrderingPolicyTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolOrderingPolicyTests.cs
@@ -261,6 +261,35 @@ public class ToolOrderingPolicyTests
 
     #endregion
 
+    [Theory]
+    [InlineData("compute vm create ", "create")]
+    [InlineData("  storage blob list  ", "list")]
+    public void ExtractActionVerb_TrailingOrLeadingWhitespace_ReturnsVerb(string command, string expected)
+    {
+        var result = ToolOrderingPolicy.ExtractActionVerb(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("az compute vm create --sku Standard", "create")]
+    [InlineData("compute disk list --output json", "list")]
+    [InlineData("storage blob upload --file test.txt --container my-container", "upload")]
+    public void ExtractActionVerb_CommandWithParameters_ReturnsVerbBeforeFlags(string command, string expected)
+    {
+        var result = ToolOrderingPolicy.ExtractActionVerb(command);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("storage-account-create", "storage-account-create")]
+    [InlineData("vm-deallocate", "vm-deallocate")]
+    public void ExtractActionVerb_HyphenatedSingleSegment_ReturnsFullSegment(string command, string expected)
+    {
+        // Hyphenated commands without spaces are treated as a single verb segment
+        var result = ToolOrderingPolicy.ExtractActionVerb(command);
+        Assert.Equal(expected, result);
+    }
+
     #region Helpers
 
     private static ToolContent MakeTool(string toolName, string? command, string fileName)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolReaderSortOrderTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/ToolReaderSortOrderTests.cs
@@ -8,8 +8,10 @@ using Xunit;
 namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
 
 /// <summary>
-/// Tests for ToolReader.GetResourceSortKey and the resource-type-first ordering
-/// of tools within each family (Issue #279).
+/// Tests for ToolReader.GetResourceSortKey and GetResourceType utilities.
+/// Note: ToolReader no longer sorts tools at read time (#503, #504) — ordering
+/// is handled by ToolOrderingPolicy at stitch time. These tests validate the
+/// sort key and resource type extraction utilities that inform grouping.
 /// </summary>
 public class ToolReaderSortOrderTests
 {

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -47,13 +47,9 @@ public class FamilyFileStitcher
         }
         else
         {
-            // Sort tools by ToolName (the generated display heading, e.g. "VM create")
-            // for consistent presentation order. ToolReader may pre-sort by resource/verb,
-            // but stitcher enforces final alphabetical order as the presentation authority. (#501)
-            foreach (var tool in familyContent.Tools
-                .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
-                .ThenBy(t => t.FileName, StringComparer.Ordinal))
+            // Sort tools for consistent single-resource presentation order (#503).
+            // Ordering delegated to ToolOrderingPolicy (alphabetical by ToolName).
+            foreach (var tool in ToolOrderingPolicy.OrderForSingleResource(familyContent.Tools))
             {
                 sb.AppendLine(tool.Content);
                 sb.AppendLine();
@@ -160,12 +156,10 @@ public class FamilyFileStitcher
             sb.AppendLine($"## {displayName}");
             sb.AppendLine();
 
-            // Sort tools by ToolName within each resource group for consistent
-            // presentation. Group order (first-seen) is preserved. (#501)
-            foreach (var tool in groupTools
-                .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
-                .ThenBy(t => t.FileName, StringComparer.Ordinal))
+            // Sort tools by action verb within each resource group for consistent
+            // presentation (#503, #504). Uses action verb (not ToolName) because the
+            // displayed heading is rewritten by ReformatToolHeadingForMultiResource.
+            foreach (var tool in ToolOrderingPolicy.OrderForMultiResource(groupTools))
             {
                 // #416: Reformat H2 heading to "Resource type: action" format before demoting
                 var reformattedContent = ReformatToolHeadingForMultiResource(tool);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolOrderingPolicy.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolOrderingPolicy.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Models;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Centralizes tool ordering logic for both single-resource and multi-resource families.
+/// This is the single authority for tool presentation order at stitch time.
+/// ToolReader provides metadata for grouping; ordering is applied here.
+/// </summary>
+public static class ToolOrderingPolicy
+{
+    /// <summary>
+    /// Orders tools for a single-resource family page.
+    /// Sort contract: case-insensitive alphabetical by ToolName, then case-sensitive
+    /// ToolName tie-break, then FileName for absolute determinism.
+    /// </summary>
+    /// <param name="tools">Unordered tools from a single-resource family.</param>
+    /// <returns>Tools in deterministic presentation order.</returns>
+    public static IEnumerable<ToolContent> OrderForSingleResource(IEnumerable<ToolContent> tools)
+    {
+        return tools
+            .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => t.ToolName, StringComparer.Ordinal)
+            .ThenBy(t => t.FileName, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Orders tools within a multi-resource group by action verb (last segment of the command),
+    /// then by FileName for determinism.
+    /// Sort contract: alphabetical by action verb extracted from the command
+    /// (the part after the resource type), NOT by ToolName — because ToolName may diverge
+    /// from the displayed heading after ReformatToolHeadingForMultiResource rewrites it.
+    /// </summary>
+    /// <param name="tools">Unordered tools within a single resource group.</param>
+    /// <returns>Tools ordered by action verb then FileName.</returns>
+    public static IEnumerable<ToolContent> OrderForMultiResource(IEnumerable<ToolContent> tools)
+    {
+        return tools
+            .OrderBy(t => ExtractActionVerb(t.Command), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => ExtractActionVerb(t.Command), StringComparer.Ordinal)
+            .ThenBy(t => t.FileName, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Extracts the action verb (last segment) from a command string.
+    /// Command format: "namespace resource1 [resource2...] verb"
+    /// Returns the verb portion (e.g., "create" from "compute disk create").
+    /// Returns empty string for null/empty commands.
+    /// </summary>
+    internal static string ExtractActionVerb(string? command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+            return string.Empty;
+
+        var segments = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length > 0 ? segments[^1] : string.Empty;
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolOrderingPolicy.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolOrderingPolicy.cs
@@ -56,6 +56,10 @@ public static class ToolOrderingPolicy
             return string.Empty;
 
         var segments = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        return segments.Length > 0 ? segments[^1] : string.Empty;
+
+        // Stop before the first parameter flag (e.g., "--sku")
+        var verbSegments = segments.TakeWhile(s => !s.StartsWith('-')).ToArray();
+
+        return verbSegments.Length > 0 ? verbSegments[^1] : string.Empty;
     }
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ToolReader.cs
@@ -77,16 +77,9 @@ public class ToolReader
             }
         }
 
-        // Sort tools within each family by resource type first, then by verb (#279).
-        // Command format: "namespace resource [resource2…] verb"
-        // Sort key groups all operations on the same resource together.
-        foreach (var family in toolsByFamily.Keys)
-        {
-            toolsByFamily[family] = toolsByFamily[family]
-                .OrderBy(t => GetResourceSortKey(t.Command), StringComparer.Ordinal)
-                .ThenBy(t => t.ToolName, StringComparer.Ordinal)
-                .ToList();
-        }
+        // Ordering is handled by ToolOrderingPolicy at stitch time (#503, #504).
+        // ToolReader groups tools by resource type for multi-resource detection
+        // but does NOT impose a presentation sort order.
 
         Console.WriteLine($"✓ Parsed {successCount} tools into {toolsByFamily.Count} families");
         if (failCount > 0)


### PR DESCRIPTION
## Summary

Centralizes tool ordering into a single ToolOrderingPolicy class, fixing the divergence between sort key and display key in multi-resource mode.

### Changes

- **New**: ToolOrderingPolicy.cs — static class with OrderForSingleResource() (alphabetical by ToolName) and OrderForMultiResource() (by action verb from command, then FileName)
- **Updated**: ToolReader.cs — removed inline sort; ToolReader now only groups, does not order
- **Updated**: FamilyFileStitcher.cs — delegates to ToolOrderingPolicy for both single and multi-resource paths
- **New**: ToolOrderingPolicyTests.cs — 15 tests covering single-resource ordering, multi-resource verb-based ordering, edge cases (empty, single, null command, tie-break), and determinism
- **Updated**: ToolReaderSortOrderTests.cs — docstring updated to reflect ToolReader no longer sorts

### Bug Fix (#504)
In multi-resource mode, tools were sorted by ToolName but the displayed heading was rewritten by ReformatToolHeadingForMultiResource(). Now sorting uses the **action verb** extracted from the command, which matches what appears in the displayed heading.

### Test Results
All 699 tests pass.

Closes #503, Closes #504