### PR TITLE
fix: move tool annotations after --- separator

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
@@ -281,10 +281,10 @@ public class CliTabWrapperTests
         Assert.Null(exception);
     }
 
-    // ── Annotation duplication to CLI tab ────────────────────────
+    // ── Annotation placement — after --- separator ─────────────
 
     [Fact]
-    public void WrapWithTabs_AnnotationInMcpContent_DuplicatedToCliTab()
+    public void WrapWithTabs_AnnotationInMcpContent_PlacedOnceAfterSeparator()
     {
         var mcpContent = "List storage accounts.\n\n" +
             "| Parameter | Required |\n|---|---|\n| Sub | Yes |\n\n" +
@@ -294,14 +294,19 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // Annotation block should appear twice — once in MCP tab, once in CLI tab
+        // Annotation block should appear exactly once — after the --- separator
         var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
-        Assert.Equal(2, annotationCount);
+        Assert.Equal(1, annotationCount);
 
-        // The CLI tab should contain the annotation block
+        // Annotation must be AFTER the --- separator
+        var separatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
+        var annotationPos = result.IndexOf("[Tool annotation hints]", StringComparison.Ordinal);
+        Assert.True(annotationPos > separatorPos, "Annotation should be after --- separator");
+
+        // Annotation must NOT be inside either tab
+        var mcpTabStart = result.IndexOf("#### [MCP Server](#tab/mcp-server)", StringComparison.Ordinal);
         var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
-        var afterCliTab = result.Substring(cliTabStart);
-        Assert.Contains("Destructive: ❌ | Idempotent: ✅", afterCliTab);
+        Assert.True(annotationPos > separatorPos, "Annotation must be outside tabs");
     }
 
     [Fact]
@@ -312,13 +317,13 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // No annotation duplication — CLI tab just has its original content
+        // No annotation anywhere
         Assert.DoesNotContain("[Tool annotation hints]", result);
         Assert.Contains("az storage account list", result);
     }
 
     [Fact]
-    public void WrapWithTabs_AnnotationBlock_AppearsAtEndOfCliTab()
+    public void WrapWithTabs_AnnotationBlock_NotInsideMcpOrCliTab()
     {
         var mcpContent = "Description.\n\n" +
             "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):\n\n" +
@@ -327,17 +332,21 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // The annotation should come AFTER the CLI content, before the --- terminator
-        var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
-        var terminatorPos = result.IndexOf("\n---", cliTabStart, StringComparison.Ordinal);
-        var annotationInCliTab = result.IndexOf("Destructive: ✅", cliTabStart, StringComparison.Ordinal);
+        // Annotation should be AFTER the --- terminator
+        var terminatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
+        var annotationPos = result.IndexOf("Destructive: ✅", StringComparison.Ordinal);
 
-        Assert.True(annotationInCliTab > cliTabStart, "Annotation should be after CLI tab header");
-        Assert.True(annotationInCliTab < terminatorPos, "Annotation should be before --- terminator");
+        Assert.True(annotationPos > terminatorPos, "Annotation should be after --- terminator");
+
+        // The MCP tab content should NOT contain annotation
+        var mcpTabStart = result.IndexOf("#### [MCP Server](#tab/mcp-server)", StringComparison.Ordinal);
+        var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
+        var mcpTabContent = result.Substring(mcpTabStart, cliTabStart - mcpTabStart);
+        Assert.DoesNotContain("[Tool annotation hints]", mcpTabContent);
     }
 
     [Fact]
