### PR TITLE
feat: add CLI examples generation to update-azure-mcp workflow

### DIFF
--- a/.github/workflows/update-azure-mcp.yml
+++ b/.github/workflows/update-azure-mcp.yml
@@ -141,6 +141,14 @@ jobs:
             echo "✅ Snapshot created: $VERSION_DIR/tools-list.json ($TOOL_COUNT tools)"
           fi
 
+      - name: Generate CLI examples
+        if: steps.cli-snapshot.outputs.is_new == 'true'
+        working-directory: ./test-npm-azure-mcp
+        run: |
+          echo "Generating CLI example commands..."
+          node generate-cli-examples.js
+          echo "✅ CLI examples generated → cli-examples.md"
+
       - name: Diff against previous version
         if: steps.cli-snapshot.outputs.is_new == 'true'
         id: diff-check
@@ -270,6 +278,7 @@ jobs:
             - `test-npm-azure-mcp/package.json`
             - `test-npm-azure-mcp/package-lock.json`
             ${{ steps.cli-snapshot.outputs.is_new == 'true' && format('- `test-npm-azure-mcp/{0}/tools-list.json` (new CLI snapshot)', steps.cli-snapshot.outputs.cli_version) || '' }}
+            ${{ steps.cli-snapshot.outputs.is_new == 'true' && '- `test-npm-azure-mcp/cli-examples.md` (regenerated CLI examples)' || '' }}
             
             ### CLI Diff
             ${{ steps.diff-check.outputs.previous_version && format('Compared against previous version `{0}`: **{1} lines changed** (+{2} / -{3})', steps.diff-check.outputs.previous_version, steps.diff-check.outputs.lines_changed, steps.diff-check.outputs.lines_added, steps.diff-check.outputs.lines_removed) || 'No previous version to diff against.' }}

--- a/test-npm-azure-mcp/generate-cli-examples.js
+++ b/test-npm-azure-mcp/generate-cli-examples.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Generates CLI example commands from the most recent tools-list.json
+// Output: alphabetical by namespace, then tool ΓÇö required params bare, optional in brackets
+
+const fs = require('fs');
+const path = require('path');
+
+const GLOBAL_SWITCHES = new Set([
+  '--subscription', '--tenant', '--tenant-id',
+  '--auth-method', '--retry-delay', '--retry-max-delay',
+  '--retry-max-retries', '--retry-mode', '--retry-network-timeout',
+  '--learn'
+]);
+
+function findLatestToolsList(baseDir) {
+  const dirs = fs.readdirSync(baseDir, { withFileTypes: true })
+    .filter(d => d.isDirectory() && d.name.startsWith('3.0.0-beta.'))
+    .map(d => d.name)
+    .sort((a, b) => {
+      const numA = parseInt(a.match(/beta\.(\d+)/)?.[1] || '0', 10);
+      const numB = parseInt(b.match(/beta\.(\d+)/)?.[1] || '0', 10);
+      return numB - numA;
+    });
+
+  if (dirs.length === 0) throw new Error('No 3.0.0-beta.* directories found');
+  const toolsPath = path.join(baseDir, dirs[0], 'tools-list.json');
+  if (!fs.existsSync(toolsPath)) throw new Error(`No tools-list.json in ${dirs[0]}`);
+  console.log(`Using: ${dirs[0]}/tools-list.json\n`);
+  return toolsPath;
+}
+
+function buildCliCommand(tool) {
+  const cmd = `azmcp ${tool.command}`;
+  const options = (tool.option || []).filter(o => !GLOBAL_SWITCHES.has(o.name));
+
+  const required = options.filter(o => o.required === true);
+  const optional = options.filter(o => o.required !== true);
+
+  // Sort each group alphabetically
+  required.sort((a, b) => a.name.localeCompare(b.name));
+  optional.sort((a, b) => a.name.localeCompare(b.name));
+
+  const parts = [cmd];
+
+  for (const p of required) {
+    const placeholder = p.name.replace(/^--/, '');
+    parts.push(`  ${p.name} <${placeholder}>`);
+  }
+
+  for (const p of optional) {
+    const placeholder = p.name.replace(/^--/, '');
+    parts.push(`  [${p.name} <${placeholder}>]`);
+  }
+
+  return parts.join(' \\\n');
+}
+
+function getNamespace(command) {
+  // namespace = first word(s) before the action verb (last word)
+  const words = command.split(' ');
+  return words.slice(0, -1).join(' ') || words[0];
+}
+
+// Main
+const baseDir = __dirname;
+const toolsPath = findLatestToolsList(baseDir);
+const data = JSON.parse(fs.readFileSync(toolsPath, 'utf8'));
+const tools = data.results || [];
+
+// Sort by command (alphabetical by namespace then tool)
+tools.sort((a, b) => a.command.localeCompare(b.command));
+
+// Group by namespace
+let currentNamespace = null;
+const lines = [];
+
+for (const tool of tools) {
+  const ns = getNamespace(tool.command);
+  if (ns !== currentNamespace) {
+    currentNamespace = ns;
+    if (lines.length > 0) lines.push('');
+    lines.push(`## ${ns}`);
+    lines.push('');
+  }
+
+  lines.push('```console');
+  lines.push(buildCliCommand(tool));
+  lines.push('```');
+  lines.push('');
+}
+
+const output = lines.join('\n');
+const outPath = path.join(baseDir, 'cli-examples.md');
+fs.writeFileSync(outPath, output, 'utf8');
+console.log(`Generated ${tools.length} CLI examples ΓåÆ cli-examples.md`);


### PR DESCRIPTION
Adds automatic CLI examples generation to the nightly @azure/mcp update workflow.

## Changes
- Added `generate-cli-examples.js` script (from PR #561)
- Added workflow step to run the script after CLI snapshot capture
- Updated PR body template to list cli-examples.md

## How it works
After the workflow captures `tools-list.json` for a new version, it now also runs `node generate-cli-examples.js` which:
- Reads the latest tools-list.json
- Filters global switches
- Generates cli-examples.md with all CLI commands in Azure CLI reference format
- The generated file is included in the automated PR

Closes #561 (supersedes the standalone script PR)