### PR TITLE
feat: inject CLI subsections into tool family articles

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -73,6 +73,13 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
                 warnings.Add($"CLI version file not found at '{cliVersionPath}'. Tool-family cleanup will use 'unknown'.");
             }
 
+            // Copy CLI enriched JSON for CLI subsection injection
+            var cliEnrichedPath = Path.Combine(context.OutputPath, "cli", "cli-output-enriched.json");
+            if (File.Exists(cliEnrichedPath))
+            {
+                File.Copy(cliEnrichedPath, Path.Combine(tempCliDirectory, "cli-output-enriched.json"), overwrite: true);
+            }
+
             var brandMappingSource = Path.Combine(context.McpToolsRoot, "data", "brand-to-server-mapping.json");
             if (File.Exists(brandMappingSource))
             {

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliSectionInjectorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliSectionInjectorTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+public class CliSectionInjectorTests
+{
+    private static Dictionary<string, CliCommand> CreateTestCliCommands()
+    {
+        return new Dictionary<string, CliCommand>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["storage account create"] = new CliCommand
+            {
+                Command = "storage account create",
+                Description = "Creates an Azure Storage account in the specified resource group.",
+                Option = new List<CliOption>
+                {
+                    new() { Name = "--tenant", Description = "Tenant ID", Type = "string" },
+                    new() { Name = "--subscription", Description = "Subscription", Type = "string" },
+                    new() { Name = "--retry-delay", Description = "Retry delay", Type = "string" },
+                    new() { Name = "--retry-max-delay", Description = "Max retry delay", Type = "string" },
+                    new() { Name = "--retry-max-retries", Description = "Max retries", Type = "string" },
+                    new() { Name = "--retry-mode", Description = "Retry mode", Type = "string" },
+                    new() { Name = "--retry-network-timeout", Description = "Network timeout", Type = "string" },
+                    new() { Name = "--auth-method", Description = "Auth method", Type = "string" },
+                    new() { Name = "--learn", Description = "Learn mode", Type = "string" },
+                    new() { Name = "--account", Description = "Storage account name.", Type = "string", Required = true },
+                    new() { Name = "--resource-group", Description = "Resource group name.", Type = "string", Required = true },
+                    new() { Name = "--location", Description = "Azure region.", Type = "string", Required = true },
+                    new() { Name = "--sku", Description = "Storage SKU.", Type = "string" },
+                    new() { Name = "--access-tier", Description = "Access tier.", Type = "string" },
+                },
+                Enrichment = new CliEnrichment
+                {
+                    ParameterEnhancements = new Dictionary<string, CliParameterEnhancement>
+                    {
+                        ["--account"] = new() { ValuePlaceholder = "unique-account-name" },
+                        ["--resource-group"] = new() { ValuePlaceholder = "resource-group" },
+                        ["--location"] = new() { ValuePlaceholder = "location" },
+                    }
+                }
+            },
+            ["storage account get"] = new CliCommand
+            {
+                Command = "storage account get",
+                Description = "Retrieves storage account details.",
+                Option = new List<CliOption>
+                {
+                    new() { Name = "--tenant", Description = "Tenant", Type = "string" },
+                    new() { Name = "--subscription", Description = "Sub", Type = "string" },
+                    new() { Name = "--account", Description = "Account name.", Type = "string" },
+                    new() { Name = "--learn", Description = "Learn", Type = "string" },
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public void InjectCliSection_InsertsAfterAnnotationLine()
+    {
+        var content = @"## Account: create
+
+<!-- @mcpcli storage account create -->
+
+Description here.
+
+| Parameter | Required or optional | Description |
+|-----------|---------------------|-------------|
+| **Account** | Required | Account name. |
+
+[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):
+
+Destructive: ✅ | Idempotent: ❌ | Open World: ❌ | Read Only: ❌ | Secret: ❌ | Local Required: ❌";
+
+        var result = CliSectionInjector.InjectCliSection(content, "storage account create", CreateTestCliCommands());
+
+        Assert.Contains("#### CLI", result);
+        Assert.Contains("Creates an Azure Storage account", result);
+        Assert.Contains("```bash", result);
+        Assert.Contains("azmcp storage account create", result);
+        Assert.Contains("--account <unique-account-name>", result);
+        Assert.Contains("--resource-group <resource-group>", result);
+        // CLI section should come after the annotation line
+        var annotationIndex = result.IndexOf("Local Required: ❌");
+        var cliIndex = result.IndexOf("#### CLI");
+        Assert.True(cliIndex > annotationIndex, "CLI section should appear after annotation hints");
+    }
+
+    [Fact]
+    public void InjectCliSection_ExcludesCommonParams()
+    {
+        var content = "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌";
+        var result = CliSectionInjector.InjectCliSection(content, "storage account create", CreateTestCliCommands());
+
+        // Common params should NOT appear in the CLI table
+        Assert.DoesNotContain("| `--tenant`", result);
+        Assert.DoesNotContain("| `--subscription`", result);
+        Assert.DoesNotContain("| `--retry-delay`", result);
+        Assert.DoesNotContain("| `--retry-max-delay`", result);
+        Assert.DoesNotContain("| `--retry-max-retries`", result);
+        Assert.DoesNotContain("| `--retry-mode`", result);
+        Assert.DoesNotContain("| `--retry-network-timeout`", result);
+        Assert.DoesNotContain("| `--auth-method`", result);
+        Assert.DoesNotContain("| `--learn`", result);
+
+        // Domain params SHOULD appear
+        Assert.Contains("| `--account`", result);
+        Assert.Contains("| `--resource-group`", result);
+        Assert.Contains("| `--location`", result);
+        Assert.Contains("| `--sku`", result);
+    }
+
+    [Fact]
+    public void InjectCliSection_RequiredParamsUseBraces_OptionalUseBrackets()
+    {
+        var content = "Destructive: ✅ | Idempotent: ❌ | Open World: ❌ | Read Only: ❌ | Secret: ❌ | Local Required: ❌";
+        var result = CliSectionInjector.InjectCliSection(content, "storage account create", CreateTestCliCommands());
+
+        // Required params: --param <value> (no brackets)
+        Assert.Contains("--account <unique-account-name>", result);
+        // Optional params: [--param <value>]
+        Assert.Contains("[--sku <sku>]", result);
+        Assert.Contains("[--access-tier <access-tier>]", result);
+    }
+
+    [Fact]
+    public void InjectCliSection_NoMatchingCommand_ReturnsOriginal()
+    {
+        var content = "Some tool content";
+        var result = CliSectionInjector.InjectCliSection(content, "nonexistent command", CreateTestCliCommands());
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public void InjectCliSection_NullCommand_ReturnsOriginal()
+    {
+        var content = "Some tool content";
+        var result = CliSectionInjector.InjectCliSection(content, null, CreateTestCliCommands());
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public void InjectCliSection_EmptyCliCommands_ReturnsOriginal()
+    {
+        var content = "Some tool content";
+        var result = CliSectionInjector.InjectCliSection(content, "storage account create", new Dictionary<string, CliCommand>());
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public void InjectCliSection_AllOptionalParams_UsesBrackets()
+    {
+        var content = "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌";
+        var result = CliSectionInjector.InjectCliSection(content, "storage account get", CreateTestCliCommands());
+
+        // account is optional in this command
+        Assert.Contains("[--account <account>]", result);
+        Assert.Contains("| `--account` | ❌ |", result);
+    }
+
+    [Fact]
+    public void InjectCliSection_RequiredParamsMarkedCorrectly()
+    {
+        var content = "Destructive: ✅ | Idempotent: ❌ | Open World: ❌ | Read Only: ❌ | Secret: ❌ | Local Required: ❌";
+        var result = CliSectionInjector.InjectCliSection(content, "storage account create", CreateTestCliCommands());
+
+        Assert.Contains("| `--account` | ✅ |", result);
+        Assert.Contains("| `--resource-group` | ✅ |", result);
+        Assert.Contains("| `--location` | ✅ |", result);
+        Assert.Contains("| `--sku` | ❌ |", result);
+    }
+
+    [Fact]
+    public void BuildCliSection_ContainsExpectedStructure()
+    {
+        var cmd = CreateTestCliCommands()["storage account create"];
+        var section = CliSectionInjector.BuildCliSection("storage account create", cmd);
+
+        Assert.StartsWith("#### CLI", section);
+        Assert.Contains("```bash", section);
+        Assert.Contains("```", section);
+        Assert.Contains("| Switch | Required | Type | Description |", section);
+        Assert.Contains("|--------|----------|------|-------------|", section);
+    }
+
+    [Fact]
+    public void BuildCliSection_MultilineDescription_CollapsedToSingleLine()
+    {
+        var cmd = new CliCommand
+        {
+            Command = "test cmd",
+            Description = "Line one\nLine two\r\nLine three",
+            Option = new List<CliOption>()
+        };
+
+        var section = CliSectionInjector.BuildCliSection("test cmd", cmd);
+        Assert.Contains("Line one Line two Line three", section);
+        Assert.DoesNotContain("\nLine two", section);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
@@ -344,6 +344,10 @@ public class CleanupGenerator
         var baseOutputDir = Path.GetFullPath("../generated");
         _cliVersion = await CliVersionReader.ReadCliVersionAsync(baseOutputDir);
         Console.WriteLine($"CLI Version: {_cliVersion}");
+
+        // Load CLI enriched data for CLI subsection injection
+        var cliEnrichedPath = Path.Combine(baseOutputDir, "cli", "cli-output-enriched.json");
+        var cliCommands = await CliSectionInjector.LoadCliCommandsAsync(cliEnrichedPath);
         Console.WriteLine();
 
         // Create output directories (resolve relative paths)
@@ -515,6 +519,25 @@ public class CleanupGenerator
 
                 // Phase 3.5: Pre-stitch H2 count validation
                 ValidateAndFixPhantomH2Sections(familyContent, progress);
+
+                // Phase 3.7: Inject CLI subsections into tool content
+                if (cliCommands.Count > 0)
+                {
+                    int cliInjected = 0;
+                    foreach (var tool in familyContent.Tools)
+                    {
+                        var updated = CliSectionInjector.InjectCliSection(tool.Content, tool.Command, cliCommands);
+                        if (!ReferenceEquals(updated, tool.Content))
+                        {
+                            tool.Content = updated;
+                            cliInjected++;
+                        }
+                    }
+                    if (cliInjected > 0)
+                    {
+                        Console.WriteLine($"{progress}   Phase 3.7: Injected CLI sections for {cliInjected}/{familyContent.Tools.Count} tools");
+                    }
+                }
 
                 // Phase 4: Stitch together
                 Console.Write($"{progress}   Phase 4: Stitching file... ");

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliSectionInjector.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliSectionInjector.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Reads CLI enriched JSON and injects #### CLI subsections into tool content
+/// after the tool annotation hints line.
+/// </summary>
+public class CliSectionInjector
+{
+    // Common/infrastructure params excluded from per-tool CLI tables
+    private static readonly HashSet<string> ExcludedParams = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--tenant",
+        "--auth-method",
+        "--retry-delay",
+        "--retry-max-delay",
+        "--retry-max-retries",
+        "--retry-mode",
+        "--retry-network-timeout",
+        "--subscription",
+        "--learn"
+    };
+
+    // Matches the annotation values line: "Destructive: ✅ | Idempotent: ❌ | ..."
+    private static readonly Regex AnnotationValuesRegex = new(
+        @"^Destructive:\s*[✅❌].+Local Required:\s*[✅❌]\s*$",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Loads CLI commands from the enriched JSON file.
+    /// Handles BOM-encoded UTF-8.
+    /// </summary>
+    public static async Task<Dictionary<string, CliCommand>> LoadCliCommandsAsync(string cliEnrichedJsonPath)
+    {
+        if (!File.Exists(cliEnrichedJsonPath))
+        {
+            Console.WriteLine($"⚠ CLI enriched JSON not found at '{cliEnrichedJsonPath}'. CLI sections will be skipped.");
+            return new Dictionary<string, CliCommand>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var jsonBytes = await File.ReadAllBytesAsync(cliEnrichedJsonPath);
+        // Skip BOM if present
+        var json = Encoding.UTF8.GetString(jsonBytes).TrimStart('\uFEFF');
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        var envelope = JsonSerializer.Deserialize<CliEnrichedEnvelope>(json, options);
+        if (envelope?.Results == null || envelope.Results.Count == 0)
+        {
+            Console.WriteLine("⚠ CLI enriched JSON has no results.");
+            return new Dictionary<string, CliCommand>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var dict = new Dictionary<string, CliCommand>(StringComparer.OrdinalIgnoreCase);
+        foreach (var cmd in envelope.Results)
+        {
+            if (!string.IsNullOrWhiteSpace(cmd.Command))
+            {
+                dict[cmd.Command] = cmd;
+            }
+        }
+
+        Console.WriteLine($"✓ Loaded {dict.Count} CLI commands from enriched JSON");
+        return dict;
+    }
+
+    /// <summary>
+    /// Injects a #### CLI subsection into tool content after the annotation hints line.
+    /// Returns the modified content, or the original if no matching CLI command exists.
+    /// </summary>
+    public static string InjectCliSection(string toolContent, string? command, Dictionary<string, CliCommand> cliCommands)
+    {
+        if (string.IsNullOrWhiteSpace(command) || cliCommands.Count == 0)
+            return toolContent;
+
+        if (!cliCommands.TryGetValue(command, out var cliCmd))
+            return toolContent;
+
+        var cliSection = BuildCliSection(command, cliCmd);
+        if (string.IsNullOrEmpty(cliSection))
+            return toolContent;
+
+        // Find the annotation values line and insert after it
+        var match = AnnotationValuesRegex.Match(toolContent);
+        if (!match.Success)
+        {
+            // Fallback: append to end of content
+            return toolContent.TrimEnd() + "\n\n" + cliSection;
+        }
+
+        var insertIndex = match.Index + match.Length;
+        return toolContent[..insertIndex] + "\n\n" + cliSection + toolContent[insertIndex..];
+    }
+
+    /// <summary>
+    /// Builds the #### CLI markdown section for a tool.
+    /// </summary>
+    internal static string BuildCliSection(string command, CliCommand cliCmd)
+    {
+        var sb = new StringBuilder();
+
+        // #### CLI heading
+        sb.AppendLine("#### CLI");
+        sb.AppendLine();
+
+        // Description paragraph
+        var description = (cliCmd.Description ?? "").Trim().Replace("\r\n", " ").Replace("\n", " ");
+        sb.AppendLine(description);
+        sb.AppendLine();
+
+        // Filter to domain-specific params only
+        var domainParams = (cliCmd.Option ?? [])
+            .Where(o => !string.IsNullOrWhiteSpace(o.Name) && !ExcludedParams.Contains(o.Name))
+            .ToList();
+
+        // Build CLI command syntax
+        var requiredParams = domainParams.Where(o => o.Required == true).ToList();
+        var optionalParams = domainParams.Where(o => o.Required != true).ToList();
+
+        sb.AppendLine("```bash");
+        sb.Append($"azmcp {command}");
+
+        if (requiredParams.Count > 0 || optionalParams.Count > 0)
+        {
+            foreach (var param in requiredParams)
+            {
+                var placeholder = GetPlaceholder(param, cliCmd);
+                sb.Append($" \\\n{Indent(command)} {param.Name} <{placeholder}>");
+            }
+            foreach (var param in optionalParams)
+            {
+                var placeholder = GetPlaceholder(param, cliCmd);
+                sb.Append($" \\\n{Indent(command)} [{param.Name} <{placeholder}>]");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("```");
+
+        // Parameter table (only if there are domain params)
+        if (domainParams.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("| Switch | Required | Type | Description |");
+            sb.AppendLine("|--------|----------|------|-------------|");
+
+            foreach (var param in domainParams)
+            {
+                var required = param.Required == true ? "✅" : "❌";
+                var type = param.Type ?? "string";
+                var desc = (param.Description ?? "").Trim().Replace("\r\n", " ").Replace("\n", " ");
+                sb.AppendLine($"| `{param.Name}` | {required} | {type} | {desc} |");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string GetPlaceholder(CliOption option, CliCommand cliCmd)
+    {
+        // Try enrichment valuePlaceholder first
+        if (cliCmd.Enrichment?.ParameterEnhancements != null &&
+            cliCmd.Enrichment.ParameterEnhancements.TryGetValue(option.Name!, out var enhancement) &&
+            !string.IsNullOrWhiteSpace(enhancement.ValuePlaceholder))
+        {
+            return enhancement.ValuePlaceholder;
+        }
+
+        // Fallback: derive from switch name (strip leading --)
+        return option.Name!.TrimStart('-');
+    }
+
+    /// <summary>
+    /// Creates indentation to align continuation lines under the first parameter.
+    /// </summary>
+    private static string Indent(string command)
+    {
+        // "azmcp " (6) + command length
+        return new string(' ', 6 + command.Length);
+    }
+}
+
+// JSON model classes for CLI enriched data
+
+public class CliEnrichedEnvelope
+{
+    [JsonPropertyName("results")]
+    public List<CliCommand> Results { get; set; } = [];
+}
+
+public class CliCommand
+{
+    [JsonPropertyName("command")]
+    public string? Command { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("option")]
+    public List<CliOption>? Option { get; set; }
+
+    [JsonPropertyName("enrichment")]
+    public CliEnrichment? Enrichment { get; set; }
+}
+
+public class CliOption
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("required")]
+    public bool? Required { get; set; }
+}
+
+public class CliEnrichment
+{
+    [JsonPropertyName("parameterEnhancements")]
+    public Dictionary<string, CliParameterEnhancement>? ParameterEnhancements { get; set; }
+}
+
+public class CliParameterEnhancement
+{
+    [JsonPropertyName("valuePlaceholder")]
+    public string? ValuePlaceholder { get; set; }
+
+    [JsonPropertyName("default")]
+    public string? Default { get; set; }
+}


### PR DESCRIPTION
## Summary

Implements CLI documentation generation in the tool family step (Phase 3.7), resolving #242.

### Changes

**New: CliSectionInjector.cs** — Reads cli-output-enriched.json and generates #### CLI subsections for each tool:
- CLI description paragraph
- Fenced bash code block with \zmcp\ command syntax (required params as \--param <value>\, optional as \[--param <value>]\)
- Parameter table with Switch/Required/Type/Description columns
- Filters out common/infrastructure params: \--tenant\, \--auth-method\, \--retry-*\, \--subscription\, \--learn\
- Uses enrichment \aluePlaceholder\ for readable placeholders

**Modified: CleanupGenerator.cs** — Loads CLI enriched data at startup, injects CLI sections in new Phase 3.7 (after H2 validation, before stitching)

**Modified: ToolFamilyCleanupStep.cs** — Copies \cli-output-enriched.json\ to the isolated temp workspace so the subprocess can access it

**New: CliSectionInjectorTests.cs** — 10 unit tests covering injection placement, param filtering, required/optional formatting, edge cases

### Test Results
- All 2,494 existing tests pass
- 10 new tests pass
- 0 errors, 0 regressions

Closes #242