### PR TITLE
feat: auto-generate cli-tab-config.json in Bootstrap step

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -5,6 +5,7 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Steps;
 using PipelineRunner.Tests.Fixtures;
+using Shared;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -97,13 +98,159 @@ public class BootstrapStepTests
         Assert.Equal(0, harness.AiCapabilityProbe.ProbeCalls);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WritesCliTabConfigJson_WithSelectedNamespaces()
+    {
+        // Brand mapping lists azurebackup; SelectedNamespaces echoes it
+        using var harness = CreateHarness(
+            selectedNamespaces: ["azurebackup"],
+            brandMappingJson: """[{"mcpServerName":"azurebackup","fileName":"azure-backup"}]""");
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        var configPath = Path.Combine(harness.Context.OutputPath, "cli-tab-config.json");
+        Assert.True(File.Exists(configPath), "cli-tab-config.json was not created in the output directory.");
+        var config = CliTabConfig.LoadFromFile(configPath);
+        Assert.True(config.IsEnabled);
+        Assert.Contains("azurebackup", config.AllowedNamespaces);
+        Assert.Single(config.AllowedNamespaces);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesCliTabConfigJson_ExpandsMergeGroupPeers()
+    {
+        // Running only "monitor" should also include "workbooks" (same mergeGroup)
+        using var harness = CreateHarness(
+            selectedNamespaces: ["monitor"],
+            brandMappingJson: """
+                [
+                  {"mcpServerName":"monitor","fileName":"azure-monitor","mergeGroup":"azure-monitor","mergeRole":"primary"},
+                  {"mcpServerName":"workbooks","fileName":"azure-workbooks","mergeGroup":"azure-monitor","mergeRole":"secondary"}
+                ]
+                """);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        var configPath = Path.Combine(harness.Context.OutputPath, "cli-tab-config.json");
+        var config = CliTabConfig.LoadFromFile(configPath);
+        Assert.True(config.IsEnabled);
+        Assert.Contains("monitor", config.AllowedNamespaces);
+        Assert.Contains("workbooks", config.AllowedNamespaces);
+        Assert.Equal(2, config.AllowedNamespaces.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesCliTabConfigJson_AllNamespacesFromBrandMapping()
+    {
+        // No selected namespaces (all-namespace run) — should pull all from brand mapping
+        using var harness = CreateHarness(
+            brandMappingJson: """
+                [
+                  {"mcpServerName":"compute","fileName":"azure-compute"},
+                  {"mcpServerName":"storage","fileName":"azure-storage"}
+                ]
+                """);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        var configPath = Path.Combine(harness.Context.OutputPath, "cli-tab-config.json");
+        Assert.True(File.Exists(configPath), "cli-tab-config.json was not created in the output directory.");
+        var config = CliTabConfig.LoadFromFile(configPath);
+        Assert.True(config.IsEnabled);
+        Assert.Contains("compute", config.AllowedNamespaces);
+        Assert.Contains("storage", config.AllowedNamespaces);
+        Assert.Equal(2, config.AllowedNamespaces.Count);
+    }
+
+    [Fact]
+    public async Task ResolveCliTabNamespacesAsync_MissingFile_FallsBackToSelectedNamespaces()
+    {
+        var result = await BootstrapStep.ResolveCliTabNamespacesAsync(
+            "nonexistent-brand-mapping.json",
+            ["azurebackup"],
+            CancellationToken.None);
+
+        Assert.Contains("azurebackup", result);
+    }
+
+    [Fact]
+    public async Task ResolveCliTabNamespacesAsync_AllNamespaceRun_ReturnsAllFromMapping()
+    {
+        var path = WriteTempBrandMapping("""
+            [
+              {"mcpServerName":"compute","fileName":"azure-compute"},
+              {"mcpServerName":"storage","fileName":"azure-storage"}
+            ]
+            """);
+        try
+        {
+            var result = await BootstrapStep.ResolveCliTabNamespacesAsync(path, [], CancellationToken.None);
+            Assert.Contains("compute", result);
+            Assert.Contains("storage", result);
+            Assert.Equal(2, result.Count);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task ResolveCliTabNamespacesAsync_SingleNamespace_NoMergeGroup_ReturnsSelf()
+    {
+        var path = WriteTempBrandMapping("""
+            [
+              {"mcpServerName":"azurebackup","fileName":"azure-backup"},
+              {"mcpServerName":"storage","fileName":"azure-storage"}
+            ]
+            """);
+        try
+        {
+            var result = await BootstrapStep.ResolveCliTabNamespacesAsync(path, ["azurebackup"], CancellationToken.None);
+            Assert.Contains("azurebackup", result);
+            Assert.DoesNotContain("storage", result);
+            Assert.Single(result);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public async Task ResolveCliTabNamespacesAsync_SingleNamespace_WithMergeGroup_IncludesPeers()
+    {
+        var path = WriteTempBrandMapping("""
+            [
+              {"mcpServerName":"monitor","fileName":"azure-monitor","mergeGroup":"azure-monitor","mergeRole":"primary"},
+              {"mcpServerName":"workbooks","fileName":"azure-workbooks","mergeGroup":"azure-monitor","mergeRole":"secondary"},
+              {"mcpServerName":"storage","fileName":"azure-storage"}
+            ]
+            """);
+        try
+        {
+            var result = await BootstrapStep.ResolveCliTabNamespacesAsync(path, ["monitor"], CancellationToken.None);
+            Assert.Contains("monitor", result);
+            Assert.Contains("workbooks", result);
+            Assert.DoesNotContain("storage", result);
+            Assert.Equal(2, result.Count);
+        }
+        finally { File.Delete(path); }
+    }
+
+    private static string WriteTempBrandMapping(string json)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"brand-mapping-test-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
     private static TestHarness CreateHarness(
         bool skipBuild = false,
         bool skipValidation = false,
         bool skipEnvValidation = false,
         bool requiresAiConfiguration = false,
         bool aiConfigured = true,
-        ICliMetadataLoader? cliMetadataLoader = null)
+        ICliMetadataLoader? cliMetadataLoader = null,
+        IReadOnlyList<string>? selectedNamespaces = null,
+        string? brandMappingJson = null)
     {
         var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-bootstrap-tests-{Guid.NewGuid():N}");
         var mcpToolsRoot = Path.Combine(repoRoot, "mcp-tools");
@@ -111,7 +258,7 @@ public class BootstrapStepTests
         Directory.CreateDirectory(Path.Combine(mcpToolsRoot, "azure-mcp"));
         Directory.CreateDirectory(Path.Combine(repoRoot, "test-npm-azure-mcp"));
         File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
-        File.WriteAllText(Path.Combine(mcpToolsRoot, "data", "brand-to-server-mapping.json"), "[]");
+        File.WriteAllText(Path.Combine(mcpToolsRoot, "data", "brand-to-server-mapping.json"), brandMappingJson ?? "[]");
         File.WriteAllText(Path.Combine(mcpToolsRoot, "azure-mcp", "azmcp-commands.md"), "# Commands");
 
         var processRunner = new ScriptedProcessRunner();
@@ -144,6 +291,7 @@ public class BootstrapStepTests
             AiCapabilityProbe = aiCapabilityProbe,
             Reports = new BufferedReportWriter(),
             PlannedSteps = plannedSteps,
+            SelectedNamespaces = selectedNamespaces ?? Array.Empty<string>(),
         };
 
         return new TestHarness(repoRoot, step, context, processRunner, buildCoordinator, aiCapabilityProbe);

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -235,6 +235,19 @@ public class BootstrapStepTests
         finally { File.Delete(path); }
     }
 
+    [Fact]
+    public async Task ResolveCliTabNamespacesAsync_MalformedJson_FallsBackToSelectedNamespaces()
+    {
+        var path = WriteTempBrandMapping("{ this is not valid json }}}");
+        try
+        {
+            var result = await BootstrapStep.ResolveCliTabNamespacesAsync(path, ["azurebackup"], CancellationToken.None);
+            Assert.Contains("azurebackup", result);
+            Assert.Single(result);
+        }
+        finally { File.Delete(path); }
+    }
+
     private static string WriteTempBrandMapping(string json)
     {
         var path = Path.Combine(Path.GetTempPath(), $"brand-mapping-test-{Guid.NewGuid():N}.json");

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -9,6 +9,9 @@
     <RootNamespace>DocGeneration.PipelineRunner</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="DocGeneration.PipelineRunner.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.GenerativeAI\DocGeneration.Core.GenerativeAI.csproj" />
   </ItemGroup>

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -314,6 +314,20 @@ public sealed class BootstrapStep : StepDefinition
                 }
             }
 
+            // Generate cli-tab-config.json so ToolFamilyCleanupStep can enable CLI tab generation.
+            // AllowedNamespaces is sourced from brand-to-server-mapping.json (the source of truth for
+            // which namespaces produce tool-family files), expanding merge group peers when needed.
+            var brandMappingPath = Path.Combine(context.McpToolsRoot, "data", "brand-to-server-mapping.json");
+            var namespacesForConfig = await ResolveCliTabNamespacesAsync(brandMappingPath, context.SelectedNamespaces, cancellationToken);
+            var cliTabConfig = CliTabConfig.ForNamespaces([.. namespacesForConfig]);
+            var cliTabConfigPath = Path.Combine(context.OutputPath, "cli-tab-config.json");
+            await File.WriteAllTextAsync(
+                cliTabConfigPath,
+                JsonSerializer.Serialize(cliTabConfig),
+                Encoding.UTF8,
+                cancellationToken);
+            context.Reports.Info($"Generated cli-tab-config.json with {cliTabConfig.AllowedNamespaces.Count} namespace(s).");
+
             CreateDirectories(context.OutputPath, BaseOutputDirectories);
             return BuildResult(context, processResults, success: true, warnings);
         }
@@ -415,6 +429,57 @@ public sealed class BootstrapStep : StepDefinition
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Resolves the set of namespaces to include in cli-tab-config.json.
+    /// Uses brand-to-server-mapping.json as the source of truth, expanding
+    /// merge group peers when a single namespace is specified.
+    /// Falls back to selectedNamespaces if the brand mapping is empty or unavailable.
+    /// </summary>
+    internal static async Task<IReadOnlyList<string>> ResolveCliTabNamespacesAsync(
+        string brandMappingPath,
+        IReadOnlyList<string> selectedNamespaces,
+        CancellationToken cancellationToken)
+    {
+        List<BrandMapping> brandMappings = [];
+        if (File.Exists(brandMappingPath))
+        {
+            var json = await File.ReadAllTextAsync(brandMappingPath, cancellationToken);
+            brandMappings = JsonSerializer.Deserialize<List<BrandMapping>>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            }) ?? [];
+        }
+
+        var validMappings = brandMappings
+            .Where(m => !string.IsNullOrWhiteSpace(m.McpServerName))
+            .ToList();
+
+        // All-namespace run: include every namespace in the brand mapping
+        if (selectedNamespaces.Count == 0)
+        {
+            var all = validMappings.Select(m => m.McpServerName!).ToArray();
+            return all.Length > 0 ? all : selectedNamespaces;
+        }
+
+        // Single-namespace run: include the namespace + any merge-group peers
+        var result = new HashSet<string>(selectedNamespaces, StringComparer.OrdinalIgnoreCase);
+        foreach (var ns in selectedNamespaces)
+        {
+            var entry = validMappings.FirstOrDefault(m =>
+                string.Equals(m.McpServerName, ns, StringComparison.OrdinalIgnoreCase));
+            if (entry?.MergeGroup is { Length: > 0 } mergeGroup)
+            {
+                foreach (var peer in validMappings.Where(m =>
+                    string.Equals(m.MergeGroup, mergeGroup, StringComparison.OrdinalIgnoreCase)))
+                {
+                    result.Add(peer.McpServerName!);
+                }
+            }
+        }
+
+        return [.. result];
     }
 
     private static void AddProcessIssue(ProcessExecutionResult processResult, ICollection<string> warnings, string summary)

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -446,10 +446,18 @@ public sealed class BootstrapStep : StepDefinition
         if (File.Exists(brandMappingPath))
         {
             var json = await File.ReadAllTextAsync(brandMappingPath, cancellationToken);
-            brandMappings = JsonSerializer.Deserialize<List<BrandMapping>>(json, new JsonSerializerOptions
+            try
             {
-                PropertyNameCaseInsensitive = true,
-            }) ?? [];
+                brandMappings = JsonSerializer.Deserialize<List<BrandMapping>>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                }) ?? [];
+            }
+            catch (JsonException)
+            {
+                // Corrupt brand-mapping file -- fall back to selectedNamespaces
+                return selectedNamespaces;
+            }
         }
 
         var validMappings = brandMappings


### PR DESCRIPTION
Bootstrap (Step 0) now auto-generates cli-tab-config.json in the output directory so ToolFamilyCleanupStep can enable CLI tab generation. Uses context.SelectedNamespaces when set (e.g. --namespace azurebackup), falls back to LoadNamespacesAsync for all-namespace runs. Adds 2 unit tests. All 246 PipelineRunner tests pass.

**Source of truth:** `mcp-tools/data/brand-to-server-mapping.json` — this file defines the namespace-to-file mapping, merge groups, and merge roles used to resolve which namespaces get CLI tabs.