-    public void ApplyTabsToFamilyArticle_AnnotationsInTool_DuplicatedToBothTabs()
+    public void ApplyTabsToFamilyArticle_AnnotationsInTool_PlacedOnceAfterSeparator()
     {
         const string familyWithAnnotations = """
             ---
@@ -365,9 +374,14 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(familyWithAnnotations, cliContent);
 
-        // Annotation should appear twice — once in each tab
+        // Annotation should appear exactly once — after the --- separator, outside tabs
         var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
-        Assert.Equal(2, annotationCount);
+        Assert.Equal(1, annotationCount);
+
+        // Verify annotation is after --- separator
+        var separatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
+        var annotationPos = result.IndexOf("[Tool annotation hints]", StringComparison.Ordinal);
+        Assert.True(annotationPos > separatorPos, "Annotation should be after --- separator");
     }
 
     private static int CountOccurrences(string text, string pattern)

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -24,7 +24,7 @@ public static class CliTabWrapper
     /// <summary>
     /// Wraps a tool section with MCP/CLI tabs.
     /// If no CLI content is available for the tool, returns the original content unchanged.
-    /// Annotation blocks found in mcpContent are duplicated into the CLI tab.
+    /// Annotation blocks are stripped from tab content and placed once after the --- separator.
     /// </summary>
     /// <param name="mcpContent">The existing MCP tool section content (without the H2 heading)</param>
     /// <param name="cliContent">The CLI content block for this tool, or null if unavailable</param>
@@ -34,34 +34,35 @@ public static class CliTabWrapper
         if (string.IsNullOrWhiteSpace(cliContent))
             return mcpContent;
 
-        // Extract annotation block from MCP content to duplicate into CLI tab
+        // Extract and strip annotation block from MCP content
         var annotationBlock = ExtractAnnotationBlock(mcpContent);
+        var mcpWithoutAnnotation = annotationBlock != null
+            ? StripAnnotationBlock(mcpContent)
+            : mcpContent;
 
         var sb = new StringBuilder();
 
         // MCP Server tab
         sb.AppendLine("#### [MCP Server](#tab/mcp-server)");
         sb.AppendLine();
-        sb.AppendLine(mcpContent.TrimEnd());
+        sb.AppendLine(mcpWithoutAnnotation.TrimEnd());
         sb.AppendLine();
 
-        // CLI tab — append annotation block if present
+        // CLI tab (no annotations inside)
         sb.AppendLine("#### [Azure MCP CLI](#tab/azure-mcp-cli)");
         sb.AppendLine();
-        if (annotationBlock != null)
-        {
-            sb.AppendLine(cliContent.TrimEnd());
-            sb.AppendLine();
-            sb.AppendLine(annotationBlock);
-        }
-        else
-        {
-            sb.AppendLine(cliContent.TrimEnd());
-        }
+        sb.AppendLine(cliContent.TrimEnd());
         sb.AppendLine();
 
         // Tab group terminator
         sb.AppendLine("---");
+
+        // Annotations appear once, after the separator, outside all tabs
+        if (annotationBlock != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine(annotationBlock);
+        }
 
         return sb.ToString();
     }
@@ -75,6 +76,14 @@ public static class CliTabWrapper
     {
         var match = AnnotationBlockPattern.Match(content);
         return match.Success ? match.Groups[1].Value.TrimEnd() : null;
+    }
+
+    /// <summary>
+    /// Removes the annotation block from tool content, returning the content without it.
+    /// </summary>
+    internal static string StripAnnotationBlock(string content)
+    {
+        return AnnotationBlockPattern.Replace(content, "").TrimEnd();
     }
 
     /// <summary>


### PR DESCRIPTION
Corrects annotation placement: annotations now appear once per tool after the `---` separator, completely outside the tabbed content. This replaces the duplicated-under-both-tabs approach from PR #578.

## Changes
- **CliTabWrapper.WrapWithTabs**: Strips annotations from MCP tab content, places them once after the `---` separator
- **StripAnnotationBlock**: New internal method to remove annotation block from content
- **Tests**: Updated 4 tests from duplication-assertion to after-separator-assertion

## Before (PR #578)
```markdown
#### [MCP Server](#tab/mcp-server)
{content}
Annotations here
#### [Azure MCP CLI](#tab/azure-mcp-cli)
{content}
Annotations here (duplicated)
---
```n
## After
```markdown
#### [MCP Server](#tab/mcp-server)
{content}
#### [Azure MCP CLI](#tab/azure-mcp-cli)
{content}
---
Annotations here (once)
```