### PR TITLE
feat: show tool annotations under both MCP and CLI tabs

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
@@ -281,6 +281,95 @@ public class CliTabWrapperTests
         Assert.Null(exception);
     }
 
+    // ── Annotation duplication to CLI tab ────────────────────────
+
+    [Fact]
+    public void WrapWithTabs_AnnotationInMcpContent_DuplicatedToCliTab()
+    {
+        var mcpContent = "List storage accounts.\n\n" +
+            "| Parameter | Required |\n|---|---|\n| Sub | Yes |\n\n" +
+            "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):\n\n" +
+            "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌";
+        var cliContent = "```bash\naz storage account list\n```\n\n| Parameter | Required |\n|---|---|\n| --sub | Yes |";
+
+        var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
+
+        // Annotation block should appear twice — once in MCP tab, once in CLI tab
+        var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
+        Assert.Equal(2, annotationCount);
+
+        // The CLI tab should contain the annotation block
+        var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
+        var afterCliTab = result.Substring(cliTabStart);
+        Assert.Contains("Destructive: ❌ | Idempotent: ✅", afterCliTab);
+    }
+
+    [Fact]
+    public void WrapWithTabs_NoAnnotationInMcpContent_CliTabUnchanged()
+    {
+        var mcpContent = "List storage accounts.\n\n| Parameter | Required |\n|---|---|\n| Sub | Yes |";
+        var cliContent = "```bash\naz storage account list\n```";
+
+        var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
+
+        // No annotation duplication — CLI tab just has its original content
+        Assert.DoesNotContain("[Tool annotation hints]", result);
+        Assert.Contains("az storage account list", result);
+    }
+
+    [Fact]
+    public void WrapWithTabs_AnnotationBlock_AppearsAtEndOfCliTab()
+    {
+        var mcpContent = "Description.\n\n" +
+            "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):\n\n" +
+            "Destructive: ✅ | Idempotent: ❌ | Open World: ✅ | Read Only: ❌ | Secret: ❌ | Local Required: ❌";
+        var cliContent = "```bash\naz tool run\n```";
+
+        var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
+
+        // The annotation should come AFTER the CLI content, before the --- terminator
+        var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
+        var terminatorPos = result.IndexOf("\n---", cliTabStart, StringComparison.Ordinal);
+        var annotationInCliTab = result.IndexOf("Destructive: ✅", cliTabStart, StringComparison.Ordinal);
+
+        Assert.True(annotationInCliTab > cliTabStart, "Annotation should be after CLI tab header");
+        Assert.True(annotationInCliTab < terminatorPos, "Annotation should be before --- terminator");
+    }
+
+    [Fact]
+    public void ApplyTabsToFamilyArticle_AnnotationsInTool_DuplicatedToBothTabs()
+    {
+        const string familyWithAnnotations = """
+            ---
+            ms.topic: include
+            ---
+
+            # Azure Storage tools
+
+            ## List accounts
+            <!-- @mcpcli storage account list -->
+
+            List storage accounts in a subscription.
+
+            [Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):
+
+            Destructive: ❌ | Idempotent: ✅ | Read Only: ✅
+
+            ---
+            """;
+
+        var cliContent = new Dictionary<string, string>
+        {
+            ["storage account list"] = "```bash\naz storage account list\n```"
+        };
+
+        var result = CliTabWrapper.ApplyTabsToFamilyArticle(familyWithAnnotations, cliContent);
+
+        // Annotation should appear twice — once in each tab
+        var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
+        Assert.Equal(2, annotationCount);
+    }
+
     private static int CountOccurrences(string text, string pattern)
     {
         int count = 0;

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -14,9 +14,17 @@ public static class CliTabWrapper
 {
     private static readonly Regex McpCliMarkerPattern = new(
         @"<!--\s*@mcpcli\s+(.+?)\s*-->", RegexOptions.Compiled);
+
+    // Matches the annotation block: "[Tool annotation hints](...):"\n\n"Destructive: ..."
+    // The block starts with the link line and includes the values line that follows.
+    private static readonly Regex AnnotationBlockPattern = new(
+        @"(\[Tool annotation hints\]\([^\)]+\):\s*\n\s*\n[^\n]*(?:Destructive|Idempotent|Read Only)[^\n]*)",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Wraps a tool section with MCP/CLI tabs.
     /// If no CLI content is available for the tool, returns the original content unchanged.
+    /// Annotation blocks found in mcpContent are duplicated into the CLI tab.
     /// </summary>
     /// <param name="mcpContent">The existing MCP tool section content (without the H2 heading)</param>
     /// <param name="cliContent">The CLI content block for this tool, or null if unavailable</param>
@@ -26,6 +34,9 @@ public static class CliTabWrapper
         if (string.IsNullOrWhiteSpace(cliContent))
             return mcpContent;
 
+        // Extract annotation block from MCP content to duplicate into CLI tab
+        var annotationBlock = ExtractAnnotationBlock(mcpContent);
+
         var sb = new StringBuilder();
 
         // MCP Server tab
@@ -34,16 +45,36 @@ public static class CliTabWrapper
         sb.AppendLine(mcpContent.TrimEnd());
         sb.AppendLine();
 
-        // CLI tab
+        // CLI tab — append annotation block if present
         sb.AppendLine("#### [Azure MCP CLI](#tab/azure-mcp-cli)");
         sb.AppendLine();
-        sb.AppendLine(cliContent.TrimEnd());
+        if (annotationBlock != null)
+        {
+            sb.AppendLine(cliContent.TrimEnd());
+            sb.AppendLine();
+            sb.AppendLine(annotationBlock);
+        }
+        else
+        {
+            sb.AppendLine(cliContent.TrimEnd());
+        }
         sb.AppendLine();
 
         // Tab group terminator
         sb.AppendLine("---");
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Extracts the annotation block from tool content.
+    /// Returns the full block ("[Tool annotation hints](...):"\n\nDestructive: ...)
+    /// or null if not found.
+    /// </summary>
+    internal static string? ExtractAnnotationBlock(string content)
+    {
+        var match = AnnotationBlockPattern.Match(content);
+        return match.Success ? match.Groups[1].Value.TrimEnd() : null;
     }
 
     /// <summary>


### PR DESCRIPTION
Annotations (Destructive/Idempotent/Open World/Read Only/Secret/Local Required) now appear under both the MCP Server tab and the Azure MCP CLI tab for each tool, so readers see them regardless of which tab they're viewing.

## Changes
- **shared/DocGeneration.Core.Shared/CliTabWrapper.cs**: Added `ExtractAnnotationBlock` method that extracts the annotation block from MCP content using regex. Modified `WrapWithTabs` to duplicate the annotation block into the CLI tab content.
- **mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs**: Added 4 new tests covering annotation duplication, no-annotation case, positioning, and family article integration.

## Test results
All 2,743 tests pass (0 failures).