### PR TITLE
Align .NET TFM: net10.0 as single source of truth

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/mcp-tools/DocGeneration.E2E.Tests/DocGeneration.E2E.Tests.csproj
+++ b/mcp-tools/DocGeneration.E2E.Tests/DocGeneration.E2E.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/DocGeneration.PipelineRunner.Tests.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/DocGeneration.PipelineRunner.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/mcp-tools/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj
+++ b/mcp-tools/DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.csproj
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools.csproj
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools/DocGeneration.Steps.AnnotationsParametersRaw.RawTools.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/DocGeneration.Steps.Bootstrap.BrandMappings.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/DocGeneration.Steps.Bootstrap.BrandMappings.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings/DocGeneration.Steps.Bootstrap.BrandMappings.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings/DocGeneration.Steps.Bootstrap.BrandMappings.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>DocGeneration.Steps.Bootstrap.BrandMappings</AssemblyName>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser.Tests/DocGeneration.Steps.Bootstrap.CommandParser.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser.Tests/DocGeneration.Steps.Bootstrap.CommandParser.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser/DocGeneration.Steps.Bootstrap.CommandParser.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.CommandParser/DocGeneration.Steps.Bootstrap.CommandParser.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>DocGeneration.Steps.Bootstrap.E2eTestPromptParser</AssemblyName>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Tests/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Tests/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.csproj
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher/DocGeneration.Steps.Bootstrap.ToolMetadataEnricher.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DocGeneration.Steps.ExamplePrompts.Generation.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DocGeneration.Steps.ExamplePrompts.Generation.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/DocGeneration.Steps.ExamplePrompts.Generation.csproj
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/DocGeneration.Steps.ExamplePrompts.Generation.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>DocGeneration.Steps.ExamplePrompts.Generation</AssemblyName>

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation.Tests/DocGeneration.Steps.ExamplePrompts.Validation.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation.Tests/DocGeneration.Steps.ExamplePrompts.Validation.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>DocGeneration.Steps.ExamplePrompts.Validation.Tests</AssemblyName>
     <RootNamespace>DocGeneration.Steps.ExamplePrompts.Validation.Tests</RootNamespace>

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/DocGeneration.Steps.ExamplePrompts.Validation.csproj
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/DocGeneration.Steps.ExamplePrompts.Validation.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/DocGeneration.Steps.HorizontalArticles.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/DocGeneration.Steps.HorizontalArticles.csproj
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/DocGeneration.Steps.HorizontalArticles.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>DocGeneration.Steps.HorizontalArticles</RootNamespace>

--- a/mcp-tools/DocGeneration.Steps.SkillsRelevance.Tests/DocGeneration.Steps.SkillsRelevance.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.SkillsRelevance.Tests/DocGeneration.Steps.SkillsRelevance.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.SkillsRelevance/DocGeneration.Steps.SkillsRelevance.csproj
+++ b/mcp-tools/DocGeneration.Steps.SkillsRelevance/DocGeneration.Steps.SkillsRelevance.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>DocGeneration.Steps.SkillsRelevance</RootNamespace>

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DocGeneration.Steps.ToolFamilyCleanup.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DocGeneration.Steps.ToolFamilyCleanup.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Validation.Tests/DocGeneration.Steps.ToolFamilyCleanup.Validation.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Validation.Tests/DocGeneration.Steps.ToolFamilyCleanup.Validation.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/DocGeneration.Steps.ToolFamilyCleanup.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/DocGeneration.Steps.ToolFamilyCleanup.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>DocGeneration.Steps.ToolFamilyCleanup</RootNamespace>

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Composition/DocGeneration.Steps.ToolGeneration.Composition.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Composition/DocGeneration.Steps.ToolGeneration.Composition.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/DocGeneration.Steps.ToolGeneration.Improvements.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/DocGeneration.Steps.ToolGeneration.Improvements.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/DocGeneration.Steps.ToolGeneration.Improvements.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/DocGeneration.Steps.ToolGeneration.Improvements.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/mcp-tools/DocGeneration.Tools.Fingerprint.Tests/DocGeneration.Tools.Fingerprint.Tests.csproj
+++ b/mcp-tools/DocGeneration.Tools.Fingerprint.Tests/DocGeneration.Tools.Fingerprint.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mcp-tools/DocGeneration.Tools.Fingerprint/DocGeneration.Tools.Fingerprint.csproj
+++ b/mcp-tools/DocGeneration.Tools.Fingerprint/DocGeneration.Tools.Fingerprint.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>DocGeneration.Tools.Fingerprint</RootNamespace>

