### PR TITLE
fix: restore NLP display names in MCP Server parameter tables

### DIFF
--- a/mcp-tools/templates/area-template.hbs
+++ b/mcp-tools/templates/area-template.hbs
@@ -32,7 +32,7 @@ mcp-cli.version: {{version}}
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **`{{name}}`** |  {{RequiredText}} | {{description}} |
+| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{ else}}
 <!-- No parameters for this tool -->

--- a/mcp-tools/templates/common-tools.hbs
+++ b/mcp-tools/templates/common-tools.hbs
@@ -28,7 +28,7 @@ This page documents the common parameters that are shared across many Azure MCP 
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **{{NL_Name}}** |  {{RequiredText}} | {{description}} |
+| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage Name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{else}}
 No parameters

--- a/mcp-tools/templates/common-tools.hbs
+++ b/mcp-tools/templates/common-tools.hbs
@@ -28,7 +28,7 @@ This page documents the common parameters that are shared across many Azure MCP 
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **`{{Name}}`** |  {{RequiredText}} | {{description}} |
+| **{{NL_Name}}** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{else}}
 No parameters

--- a/mcp-tools/templates/param-annotation-template.hbs
+++ b/mcp-tools/templates/param-annotation-template.hbs
@@ -3,7 +3,7 @@
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **`{{name}}`** |  {{RequiredText}} | {{description}} |
+| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{else}}
 <!-- No parameters for this tool -->

--- a/mcp-tools/templates/parameter-template.hbs
+++ b/mcp-tools/templates/parameter-template.hbs
@@ -3,7 +3,7 @@
 | Parameter |  Required or optional | Description |
 |-----------------------|----------------------|-------------|
 {{#each option}}
-| **`{{name}}`** |  {{RequiredText}} | {{description}} |
+| **{{#if (eq NL_Name "Unknown")}}{{formatNaturalLanguage name}}{{else}}{{replace NL_Name "." " "}}{{/if}}** |  {{RequiredText}} | {{description}} |
 {{/each}}
 {{#if hasConditionalRequired}}
 


### PR DESCRIPTION
## Problem

PR #565 reverted the parameter column in 4 Handlebars templates to use raw CLI switch names (e.g. --vault, --resource-group). This was intended only for the CLI tab but accidentally affected the MCP Server tab as well.

MCP Server users interact via natural language — the parameter table should show Vault name, Resource group, not --vault, --resource-group.

## Root Cause

The pipeline has two separate parameter rendering paths:
- MCP Server tab: rendered by the 4 Handlebars templates
- CLI tab: rendered independently by CliContentAssembler using sw.Name directly

PR #565 changed the templates, but those changes propagate only to the MCP Server tab. The CLI tab was unaffected.

## Fix

Revert all 4 templates to the pre-PR#565 NLP display name pattern:
- parameter-template.hbs
- area-template.hbs
- param-annotation-template.hbs
- common-tools.hbs

All 4 now use NL_Name / formatNaturalLanguage name. CLI tab unaffected.

## Verified

Ran full azurebackup pipeline. MCP Server tab shows Vault name, Resource group. CLI tab shows --vault, --resource-group. All tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>