### PR TITLE
fix: render raw CLI param names in parameter tables (#553)

### DIFF
--- a/mcp-tools/templates/area-template.hbs
+++ b/mcp-tools/templates/area-template.hbs
@@ -32,7 +32,7 @@ mcp-cli.version: {{version}}
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
+| **`{{name}}`** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{ else}}
 <!-- No parameters for this tool -->

--- a/mcp-tools/templates/common-tools.hbs
+++ b/mcp-tools/templates/common-tools.hbs
@@ -28,7 +28,7 @@ This page documents the common parameters that are shared across many Azure MCP 
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **{{NL_Name}}** |  {{RequiredText}} | {{description}} |
+| **`{{Name}}`** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{else}}
 No parameters

--- a/mcp-tools/templates/param-annotation-template.hbs
+++ b/mcp-tools/templates/param-annotation-template.hbs
@@ -3,7 +3,7 @@
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
+| **`{{name}}`** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{else}}
 <!-- No parameters for this tool -->

--- a/mcp-tools/templates/parameter-template.hbs
+++ b/mcp-tools/templates/parameter-template.hbs
@@ -3,7 +3,7 @@
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
+| **`{{name}}`** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{#if hasConditionalRequired}}
 


### PR DESCRIPTION
## PRD #560 Fix 2 — Render exact CLI option names in Parameter column

**Problem:** Parameter tables showed NL-converted names like "Vault name" instead of the raw CLI names like `--vault`. The `NL_Name` field is set via `NormalizeParameter()` which converts `--vault` → "Vault name".

**Fix:** In 4 Handlebars templates, replaced the `NL_Name` rendering logic with the raw `name` (or `Name`) field, wrapped in backticks for CLI style:

- `parameter-template.hbs` — `name` field (camelCase)
- `area-template.hbs` — `name` field (camelCase)
- `param-annotation-template.hbs` — `name` field (camelCase)
- `common-tools.hbs` — `Name` field (PascalCase, matching CommonParameter model)

**Not changed:** `NL_Name` property and `NormalizeParameter()` method are left intact — they may be used elsewhere.

Refs: #553, #560