--- a/mcp-tools/DocGeneration.Utilities.ToolMetadataExtractor/DocGeneration.Utilities.ToolMetadataExtractor.csproj
+++ b/mcp-tools/DocGeneration.Utilities.ToolMetadataExtractor/DocGeneration.Utilities.ToolMetadataExtractor.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>DocGeneration.Utilities.ToolMetadataExtractor</AssemblyName>

--- a/shared/DocGeneration.Core.GenerativeAI.Tests/DocGeneration.Core.GenerativeAI.Tests.csproj
+++ b/shared/DocGeneration.Core.GenerativeAI.Tests/DocGeneration.Core.GenerativeAI.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>DocGeneration.Core.GenerativeAI.Tests</AssemblyName>
     <RootNamespace>DocGeneration.Core.GenerativeAI.Tests</RootNamespace>

--- a/shared/DocGeneration.Core.GenerativeAI/DocGeneration.Core.GenerativeAI.csproj
+++ b/shared/DocGeneration.Core.GenerativeAI/DocGeneration.Core.GenerativeAI.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/shared/DocGeneration.Core.Shared.Tests/DocGeneration.Core.Shared.Tests.csproj
+++ b/shared/DocGeneration.Core.Shared.Tests/DocGeneration.Core.Shared.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/shared/DocGeneration.Core.Shared/DocGeneration.Core.Shared.csproj
+++ b/shared/DocGeneration.Core.Shared/DocGeneration.Core.Shared.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
     <AssemblyName>DocGeneration.Core.Shared</AssemblyName>

--- a/shared/DocGeneration.Core.TemplateEngine.Tests/DocGeneration.Core.TemplateEngine.Tests.csproj
+++ b/shared/DocGeneration.Core.TemplateEngine.Tests/DocGeneration.Core.TemplateEngine.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/shared/DocGeneration.Core.TemplateEngine/DocGeneration.Core.TemplateEngine.csproj
+++ b/shared/DocGeneration.Core.TemplateEngine/DocGeneration.Core.TemplateEngine.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>DocGeneration.Core.TemplateEngine</RootNamespace>

--- a/shared/DocGeneration.Core.TextTransformation.Tests/DocGeneration.Core.TextTransformation.Tests.csproj
+++ b/shared/DocGeneration.Core.TextTransformation.Tests/DocGeneration.Core.TextTransformation.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/shared/DocGeneration.Core.TextTransformation/DocGeneration.Core.TextTransformation.csproj
+++ b/shared/DocGeneration.Core.TextTransformation/DocGeneration.Core.TextTransformation.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>DocGeneration.Core.TextTransformation</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>

--- a/shared/DocGeneration.TestInfrastructure/DocGeneration.TestInfrastructure.csproj
+++ b/shared/DocGeneration.TestInfrastructure/DocGeneration.TestInfrastructure.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/skills-generation/SkillsGen.Cli/SkillsGen.Cli.csproj
+++ b/skills-generation/SkillsGen.Cli/SkillsGen.Cli.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/skills-generation/SkillsGen.Core.Tests/SkillsGen.Core.Tests.csproj
+++ b/skills-generation/SkillsGen.Core.Tests/SkillsGen.Core.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/skills-generation/SkillsGen.Core/SkillsGen.Core.csproj
+++ b/skills-generation/SkillsGen.Core/SkillsGen.Core.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />


### PR DESCRIPTION
## Summary
Updates .NET Target Framework Moniker (TFM) alignment so Directory.Build.props is the single source of truth.

## Changes
- ✅ Updated \Directory.Build.props\ TargetFramework from \
et9.0\ to \
et10.0\
- ✅ Removed \<TargetFramework>\ overrides from all 44 .csproj files
- ✅ Verified: \dotnet build\ succeeds with 0 errors
- ✅ Verified: \dotnet test\ passes all 2,514 tests

## Why
Before this change, \Directory.Build.props\ specified \
et9.0\ but every .csproj file overrode it to \
et10.0\. This created maintenance burden and potential inconsistencies. Now Directory.Build.props is the single source of truth.

## Testing
- Full solution build: ✅ Success
- Full test suite (2,514 tests): ✅ All passed
- No .csproj files contain TargetFramework overrides

Closes #533