### PR TITLE
fix: align PageGenerator RequiredText with BuildRequiredText (#554)

### DIFF
--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
@@ -95,6 +95,10 @@ public class PageGenerator
                 
                 if (tool.Option != null)
                 {
+                    var conditionalParameters = new HashSet<string>(
+                        tool.ConditionalRequiredParameters ?? new List<string>(),
+                        StringComparer.OrdinalIgnoreCase);
+
                     var filteredOptions = tool.Option
                         .Where(opt => ParameterFilterHelper.ShouldInclude(opt, commonParameterNames));
 
@@ -106,7 +110,7 @@ public class PageGenerator
                             NL_Name = Config.TextNormalizer.NormalizeParameter(opt.Name ?? ""),
                             Type = opt.Type,
                             Required = opt.Required,
-                            RequiredText = opt.Required == true ? "Required" : "Optional",
+                            RequiredText = ParameterGenerator.BuildRequiredText(opt.Required == true, opt.Name ?? "", conditionalParameters),
                             Description = ParameterDescriptionBackticker.Apply(
                                 Config.TextNormalizer.WrapExampleValues(
                                     Config.TextNormalizer.EnsureEndsPeriod(Config.TextNormalizer.ReplaceStaticText(opt.Description ?? "")))),


### PR DESCRIPTION
## Summary

Part of PRD #560 Fix 3. Replaces inline ternary in PageGenerator.cs with a call to \ParameterGenerator.BuildRequiredText()\, so area pages correctly show conditional \Required*\/\Optional*\ markers — consistent with parameter pages.

### What changed
- Added \conditionalParameters\ HashSet from \	ool.ConditionalRequiredParameters\
- Replaced \opt.Required == true ? "Required" : "Optional"\ with \ParameterGenerator.BuildRequiredText()\

### Testing
- \dotnet build\ — passes
- \dotnet test\ — all tests pass (1 pre-existing E2E failure unrelated to this change)

Refs: #554 #560