### PR TITLE
feat: Add CHANGELOG decision gate before namespace processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **CHANGELOG decision gate** — `PipelineRunner.RunAsync()` now checks the upstream `servers/Azure.Mcp.Server/CHANGELOG.md` before processing each namespace. Namespaces with no entries in CHANGELOG versions >= the current CLI version are skipped with an informational message, preventing wasted PRs on azure-dev-docs-pr. New namespaces (no existing article) always process. Gate can be disabled via `--skip-changelog-gate`. Implements `IChangelogGate` / `ChangelogGate` / `ChangelogParser`. Closes #571.
+
+### Changed
+
+- **`DefaultMcpBranch` updated to `main`** — `PipelineRequest.DefaultMcpBranch` changed from `release/azure/2.x` to `main` to track the current default upstream branch. Override via `--mcp-branch` or `MCP_BRANCH` env var. (#571)
+
+### Added
+
 - **Pipeline smoke tests** — New `DocGeneration.PipelineRunner.SmokeTests` project provides end-to-end smoke tests that run the full pipeline on small test namespaces (quota, redis) and verify output matches committed baseline fixtures. Tests serve as a safety net for refactoring, ensuring code changes don't alter pipeline behavior or output structure. Includes `BaselineManager` for capturing/comparing golden files and comprehensive documentation on updating baselines. Closes #534. PR #[PR_NUMBER]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **CHANGELOG decision gate** — `PipelineRunner.RunAsync()` now checks the upstream `servers/Azure.Mcp.Server/CHANGELOG.md` before processing each namespace. Namespaces with no entries in CHANGELOG versions >= the current CLI version are skipped with an informational message, preventing wasted PRs on azure-dev-docs-pr. New namespaces (no existing article) always process. Gate can be disabled via `--skip-changelog-gate`. Implements `IChangelogGate` / `ChangelogGate` / `ChangelogParser`. Closes #571.
+- **Fingerprint baseline comparison gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline fingerprint gate (`--run-fingerprint-gate`) that snapshots `generated-*` output directories and diffs them against `fingerprint-baseline.json`. Detects unintended output drift (file count/size changes) across namespaces. Skips safely when no baseline exists. Implemented via `IFingerprintGate` / `FingerprintGate`, which invokes `DocGeneration.Tools.Fingerprint` as a subprocess.
+
+- **Prompt regression gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline prompt regression gate (`--run-prompt-regression-gate`) that runs `DocGeneration.PromptRegression.Tests` as a subprocess. Catches prompt template regressions by running the full regression suite after generation. Implemented via `IPromptRegressionGate` / `PromptRegressionGate`.
+
+- **CHANGELOG decision gate**— `PipelineRunner.RunAsync()` now checks the upstream `servers/Azure.Mcp.Server/CHANGELOG.md` before processing each namespace. Namespaces with no entries in CHANGELOG versions >= the current CLI version are skipped with an informational message, preventing wasted PRs on azure-dev-docs-pr. New namespaces (no existing article) always process. Gate can be disabled via `--skip-changelog-gate`. Implements `IChangelogGate` / `ChangelogGate` / `ChangelogParser`. Closes #571.
 
 ### Changed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,6 +203,54 @@ Some Azure services span multiple MCP namespaces but publish as a single article
 
 **C# implementation**: `NamespaceMerger.cs` provides typed merge logic with `ParseArticle()` / `Merge()` / `UpdateToolCount()` methods, mirrored by the Node.js-based `merge-namespaces.sh` for shell-level execution.
 
+### Fingerprint Baseline Gate (`--run-fingerprint-gate`)
+
+After all namespace-scoped steps complete, `PipelineRunner.RunAsync()` can run an optional post-pipeline fingerprint comparison gate.
+
+**Gate logic:**
+
+1. Runs `DocGeneration.Tools.Fingerprint snapshot` to capture a candidate snapshot of all `generated-*` directories.
+2. Runs `DocGeneration.Tools.Fingerprint diff` comparing the candidate against `fingerprint-baseline.json` at repo root.
+3. If `diff` exits with code 1 (quality regressions detected) → pipeline exits with `FatalExitCode`.
+4. If no `fingerprint-baseline.json` exists → gate is **skipped** (safe first-run behaviour).
+5. Candidate file (`fingerprint-candidate.json`) is cleaned up in a `finally` block regardless of outcome.
+
+**CLI flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--run-fingerprint-gate` | Enable fingerprint baseline comparison after all namespaces are processed. |
+
+**Key components:**
+
+- `IFingerprintGate` / `FingerprintGate` — service interface and concrete implementation; invokes fingerprint tool as subprocess via `IProcessRunner`.
+- `FingerprintGateResult` — result record with `Pass` / `Fail` factory methods and a `Reason` string.
+
+---
+
+### Prompt Regression Gate (`--run-prompt-regression-gate`)
+
+After all namespace-scoped steps complete, `PipelineRunner.RunAsync()` can run an optional post-pipeline prompt regression gate.
+
+**Gate logic:**
+
+1. Runs `dotnet test DocGeneration.PromptRegression.Tests --no-build --configuration Release --verbosity quiet` via `IProcessRunner`.
+2. If the test runner exits non-zero → pipeline exits with `FatalExitCode`.
+3. Stdout is scanned for the xUnit summary line (e.g., `Passed! – Failed: 0, Passed: 54`) and included in the gate result reason.
+
+**CLI flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--run-prompt-regression-gate` | Run the full prompt regression test suite after all namespaces are processed. |
+
+**Key components:**
+
+- `IPromptRegressionGate` / `PromptRegressionGate` — service interface and concrete implementation; invokes `dotnet test` as subprocess via `IProcessRunner`.
+- `PromptRegressionGateResult` — result record with `Pass` / `Fail` factory methods and a `Reason` string.
+
+---
+
 ### CHANGELOG Gate (AD-571)
 
 Before processing namespace-scoped steps, `PipelineRunner.RunAsync()` applies an optional pre-processing gate that evaluates whether the namespace has changes in the upstream `servers/Azure.Mcp.Server/CHANGELOG.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,6 +203,40 @@ Some Azure services span multiple MCP namespaces but publish as a single article
 
 **C# implementation**: `NamespaceMerger.cs` provides typed merge logic with `ParseArticle()` / `Merge()` / `UpdateToolCount()` methods, mirrored by the Node.js-based `merge-namespaces.sh` for shell-level execution.
 
+### CHANGELOG Gate (AD-571)
+
+Before processing namespace-scoped steps, `PipelineRunner.RunAsync()` applies an optional pre-processing gate that evaluates whether the namespace has changes in the upstream `servers/Azure.Mcp.Server/CHANGELOG.md`.
+
+**Gate logic (evaluated per namespace):**
+
+1. **New namespaces** (no existing article in `tool-family/`) — always processed regardless of CHANGELOG.
+2. **Fetch CHANGELOG** from `https://raw.githubusercontent.com/microsoft/mcp/{branch}/servers/Azure.Mcp.Server/CHANGELOG.md`.
+3. **Find relevant sections** — version sections where the version is >= `cliVersion` (includes `[Unreleased]`).
+4. If **no relevant sections found** → process (conservative fallback).
+5. If the **namespace name appears** (case-insensitive) in any relevant section's content → process.
+6. Otherwise → **skip** with an informational message (avoids generating an empty-diff PR).
+7. **Fetch failures** (network, timeout) → process (conservative fallback).
+
+**CLI flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--skip-changelog-gate` | Bypass the gate entirely; process all namespaces. |
+
+**Key components:**
+
+- `IChangelogGate` / `ChangelogGate` — service interface and production implementation with injected `HttpClient`.
+- `ChangelogParser` — internal static class that parses `## [Version]` sections and implements `HasMentionOf()` / `IsVersionRelevantFor()`.
+- `ChangelogGateResult` — record carrying `ShouldSkip` + `Reason` for logging.
+
+### Branch-Aware Upstream Fetching (`--mcp-branch`)
+
+`BootstrapStep` and `ChangelogGate` both fetch files from `microsoft/mcp` using a configurable branch. Resolution order:
+
+1. `--mcp-branch` CLI flag
+2. `MCP_BRANCH` environment variable
+3. Default: `main`
+
 ### Parallel Execution
 
 After Step 0 (bootstrap) runs once, namespace-scoped steps can execute in parallel:

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
@@ -1,5 +1,6 @@
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
+using System.Threading.Tasks;
 
 namespace PipelineRunner.Tests.Fixtures;
 
@@ -91,4 +92,24 @@ internal sealed class StubCliMetadataLoader : ICliMetadataLoader
 
     public ValueTask<IReadOnlyList<string>> LoadNamespacesAsync(string outputPath, CancellationToken cancellationToken)
         => throw new NotSupportedException();
+}
+
+/// <summary>
+/// A changelog gate stub that skips a specific named namespace and processes all others.
+/// Use this in smoke tests and pipeline-level tests to avoid real network calls.
+/// </summary>
+internal sealed class SkipSpecificNamespaceGate(string namespaceToSkip) : IChangelogGate
+{
+    public Task<ChangelogGateResult> EvaluateAsync(
+        string namespaceName,
+        string baselineVersion,
+        string mcpBranch,
+        bool hasExistingArticle,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(
+            string.Equals(namespaceName, namespaceToSkip, StringComparison.OrdinalIgnoreCase)
+                ? ChangelogGateResult.Skip($"namespace '{namespaceName}' not in CHANGELOG (test stub)")
+                : ChangelogGateResult.Process($"namespace '{namespaceName}' found in CHANGELOG (test stub)"));
+    }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
@@ -35,7 +35,7 @@ public class DryRunIntegrationTests
                 StepRegistry.CreateDefault(Path.Combine(repoRoot, "mcp-tools", "scripts")),
                 contextFactory);
 
-            var request = new PipelineRequest("compute", new[] { 1, 2, 3, 4, 5, 6 }, ".\\generated-compute", false, false, true);
+            var request = new PipelineRequest("compute", new[] { 1, 2, 3, 4, 5, 6 }, ".\\generated-compute", false, false, true, SkipChangelogGate: true);
             var exitCode = await runner.RunAsync(request, CancellationToken.None);
 
             Assert.Equal(0, exitCode);

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogGateCliTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogGateCliTests.cs
@@ -1,0 +1,36 @@
+using PipelineRunner.Cli;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class ChangelogGateCliTests
+{
+    [Fact]
+    public void Parse_SkipChangelogGateFlag_ParsedCorrectly()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute", "--skip-changelog-gate"]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.SkipChangelogGate);
+    }
+
+    [Fact]
+    public void Parse_NoSkipChangelogGateFlag_DefaultsFalse()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute"]);
+
+        Assert.NotNull(result.Request);
+        Assert.False(result.Request!.SkipChangelogGate);
+    }
+
+    [Fact]
+    public void Parse_SkipChangelogGateWithOtherFlags_ParsedCorrectly()
+    {
+        var result = PipelineCli.Parse(["--namespace", "storage", "--skip-changelog-gate", "--skip-build", "--steps", "1,2"]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.SkipChangelogGate);
+        Assert.True(result.Request.SkipBuild);
+        Assert.Equal(new[] { 1, 2 }, result.Request.Steps);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogGateTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogGateTests.cs
@@ -1,0 +1,169 @@
+using PipelineRunner.Services;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class ChangelogGateTests
+{
+    private const string BaselineVersion = "1.2.3";
+
+    // ─── New namespace (hasExistingArticle = false) ────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_NewNamespace_AlwaysProcesses()
+    {
+        var gate = CreateGate("""
+            ## [1.2.3]
+            - compute: new tool
+            """);
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: false, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+        Assert.Contains("new namespace", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Namespace mentioned ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_NamespaceMentionedInRelevantSection_Processes()
+    {
+        var gate = CreateGate("""
+            ## [1.2.3]
+            ### Changed
+            - storage: improved reliability
+            - compute: new list command
+            """);
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+        Assert.Contains("storage", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NamespaceMentionedInUnreleasedSection_Processes()
+    {
+        var gate = CreateGate("""
+            ## [Unreleased]
+            - compute: added batch support
+
+            ## [1.2.2]
+            - storage: old fix
+            """);
+
+        var result = await gate.EvaluateAsync("compute", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+    }
+
+    // ─── Namespace not mentioned ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_NamespaceNotMentionedInRelevantSections_Skips()
+    {
+        var gate = CreateGate("""
+            ## [1.2.3]
+            - compute: new tool
+            - keyvault: updated descriptions
+
+            ## [1.2.2]
+            - storage: old fix
+            """);
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.True(result.ShouldSkip);
+        Assert.Contains("storage", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SkippedReason_MentionsBaselineVersion()
+    {
+        var gate = CreateGate("""
+            ## [1.2.3]
+            - compute: only compute changed
+            """);
+
+        var result = await gate.EvaluateAsync("advisor", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.True(result.ShouldSkip);
+        Assert.Contains(BaselineVersion, result.Reason, StringComparison.Ordinal);
+    }
+
+    // ─── Fetch failure fallback ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_FetchThrows_ProcessesAsSafeFallback()
+    {
+        var gate = new ChangelogGate(static (_, _) => Task.FromException<string>(new HttpRequestException("Network unreachable")));
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+        Assert.Contains("fallback", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── No relevant sections fallback ────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_NoSectionsNewerThanBaseline_ProcessesAsSafeFallback()
+    {
+        // All sections are older than baseline "1.2.3"
+        var gate = CreateGate("""
+            ## [1.2.2]
+            - storage: old entry
+
+            ## [1.0.0]
+            - compute: initial
+            """);
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+        Assert.Contains("fallback", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EmptyChangelog_ProcessesAsSafeFallback()
+    {
+        var gate = CreateGate(string.Empty);
+
+        var result = await gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, CancellationToken.None);
+
+        Assert.False(result.ShouldSkip);
+    }
+
+    // ─── Cancellation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_CancellationRequested_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        var gate = new ChangelogGate(async (_, ct) =>
+        {
+            await cts.CancelAsync();
+            ct.ThrowIfCancellationRequested();
+            return string.Empty;
+        });
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            gate.EvaluateAsync("storage", BaselineVersion, "main", hasExistingArticle: true, cts.Token));
+    }
+
+    // ─── BuildChangelogUrl ────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildChangelogUrl_ContainsBranchAndPath()
+    {
+        var url = ChangelogGate.BuildChangelogUrl("main");
+        Assert.Contains("main", url, StringComparison.Ordinal);
+        Assert.Contains("CHANGELOG.md", url, StringComparison.Ordinal);
+        Assert.Contains("raw.githubusercontent.com", url, StringComparison.Ordinal);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ChangelogGate CreateGate(string content)
+        => new((_, _) => Task.FromResult(content));
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogParserTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ChangelogParserTests.cs
@@ -1,0 +1,183 @@
+using PipelineRunner.Services;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class ChangelogParserTests
+{
+    // ─── ParseSections ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseSections_EmptyContent_ReturnsEmpty()
+    {
+        var sections = ChangelogParser.ParseSections(string.Empty);
+        Assert.Empty(sections);
+    }
+
+    [Fact]
+    public void ParseSections_WhitespaceContent_ReturnsEmpty()
+    {
+        var sections = ChangelogParser.ParseSections("   \n\n  ");
+        Assert.Empty(sections);
+    }
+
+    [Fact]
+    public void ParseSections_SingleVersionSection_ReturnsSingleSection()
+    {
+        const string content = """
+            # Changelog
+
+            ## [1.2.3] - 2025-05-01
+            ### Changed
+            - storage: improved reliability
+            """;
+
+        var sections = ChangelogParser.ParseSections(content);
+
+        var section = Assert.Single(sections);
+        Assert.Equal("1.2.3", section.Version);
+        Assert.Contains("storage:", section.Content);
+    }
+
+    [Fact]
+    public void ParseSections_MultipleVersionSections_ParsesAll()
+    {
+        const string content = """
+            ## [Unreleased]
+            - compute: new tool
+
+            ## [1.2.3] - 2025-05-01
+            - storage: updated
+
+            ## [1.2.2] - 2025-04-01
+            - keyvault: fix
+            """;
+
+        var sections = ChangelogParser.ParseSections(content);
+
+        Assert.Equal(3, sections.Count);
+        Assert.Equal("Unreleased", sections[0].Version);
+        Assert.Equal("1.2.3", sections[1].Version);
+        Assert.Equal("1.2.2", sections[2].Version);
+    }
+
+    [Fact]
+    public void ParseSections_ContentIsScopedToSection()
+    {
+        const string content = """
+            ## [2.0.0]
+            - compute: major changes
+
+            ## [1.0.0]
+            - storage: first release
+            """;
+
+        var sections = ChangelogParser.ParseSections(content);
+
+        Assert.Equal(2, sections.Count);
+        Assert.Contains("compute:", sections[0].Content);
+        Assert.DoesNotContain("storage:", sections[0].Content);
+        Assert.Contains("storage:", sections[1].Content);
+        Assert.DoesNotContain("compute:", sections[1].Content);
+    }
+
+    // ─── HasMentionOf ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HasMentionOf_NamespacePresent_ReturnsTrue()
+    {
+        const string content = "- storage: fixed connection timeout";
+        Assert.True(ChangelogParser.HasMentionOf(content, "storage"));
+    }
+
+    [Fact]
+    public void HasMentionOf_NamespaceAbsent_ReturnsFalse()
+    {
+        const string content = "- compute: new list command";
+        Assert.False(ChangelogParser.HasMentionOf(content, "storage"));
+    }
+
+    [Fact]
+    public void HasMentionOf_IsCaseInsensitive()
+    {
+        const string content = "- Storage: improved reliability";
+        Assert.True(ChangelogParser.HasMentionOf(content, "storage"));
+    }
+
+    [Fact]
+    public void HasMentionOf_NamespaceAsSubstring_ReturnsTrue()
+    {
+        // "storage" appears in "azure-storage-account"
+        const string content = "- azmcp azure-storage-account list updated";
+        Assert.True(ChangelogParser.HasMentionOf(content, "storage"));
+    }
+
+    [Fact]
+    public void HasMentionOf_EmptyContent_ReturnsFalse()
+    {
+        Assert.False(ChangelogParser.HasMentionOf(string.Empty, "storage"));
+    }
+
+    [Fact]
+    public void HasMentionOf_EmptyNamespace_ReturnsFalse()
+    {
+        Assert.False(ChangelogParser.HasMentionOf("some content", string.Empty));
+    }
+
+    // ─── IsVersionRelevantFor ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IsVersionRelevantFor_Unreleased_AlwaysRelevant()
+    {
+        Assert.True(ChangelogParser.IsVersionRelevantFor("Unreleased", "1.2.3"));
+        Assert.True(ChangelogParser.IsVersionRelevantFor("Unreleased", "99.0.0"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_NewerVersion_ReturnsTrue()
+    {
+        Assert.True(ChangelogParser.IsVersionRelevantFor("1.2.4", "1.2.3"));
+        Assert.True(ChangelogParser.IsVersionRelevantFor("2.0.0", "1.9.9"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_EqualVersion_ReturnsTrue()
+    {
+        // We want to check the section that matches the current version
+        Assert.True(ChangelogParser.IsVersionRelevantFor("1.2.3", "1.2.3"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_OlderVersion_ReturnsFalse()
+    {
+        Assert.False(ChangelogParser.IsVersionRelevantFor("1.2.2", "1.2.3"));
+        Assert.False(ChangelogParser.IsVersionRelevantFor("0.9.0", "1.0.0"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_VersionWithDateSuffix_ParsesCorrectly()
+    {
+        // CHANGELOG headers often include a date: ## [1.2.3] - 2025-05-01
+        // The version string captured is "1.2.3] - 2025-05-01" — but our parser
+        // captures only the inner text, e.g. "1.2.3 - 2025-05-01" or "1.2.3".
+        // Verify we correctly parse the numeric prefix before a space.
+        Assert.True(ChangelogParser.IsVersionRelevantFor("1.2.4 - 2025-05-01", "1.2.3"));
+        Assert.False(ChangelogParser.IsVersionRelevantFor("1.2.2 - 2025-03-01", "1.2.3"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_PreReleaseSuffix_ParsesNumericPart()
+    {
+        // Pre-release versions like "1.0.0-rc.2.25502.107" strip to "1.0.0"
+        Assert.True(ChangelogParser.IsVersionRelevantFor("1.0.0", "1.0.0-rc.2.25502.107"));
+        Assert.False(ChangelogParser.IsVersionRelevantFor("0.9.0", "1.0.0-rc.2.25502.107"));
+    }
+
+    [Fact]
+    public void IsVersionRelevantFor_UnparseableVersion_ReturnsTrue()
+    {
+        // Conservative: when we can't parse, include the section
+        Assert.True(ChangelogParser.IsVersionRelevantFor("not-a-version", "1.2.3"));
+        Assert.True(ChangelogParser.IsVersionRelevantFor("1.2.3", "not-a-version"));
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FingerprintGateTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FingerprintGateTests.cs
@@ -1,0 +1,241 @@
+using PipelineRunner.Services;
+using PipelineRunner.Tests.Fixtures;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="FingerprintGate"/>.
+/// Uses a callback process runner so no real dotnet process is spawned.
+/// </summary>
+public class FingerprintGateTests
+{
+    // ── Baseline not found (safe fallback) ────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_BaselineNotFound_PassesWithFallbackReason()
+    {
+        var repoRoot = CreateTempDir();
+        try
+        {
+            // No fingerprint-baseline.json in repoRoot
+            var gate = BuildGate(out var runner, out _);
+            var result = await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains("safe fallback", result.Reason, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(runner.Invocations); // no subprocess calls when baseline absent
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Snapshot subprocess fails ──────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_SnapshotFails_ReturnsFail()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 1, snapshotStderr: "disk full");
+            var result = await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("snapshot failed", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Snapshot succeeds, diff returns 0 (no regressions) ────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_DiffSucceeds_ReturnsPass()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 0, diffExitCode: 0,
+                createCandidateFile: true);
+            var result = await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains("No quality regressions", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Diff exits 1 (quality regressions detected) ───────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_DiffDetectsRegressions_ReturnsFail()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 0, diffExitCode: 1,
+                diffStdout: "⚠️  1 namespace(s) with quality regressions.",
+                createCandidateFile: true);
+            var result = await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("regressions", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Subprocess invocation order: snapshot → diff ───────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_InvokesSnapshotBeforeDiff()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 0, diffExitCode: 0,
+                createCandidateFile: true);
+            await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.Equal(2, runner.Invocations.Count);
+            Assert.Contains("snapshot", string.Join(" ", runner.Invocations[0].Arguments), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("diff", string.Join(" ", runner.Invocations[1].Arguments), StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Snapshot produces no output file ──────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_SnapshotProducesNoFile_ReturnsFail()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            // Snapshot exits 0 but never writes the candidate file
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 0, createCandidateFile: false);
+            var result = await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("no output file", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Candidate file is cleaned up after evaluation ─────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_CandidateFileCleanedUpAfterDiff()
+    {
+        var repoRoot = CreateTempDirWithBaseline();
+        try
+        {
+            var gate = BuildGate(out var runner, out _,
+                snapshotExitCode: 0, diffExitCode: 0,
+                createCandidateFile: true);
+            await gate.EvaluateAsync(repoRoot, Path.Combine(repoRoot, "mcp-tools"), CancellationToken.None);
+
+            var candidatePath = Path.Combine(repoRoot, FingerprintGate.CandidateFileName);
+            Assert.False(File.Exists(candidatePath), "Candidate file should be deleted after gate evaluation.");
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static FingerprintGate BuildGate(
+        out InvocationCapturingRunner runner,
+        out BufferedReportWriter writer,
+        int snapshotExitCode = 0,
+        string snapshotStderr = "",
+        int diffExitCode = 0,
+        string diffStdout = "",
+        bool createCandidateFile = false)
+    {
+        var capturedRunner = new InvocationCapturingRunner(snapshotExitCode, snapshotStderr, diffExitCode, diffStdout, createCandidateFile);
+        runner = capturedRunner;
+        writer = new BufferedReportWriter();
+        return new FingerprintGate(capturedRunner, writer);
+    }
+
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"fp-gate-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string CreateTempDirWithBaseline()
+    {
+        var dir = CreateTempDir();
+        File.WriteAllText(Path.Combine(dir, FingerprintGate.BaselineFileName), "{}");
+        return dir;
+    }
+
+    /// <summary>
+    /// Process runner that records invocations and simulates fingerprint tool behaviour.
+    /// First call = snapshot, second call = diff.
+    /// </summary>
+    private sealed class InvocationCapturingRunner : IProcessRunner
+    {
+        private readonly int _snapshotExitCode;
+        private readonly string _snapshotStderr;
+        private readonly int _diffExitCode;
+        private readonly string _diffStdout;
+        private readonly bool _createCandidateFile;
+        private int _callCount;
+
+        public InvocationCapturingRunner(
+            int snapshotExitCode, string snapshotStderr,
+            int diffExitCode, string diffStdout,
+            bool createCandidateFile)
+        {
+            _snapshotExitCode = snapshotExitCode;
+            _snapshotStderr = snapshotStderr;
+            _diffExitCode = diffExitCode;
+            _diffStdout = diffStdout;
+            _createCandidateFile = createCandidateFile;
+        }
+
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
+        {
+            Invocations.Add(spec);
+            _callCount++;
+
+            // First call is the snapshot, second is the diff
+            if (_callCount == 1)
+            {
+                if (_createCandidateFile)
+                {
+                    // Simulate fingerprint tool writing candidate file to working dir
+                    var candidatePath = spec.Arguments
+                        .SkipWhile(a => a != "--output")
+                        .Skip(1)
+                        .FirstOrDefault();
+                    if (candidatePath is not null)
+                        File.WriteAllText(candidatePath, "{}");
+                }
+                return ValueTask.FromResult(Make(spec, _snapshotExitCode, string.Empty, _snapshotStderr));
+            }
+
+            return ValueTask.FromResult(Make(spec, _diffExitCode, _diffStdout, string.Empty));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken ct)
+            => RunAsync(new ProcessSpec("dotnet", ["build", solutionPath], string.Empty), ct);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken ct)
+            => RunAsync(new ProcessSpec("dotnet", ["run", "--project", projectPath, .. arguments], workingDirectory), ct);
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), ct);
+
+        private static ProcessExecutionResult Make(ProcessSpec spec, int exitCode, string stdout, string stderr)
+            => new(spec.FileName, spec.Arguments, spec.WorkingDirectory, exitCode, stdout, stderr, TimeSpan.Zero);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/McpBranchResolutionTests.cs
@@ -7,7 +7,7 @@ namespace PipelineRunner.Tests.Unit;
 public class McpBranchResolutionTests
 {
     [Fact]
-    public void ResolvedMcpBranch_DefaultsTo2x_WhenNothingSet()
+    public void ResolvedMcpBranch_DefaultsToMain_WhenNothingSet()
     {
         // Ensure env var is not set for this test
         var originalValue = Environment.GetEnvironmentVariable("MCP_BRANCH");
@@ -16,7 +16,7 @@ public class McpBranchResolutionTests
             Environment.SetEnvironmentVariable("MCP_BRANCH", null);
             var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: null);
             Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
-            Assert.Equal("release/azure/2.x", request.ResolvedMcpBranch);
+            Assert.Equal("main", request.ResolvedMcpBranch);
         }
         finally
         {
@@ -72,6 +72,7 @@ public class McpBranchResolutionTests
             Environment.SetEnvironmentVariable("MCP_BRANCH", null);
             var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: "  ");
             Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
+            Assert.Equal("main", request.ResolvedMcpBranch);
         }
         finally
         {
@@ -88,6 +89,7 @@ public class McpBranchResolutionTests
             Environment.SetEnvironmentVariable("MCP_BRANCH", "  ");
             var request = new PipelineRequest(null, [1], ".\\generated", false, false, false, McpBranch: null);
             Assert.Equal(PipelineRequest.DefaultMcpBranch, request.ResolvedMcpBranch);
+            Assert.Equal("main", request.ResolvedMcpBranch);
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PipelineRunnerGlobalScopeTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PipelineRunnerGlobalScopeTests.cs
@@ -37,7 +37,7 @@ public class PipelineRunnerGlobalScopeTests
             var namespaceStep = new RecordingStep(1, "Generate annotations", StepScope.Namespace, executionOrder);
             var runner = new global::PipelineRunner.PipelineRunner(new StepRegistry([bootstrapStep, namespaceStep]), contextFactory);
 
-            var request = new PipelineRequest(null, [1], ".\\generated", SkipBuild: true, SkipValidation: false, DryRun: false);
+            var request = new PipelineRequest(null, [1], ".\\generated", SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: true);
             var exitCode = await runner.RunAsync(request, CancellationToken.None);
 
             Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
@@ -51,6 +51,68 @@ public class PipelineRunnerGlobalScopeTests
         }
     }
 
+    [Fact]
+    public async Task RunAsync_ChangelogGateSkipsNamespace_PipelineCompletesGracefully()
+    {
+        // Regression guard for Bootstrap/cli-tab-config.json interaction (RISK 2):
+        // Bootstrap (commit c0a6ec9) writes cli-tab-config.json listing ALL resolved namespaces BEFORE the
+        // namespace loop runs. The CHANGELOG gate can then skip some of those namespaces inside the loop.
+        // This test documents and verifies that skipping a namespace via the gate is graceful:
+        // the pipeline succeeds and the skipped namespace's steps are not executed, even though
+        // cli-tab-config.json still has an entry for it (orphan entries do not cause a pipeline error).
+
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-changelog-gate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var executionOrder = new List<string>();
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                new RecordingProcessRunner(),
+                new WorkspaceManager(),
+                new StaticCliMetadataLoader(),   // returns ["compute", "storage"]
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            // Gate skips "storage" — simulating that no CHANGELOG entries exist for it.
+            // In a real run Bootstrap has already written cli-tab-config.json with both namespaces,
+            // but the skipped namespace never reaches Step 1+.
+            var changelogGate = new SkipSpecificNamespaceGate("storage");
+            var bootstrapStep = new RecordingStep(0, "Bootstrap pipeline", StepScope.Global, executionOrder);
+            var namespaceStep = new RecordingStep(1, "Generate annotations", StepScope.Namespace, executionOrder);
+            var runner = new global::PipelineRunner.PipelineRunner(
+                new StepRegistry([bootstrapStep, namespaceStep]),
+                contextFactory,
+                changelogGate);
+
+            // SkipChangelogGate = false — the gate IS active for this test
+            var request = new PipelineRequest(null, [1], ".\\generated", SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: false);
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            // Pipeline must complete successfully — skipping a namespace via the gate is not an error
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+
+            // Bootstrap (global step) runs once; namespace step runs only for "compute" (not "storage")
+            Assert.Equal(1, bootstrapStep.Executions);
+            Assert.Equal(1, namespaceStep.Executions);
+            Assert.Equal(new[] { "global", "namespace:compute" }, executionOrder);
+
+            // The skip reason for "storage" must appear in the pipeline report
+            Assert.Contains(reportWriter.Messages,
+                m => m.Contains("storage", StringComparison.OrdinalIgnoreCase)
+                  && m.Contains("Skipped", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
     private sealed class RecordingStep : StepDefinition
     {
         private readonly List<string> _executionOrder;

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PromptRegressionGateTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PromptRegressionGateTests.cs
@@ -1,0 +1,165 @@
+using PipelineRunner.Services;
+using PipelineRunner.Tests.Fixtures;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="PromptRegressionGate"/>.
+/// Uses a recording process runner to avoid real dotnet test invocations.
+/// </summary>
+public class PromptRegressionGateTests
+{
+    // ── Test project not found ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_TestProjectNotFound_ReturnsFail()
+    {
+        var mcpToolsRoot = Path.Combine(Path.GetTempPath(), $"prg-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(mcpToolsRoot);
+        try
+        {
+            // No DocGeneration.PromptRegression.Tests project in mcpToolsRoot
+            var gate = BuildGate(out _, out _, exitCode: 0);
+            var result = await gate.EvaluateAsync(mcpToolsRoot, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("not found", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(mcpToolsRoot, true); }
+    }
+
+    // ── Tests pass (exit 0) ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_TestsPass_ReturnsPass()
+    {
+        var mcpToolsRoot = CreateMcpToolsRootWithProject();
+        try
+        {
+            var gate = BuildGate(out _, out _, exitCode: 0,
+                stdout: "Passed! - Failed: 0, Passed: 12, Skipped: 0, Total: 12");
+            var result = await gate.EvaluateAsync(mcpToolsRoot, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains("passed", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(mcpToolsRoot, true); }
+    }
+
+    // ── Tests fail (exit 1) ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_TestsFail_ReturnsFail()
+    {
+        var mcpToolsRoot = CreateMcpToolsRootWithProject();
+        try
+        {
+            var gate = BuildGate(out _, out _, exitCode: 1,
+                stdout: "Failed!  - Failed: 2, Passed: 10, Skipped: 0, Total: 12");
+            var result = await gate.EvaluateAsync(mcpToolsRoot, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("failed", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(mcpToolsRoot, true); }
+    }
+
+    // ── Verifies correct dotnet test arguments ─────────────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_InvokesDotNetTest_WithCorrectProjectAndFlags()
+    {
+        var mcpToolsRoot = CreateMcpToolsRootWithProject();
+        try
+        {
+            var gate = BuildGate(out var runner, out _, exitCode: 0);
+            await gate.EvaluateAsync(mcpToolsRoot, CancellationToken.None);
+
+            Assert.Single(runner.Invocations);
+            var args = string.Join(" ", runner.Invocations[0].Arguments);
+            Assert.Contains("test", args, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("DocGeneration.PromptRegression.Tests", args, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("--no-build", args, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Release", args, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(mcpToolsRoot, true); }
+    }
+
+    // ── Test summary line is captured in pass reason ───────────────────────
+
+    [Fact]
+    public async Task EvaluateAsync_SummaryLineAppended_ToPassReason()
+    {
+        var mcpToolsRoot = CreateMcpToolsRootWithProject();
+        try
+        {
+            const string summaryLine = "Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7";
+            var gate = BuildGate(out _, out _, exitCode: 0, stdout: $"some output\n{summaryLine}");
+            var result = await gate.EvaluateAsync(mcpToolsRoot, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains("Total: 7", result.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(mcpToolsRoot, true); }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static PromptRegressionGate BuildGate(
+        out FixedProcessRunner runner,
+        out BufferedReportWriter writer,
+        int exitCode = 0,
+        string stdout = "")
+    {
+        var r = new FixedProcessRunner(exitCode, stdout);
+        runner = r;
+        writer = new BufferedReportWriter();
+        return new PromptRegressionGate(r, writer);
+    }
+
+    private static string CreateMcpToolsRootWithProject()
+    {
+        var mcpToolsRoot = Path.Combine(Path.GetTempPath(), $"prg-test-{Guid.NewGuid():N}");
+        var projectDir = Path.Combine(mcpToolsRoot, "DocGeneration.PromptRegression.Tests");
+        Directory.CreateDirectory(projectDir);
+        File.WriteAllText(
+            Path.Combine(projectDir, "DocGeneration.PromptRegression.Tests.csproj"),
+            "<Project />");
+        return mcpToolsRoot;
+    }
+
+    /// <summary>
+    /// A lightweight process runner that returns a fixed exit code and stdout for every call.
+    /// </summary>
+    private sealed class FixedProcessRunner : IProcessRunner
+    {
+        private readonly int _exitCode;
+        private readonly string _stdout;
+
+        public FixedProcessRunner(int exitCode, string stdout)
+        {
+            _exitCode = exitCode;
+            _stdout = stdout;
+        }
+
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
+        {
+            Invocations.Add(spec);
+            return ValueTask.FromResult(
+                new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory,
+                    _exitCode, _stdout, string.Empty, TimeSpan.Zero));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken ct)
+            => RunAsync(new ProcessSpec("dotnet", ["build", solutionPath], string.Empty), ct);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken ct)
+            => RunAsync(new ProcessSpec("dotnet", ["run", "--project", projectPath, .. arguments], workingDirectory), ct);
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), ct);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGateCliTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGateCliTests.cs
@@ -1,0 +1,80 @@
+using PipelineRunner.Cli;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// CLI parsing tests for the --run-fingerprint-gate and --run-prompt-regression-gate flags.
+/// </summary>
+public class ValidationGateCliTests
+{
+    // ── --run-fingerprint-gate ─────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_RunFingerprintGateFlag_ParsedAsTrue()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute", "--run-fingerprint-gate"]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.RunFingerprintGate);
+    }
+
+    [Fact]
+    public void Parse_NoRunFingerprintGateFlag_DefaultsFalse()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute"]);
+
+        Assert.NotNull(result.Request);
+        Assert.False(result.Request!.RunFingerprintGate);
+    }
+
+    // ── --run-prompt-regression-gate ───────────────────────────────────────
+
+    [Fact]
+    public void Parse_RunPromptRegressionGateFlag_ParsedAsTrue()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute", "--run-prompt-regression-gate"]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.RunPromptRegressionGate);
+    }
+
+    [Fact]
+    public void Parse_NoRunPromptRegressionGateFlag_DefaultsFalse()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute"]);
+
+        Assert.NotNull(result.Request);
+        Assert.False(result.Request!.RunPromptRegressionGate);
+    }
+
+    // ── Both flags together ────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_BothValidationGateFlags_BothParsedCorrectly()
+    {
+        var result = PipelineCli.Parse([
+            "--namespace", "storage",
+            "--run-fingerprint-gate",
+            "--run-prompt-regression-gate",
+            "--skip-build"
+        ]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.RunFingerprintGate);
+        Assert.True(result.Request.RunPromptRegressionGate);
+        Assert.True(result.Request.SkipBuild);
+    }
+
+    // ── Default state of all flags ─────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NoValidationGateFlags_BothDefaultFalse()
+    {
+        var result = PipelineCli.Parse(["--namespace", "advisor", "--skip-changelog-gate"]);
+
+        Assert.NotNull(result.Request);
+        Assert.False(result.Request!.RunFingerprintGate);
+        Assert.False(result.Request!.RunPromptRegressionGate);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGatePipelineTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGatePipelineTests.cs
@@ -1,0 +1,335 @@
+using System.Text.Json;
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Registry;
+using PipelineRunner.Services;
+using PipelineRunner.Tests.Fixtures;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Pipeline-level tests ensuring fingerprint and prompt regression gates
+/// integrate correctly with PipelineRunner.RunAsync().
+/// </summary>
+public class ValidationGatePipelineTests
+{
+    // ── Fingerprint gate failure stops the pipeline ─────────────────────────
+
+    [Fact]
+    public async Task RunAsync_FingerprintGateFails_ReturnsFatalExitCode()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var runner = BuildRunner(repoRoot,
+                fingerprintGate: new StubFingerprintGate(success: false, reason: "quality regressions detected"),
+                promptRegressionGate: null);
+
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true,
+                RunFingerprintGate: true,
+                RunPromptRegressionGate: false);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.FatalExitCode, exitCode);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Prompt regression gate failure stops the pipeline ──────────────────
+
+    [Fact]
+    public async Task RunAsync_PromptRegressionGateFails_ReturnsFatalExitCode()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var runner = BuildRunner(repoRoot,
+                fingerprintGate: null,
+                promptRegressionGate: new StubPromptRegressionGate(success: false, reason: "2 tests failed"));
+
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true,
+                RunFingerprintGate: false,
+                RunPromptRegressionGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.FatalExitCode, exitCode);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Gates disabled by default — not invoked ─────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_FingerprintGateFlagFalse_GateNotInvoked()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var fpGate = new StubFingerprintGate(success: false, reason: "should not be called");
+            var runner = BuildRunner(repoRoot, fingerprintGate: fpGate, promptRegressionGate: null);
+
+            // RunFingerprintGate defaults to false
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(0, fpGate.CallCount); // gate was never called
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    [Fact]
+    public async Task RunAsync_PromptRegressionGateFlagFalse_GateNotInvoked()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var prgGate = new StubPromptRegressionGate(success: false, reason: "should not be called");
+            var runner = BuildRunner(repoRoot, fingerprintGate: null, promptRegressionGate: prgGate);
+
+            // RunPromptRegressionGate defaults to false
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(0, prgGate.CallCount);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Both gates pass — pipeline succeeds ────────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_BothGatesPass_ReturnsSuccess()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var runner = BuildRunner(repoRoot,
+                fingerprintGate: new StubFingerprintGate(success: true, reason: "no regressions"),
+                promptRegressionGate: new StubPromptRegressionGate(success: true, reason: "all tests pass"));
+
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true,
+                RunFingerprintGate: true,
+                RunPromptRegressionGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Gates run after namespace steps complete ───────────────────────────
+
+    [Fact]
+    public async Task RunAsync_GatesRunAfterNamespaceStepsComplete()
+    {
+        var repoRoot = CreateTestRoot();
+        try
+        {
+            var executionOrder = new List<string>();
+
+            var step = new OrderTrackingStep(1, "Generate annotations", StepScope.Namespace, executionOrder);
+            var fpGate = new OrderTrackingFingerprintGate(executionOrder);
+            var runner = BuildRunnerWithStep(repoRoot, step, fpGate, null);
+
+            var request = new PipelineRequest(null, [1], ".\\generated",
+                SkipBuild: true, SkipValidation: false, DryRun: false,
+                SkipChangelogGate: true,
+                RunFingerprintGate: true,
+                RunPromptRegressionGate: false);
+
+            await runner.RunAsync(request, CancellationToken.None);
+
+            // All namespace steps come before the gate
+            var lastStepIndex = executionOrder.LastIndexOf(
+                executionOrder.FindLast(e => e.StartsWith("step:", StringComparison.Ordinal)) ?? "");
+            var gateIndex = executionOrder.IndexOf("fingerprint-gate");
+
+            Assert.True(gateIndex > lastStepIndex,
+                $"Fingerprint gate should run after steps. Order: [{string.Join(", ", executionOrder)}]");
+        }
+        finally { Directory.Delete(repoRoot, true); }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static string CreateTestRoot()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"vg-pipeline-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(dir, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(dir, "mcp-doc-generation.sln"), string.Empty);
+        return dir;
+    }
+
+    private static global::PipelineRunner.PipelineRunner BuildRunner(
+        string repoRoot,
+        IFingerprintGate? fingerprintGate,
+        IPromptRegressionGate? promptRegressionGate)
+    {
+        var contextFactory = new PipelineContextFactory(
+            new RecordingProcessRunner(),
+            new WorkspaceManager(),
+            new StaticCliMetadataLoader(),
+            new TargetMatcher(),
+            new StubFilteredCliWriter(),
+            new StubBuildCoordinator(),
+            new StubAiCapabilityProbe(),
+            new BufferedReportWriter(),
+            repoRoot);
+
+        var noopStep = new NoopNamespaceStep();
+        return new global::PipelineRunner.PipelineRunner(
+            new StepRegistry([noopStep]),
+            contextFactory,
+            changelogGate: null,
+            fingerprintGate: fingerprintGate,
+            promptRegressionGate: promptRegressionGate);
+    }
+
+    private static global::PipelineRunner.PipelineRunner BuildRunnerWithStep(
+        string repoRoot,
+        IPipelineStep step,
+        IFingerprintGate? fingerprintGate,
+        IPromptRegressionGate? promptRegressionGate)
+    {
+        var contextFactory = new PipelineContextFactory(
+            new RecordingProcessRunner(),
+            new WorkspaceManager(),
+            new StaticCliMetadataLoader(),
+            new TargetMatcher(),
+            new StubFilteredCliWriter(),
+            new StubBuildCoordinator(),
+            new StubAiCapabilityProbe(),
+            new BufferedReportWriter(),
+            repoRoot);
+
+        return new global::PipelineRunner.PipelineRunner(
+            new StepRegistry([step]),
+            contextFactory,
+            changelogGate: null,
+            fingerprintGate: fingerprintGate,
+            promptRegressionGate: promptRegressionGate);
+    }
+
+    // ── Stub gates ────────────────────────────────────────────────────────
+
+    private sealed class StubFingerprintGate(bool success, string reason) : IFingerprintGate
+    {
+        public int CallCount { get; private set; }
+
+        public Task<FingerprintGateResult> EvaluateAsync(string repoRoot, string mcpToolsRoot, CancellationToken ct)
+        {
+            CallCount++;
+            return Task.FromResult(success
+                ? FingerprintGateResult.Pass(reason)
+                : FingerprintGateResult.Fail(reason));
+        }
+    }
+
+    private sealed class StubPromptRegressionGate(bool success, string reason) : IPromptRegressionGate
+    {
+        public int CallCount { get; private set; }
+
+        public Task<PromptRegressionGateResult> EvaluateAsync(string mcpToolsRoot, CancellationToken ct)
+        {
+            CallCount++;
+            return Task.FromResult(success
+                ? PromptRegressionGateResult.Pass(reason)
+                : PromptRegressionGateResult.Fail(reason));
+        }
+    }
+
+    private sealed class OrderTrackingFingerprintGate(List<string> order) : IFingerprintGate
+    {
+        public Task<FingerprintGateResult> EvaluateAsync(string repoRoot, string mcpToolsRoot, CancellationToken ct)
+        {
+            order.Add("fingerprint-gate");
+            return Task.FromResult(FingerprintGateResult.Pass("ok"));
+        }
+    }
+
+    // ── Test step helpers ──────────────────────────────────────────────────
+
+    private sealed class NoopNamespaceStep : StepDefinition
+    {
+        public NoopNamespaceStep() : base(1, "Noop step", StepScope.Namespace, FailurePolicy.Fatal) { }
+
+        public override ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken ct)
+            => ValueTask.FromResult(new StepResult(true, Array.Empty<string>(), TimeSpan.Zero,
+                Array.Empty<string>(), Array.Empty<string>(), Array.Empty<ValidatorResult>(),
+                Array.Empty<ArtifactFailure>()));
+    }
+
+    private sealed class OrderTrackingStep(int id, string name, StepScope scope, List<string> order)
+        : StepDefinition(id, name, scope, FailurePolicy.Fatal)
+    {
+        public override ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken ct)
+        {
+            order.Add($"step:{id}");
+            return ValueTask.FromResult(new StepResult(true, Array.Empty<string>(), TimeSpan.Zero,
+                Array.Empty<string>(), Array.Empty<string>(), Array.Empty<ValidatorResult>(),
+                Array.Empty<ArtifactFailure>()));
+        }
+    }
+
+    // ── CLI metadata loader that returns two namespaces ────────────────────
+
+    private sealed class StaticCliMetadataLoader : ICliMetadataLoader
+    {
+        private readonly CliMetadataSnapshot _snapshot = CreateSnapshot();
+
+        public bool CliOutputExists(string outputPath) => true;
+        public bool CliVersionExists(string outputPath) => true;
+        public bool NamespaceMetadataExists(string outputPath) => true;
+
+        public ValueTask<CliMetadataSnapshot> LoadCliOutputAsync(string outputPath, CancellationToken ct)
+            => ValueTask.FromResult(_snapshot);
+
+        public ValueTask<string> LoadCliVersionAsync(string outputPath, CancellationToken ct)
+            => ValueTask.FromResult("1.0.0");
+
+        public ValueTask<IReadOnlyList<string>> LoadNamespacesAsync(string outputPath, CancellationToken ct)
+            => ValueTask.FromResult<IReadOnlyList<string>>(["compute", "storage"]);
+
+        private static CliMetadataSnapshot CreateSnapshot()
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                results = new[]
+                {
+                    new { command = "compute list", name = "compute list", description = "desc" },
+                }
+            });
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement.Clone();
+            var tools = root.GetProperty("results")
+                .EnumerateArray()
+                .Select(t => new CliTool(
+                    t.GetProperty("command").GetString() ?? string.Empty,
+                    t.GetProperty("name").GetString() ?? string.Empty,
+                    t.GetProperty("description").GetString(),
+                    t.Clone()))
+                .ToArray();
+            return new CliMetadataSnapshot(
+                Path.Combine(Path.GetTempPath(), $"cli-{Guid.NewGuid():N}.json"), root, tools);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -21,6 +21,8 @@ public static class PipelineCli
         rootCommand.AddOption(options.DryRun);
         rootCommand.AddOption(options.McpBranch);
         rootCommand.AddOption(options.SkipChangelogGate);
+        rootCommand.AddOption(options.RunFingerprintGate);
+        rootCommand.AddOption(options.RunPromptRegressionGate);
         return rootCommand;
     }
 
@@ -59,7 +61,9 @@ public static class PipelineCli
             parseResult.GetValueForOption(options.SkipEnvValidation),
             parseResult.GetValueForOption(options.SkipDeps),
             parseResult.GetValueForOption(options.McpBranch),
-            parseResult.GetValueForOption(options.SkipChangelogGate));
+            parseResult.GetValueForOption(options.SkipChangelogGate),
+            parseResult.GetValueForOption(options.RunFingerprintGate),
+            parseResult.GetValueForOption(options.RunPromptRegressionGate));
 
         var validationErrors = request.Validate();
         return validationErrors.Count > 0
@@ -114,6 +118,8 @@ public static class PipelineCli
         rootCommand.AddOption(options.DryRun);
         rootCommand.AddOption(options.McpBranch);
         rootCommand.AddOption(options.SkipChangelogGate);
+        rootCommand.AddOption(options.RunFingerprintGate);
+        rootCommand.AddOption(options.RunPromptRegressionGate);
         return rootCommand;
     }
 
@@ -128,7 +134,9 @@ public static class PipelineCli
             new Option<bool>("--skip-deps", "Skip step dependency validation. Allows running a step without its prerequisites."),
             new Option<bool>("--dry-run", "Print the resolved execution plan without running bootstrap or steps."),
             new Option<string?>("--mcp-branch", "Branch of microsoft/mcp to fetch upstream files from. Overrides MCP_BRANCH env var. Default: main."),
-            new Option<bool>("--skip-changelog-gate", "Skip the CHANGELOG gate check and process all namespaces regardless of CHANGELOG entries."));
+            new Option<bool>("--skip-changelog-gate", "Skip the CHANGELOG gate check and process all namespaces regardless of CHANGELOG entries."),
+            new Option<bool>("--run-fingerprint-gate", "After pipeline steps, compare output fingerprints against fingerprint-baseline.json. Fails on quality regressions."),
+            new Option<bool>("--run-prompt-regression-gate", "After pipeline steps, run the DocGeneration.PromptRegression.Tests suite to verify prompt templates are unaffected."));
 
     private sealed record CliOptions(
         Option<string?> Namespace,
@@ -140,5 +148,7 @@ public static class PipelineCli
         Option<bool> SkipDeps,
         Option<bool> DryRun,
         Option<string?> McpBranch,
-        Option<bool> SkipChangelogGate);
+        Option<bool> SkipChangelogGate,
+        Option<bool> RunFingerprintGate,
+        Option<bool> RunPromptRegressionGate);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -20,6 +20,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipDeps);
         rootCommand.AddOption(options.DryRun);
         rootCommand.AddOption(options.McpBranch);
+        rootCommand.AddOption(options.SkipChangelogGate);
         return rootCommand;
     }
 
@@ -57,7 +58,8 @@ public static class PipelineCli
             parseResult.GetValueForOption(options.DryRun),
             parseResult.GetValueForOption(options.SkipEnvValidation),
             parseResult.GetValueForOption(options.SkipDeps),
-            parseResult.GetValueForOption(options.McpBranch));
+            parseResult.GetValueForOption(options.McpBranch),
+            parseResult.GetValueForOption(options.SkipChangelogGate));
 
         var validationErrors = request.Validate();
         return validationErrors.Count > 0
@@ -111,6 +113,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipDeps);
         rootCommand.AddOption(options.DryRun);
         rootCommand.AddOption(options.McpBranch);
+        rootCommand.AddOption(options.SkipChangelogGate);
         return rootCommand;
     }
 
@@ -124,7 +127,8 @@ public static class PipelineCli
             new Option<bool>("--skip-env-validation", "Skip Azure OpenAI environment validation during bootstrap."),
             new Option<bool>("--skip-deps", "Skip step dependency validation. Allows running a step without its prerequisites."),
             new Option<bool>("--dry-run", "Print the resolved execution plan without running bootstrap or steps."),
-            new Option<string?>("--mcp-branch", "Branch of microsoft/mcp to fetch upstream files from. Overrides MCP_BRANCH env var. Default: release/azure/2.x."));
+            new Option<string?>("--mcp-branch", "Branch of microsoft/mcp to fetch upstream files from. Overrides MCP_BRANCH env var. Default: main."),
+            new Option<bool>("--skip-changelog-gate", "Skip the CHANGELOG gate check and process all namespaces regardless of CHANGELOG entries."));
 
     private sealed record CliOptions(
         Option<string?> Namespace,
@@ -135,5 +139,6 @@ public static class PipelineCli
         Option<bool> SkipEnvValidation,
         Option<bool> SkipDeps,
         Option<bool> DryRun,
-        Option<string?> McpBranch);
+        Option<string?> McpBranch,
+        Option<bool> SkipChangelogGate);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -10,7 +10,9 @@ public sealed record PipelineRequest(
     bool SkipEnvValidation = false,
     bool SkipDependencyValidation = false,
     string? McpBranch = null,
-    bool SkipChangelogGate = false)
+    bool SkipChangelogGate = false,
+    bool RunFingerprintGate = false,
+    bool RunPromptRegressionGate = false)
 {
     /// <summary>
     /// Default upstream branch for fetching files from the microsoft/mcp repository.

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -9,12 +9,13 @@ public sealed record PipelineRequest(
     bool DryRun,
     bool SkipEnvValidation = false,
     bool SkipDependencyValidation = false,
-    string? McpBranch = null)
+    string? McpBranch = null,
+    bool SkipChangelogGate = false)
 {
     /// <summary>
     /// Default upstream branch for fetching files from the microsoft/mcp repository.
     /// </summary>
-    public const string DefaultMcpBranch = "release/azure/2.x";
+    public const string DefaultMcpBranch = "main";
 
     /// <summary>
     /// Resolves the effective MCP branch: CLI flag > MCP_BRANCH env var > default constant.

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -15,11 +15,13 @@ public sealed class PipelineRunner
 
     private readonly StepRegistry _stepRegistry;
     private readonly PipelineContextFactory _contextFactory;
+    private readonly IChangelogGate? _changelogGate;
 
-    public PipelineRunner(StepRegistry stepRegistry, PipelineContextFactory contextFactory)
+    public PipelineRunner(StepRegistry stepRegistry, PipelineContextFactory contextFactory, IChangelogGate? changelogGate = null)
     {
         _stepRegistry = stepRegistry;
         _contextFactory = contextFactory;
+        _changelogGate = changelogGate;
     }
 
     public static PipelineRunner CreateDefault(string? repoRoot = null, TextWriter? output = null, TextWriter? error = null)
@@ -45,7 +47,7 @@ public sealed class PipelineRunner
 
         var resolvedRepoRoot = PipelineContextFactory.ResolveRepoRoot(repoRoot);
         var stepRegistry = StepRegistry.CreateDefault(Path.Combine(resolvedRepoRoot, "mcp-tools", "scripts"));
-        return new PipelineRunner(stepRegistry, contextFactory);
+        return new PipelineRunner(stepRegistry, contextFactory, new ChangelogGate());
     }
 
     public async Task<int> RunAsync(PipelineRequest request, CancellationToken cancellationToken = default)
@@ -122,6 +124,23 @@ public sealed class PipelineRunner
         {
             context.Reports.Info($"Namespace: {namespaceName}");
             context.Items["Namespace"] = namespaceName;
+
+            if (!request.SkipChangelogGate && _changelogGate is not null)
+            {
+                var hasExistingArticle = HasExistingArticle(context, namespaceName);
+                var gateResult = await _changelogGate.EvaluateAsync(
+                    namespaceName,
+                    context.CliVersion ?? string.Empty,
+                    context.McpBranch,
+                    hasExistingArticle,
+                    cancellationToken);
+
+                if (gateResult.ShouldSkip)
+                {
+                    context.Reports.Info($"  Skipped (changelog gate): {gateResult.Reason}");
+                    continue;
+                }
+            }
 
             foreach (var step in namespaceSteps)
             {
@@ -409,6 +428,23 @@ public sealed class PipelineRunner
                 context.Reports.Warning($"  {error}");
             }
         }
+    }
+
+    private static bool HasExistingArticle(PipelineContext context, string namespaceName)
+    {
+        var toolFamilyDir = Path.Combine(context.OutputPath, "tool-family");
+        if (!Directory.Exists(toolFamilyDir))
+        {
+            return false;
+        }
+
+        // Article filenames may differ due to brand mapping, but typically contain the namespace name
+        var normalized = context.TargetMatcher.Normalize(namespaceName)
+            .Replace(" ", "-", StringComparison.Ordinal)
+            .ToLowerInvariant();
+
+        return Directory.EnumerateFiles(toolFamilyDir, "*.md", SearchOption.TopDirectoryOnly)
+            .Any(f => Path.GetFileNameWithoutExtension(f).Contains(normalized, StringComparison.OrdinalIgnoreCase));
     }
 
     private sealed record StepExecutionOutcome(

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -16,12 +16,21 @@ public sealed class PipelineRunner
     private readonly StepRegistry _stepRegistry;
     private readonly PipelineContextFactory _contextFactory;
     private readonly IChangelogGate? _changelogGate;
+    private readonly IFingerprintGate? _fingerprintGate;
+    private readonly IPromptRegressionGate? _promptRegressionGate;
 
-    public PipelineRunner(StepRegistry stepRegistry, PipelineContextFactory contextFactory, IChangelogGate? changelogGate = null)
+    public PipelineRunner(
+        StepRegistry stepRegistry,
+        PipelineContextFactory contextFactory,
+        IChangelogGate? changelogGate = null,
+        IFingerprintGate? fingerprintGate = null,
+        IPromptRegressionGate? promptRegressionGate = null)
     {
         _stepRegistry = stepRegistry;
         _contextFactory = contextFactory;
         _changelogGate = changelogGate;
+        _fingerprintGate = fingerprintGate;
+        _promptRegressionGate = promptRegressionGate;
     }
 
     public static PipelineRunner CreateDefault(string? repoRoot = null, TextWriter? output = null, TextWriter? error = null)
@@ -47,7 +56,9 @@ public sealed class PipelineRunner
 
         var resolvedRepoRoot = PipelineContextFactory.ResolveRepoRoot(repoRoot);
         var stepRegistry = StepRegistry.CreateDefault(Path.Combine(resolvedRepoRoot, "mcp-tools", "scripts"));
-        return new PipelineRunner(stepRegistry, contextFactory, new ChangelogGate());
+        var fingerprintGate = new FingerprintGate(processRunner, reportWriter);
+        var promptRegressionGate = new PromptRegressionGate(processRunner, reportWriter);
+        return new PipelineRunner(stepRegistry, contextFactory, new ChangelogGate(), fingerprintGate, promptRegressionGate);
     }
 
     public async Task<int> RunAsync(PipelineRequest request, CancellationToken cancellationToken = default)
@@ -153,7 +164,59 @@ public sealed class PipelineRunner
             }
         }
 
+        var gatesExitCode = await RunValidationGatesAsync(context, warnings, criticalFailures, cancellationToken);
+        if (gatesExitCode != SuccessExitCode)
+        {
+            return CompleteRun(context, warnings, criticalFailures, gatesExitCode);
+        }
+
         return CompleteRun(context, warnings, criticalFailures, SuccessExitCode);
+    }
+
+    private async Task<int> RunValidationGatesAsync(
+        PipelineContext context,
+        ICollection<string> warnings,
+        ICollection<CriticalFailureRecordReference> criticalFailures,
+        CancellationToken cancellationToken)
+    {
+        if (context.Request.RunFingerprintGate && _fingerprintGate is not null)
+        {
+            context.Reports.Info("Running fingerprint baseline gate...");
+            var result = await _fingerprintGate.EvaluateAsync(
+                context.RepoRoot,
+                context.McpToolsRoot,
+                cancellationToken);
+
+            if (result.Success)
+            {
+                context.Reports.Info($"  ✅ Fingerprint gate passed: {result.Reason}");
+            }
+            else
+            {
+                context.Reports.Error($"  ❌ Fingerprint gate failed: {result.Reason}");
+                return FatalExitCode;
+            }
+        }
+
+        if (context.Request.RunPromptRegressionGate && _promptRegressionGate is not null)
+        {
+            context.Reports.Info("Running prompt regression gate...");
+            var result = await _promptRegressionGate.EvaluateAsync(
+                context.McpToolsRoot,
+                cancellationToken);
+
+            if (result.Success)
+            {
+                context.Reports.Info($"  ✅ Prompt regression gate passed: {result.Reason}");
+            }
+            else
+            {
+                context.Reports.Error($"  ❌ Prompt regression gate failed: {result.Reason}");
+                return FatalExitCode;
+            }
+        }
+
+        return SuccessExitCode;
     }
 
     public static int MapBootstrapExitCode(int exitCode)

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogGate.cs
@@ -1,0 +1,92 @@
+using System.Text;
+
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Fetches and evaluates the upstream CHANGELOG to decide whether a namespace
+/// has changes in versions at or newer than the current CLI version.
+/// </summary>
+public sealed class ChangelogGate : IChangelogGate
+{
+    /// <summary>Path within the microsoft/mcp repo to the Azure MCP Server CHANGELOG.</summary>
+    internal const string ChangelogRelativePath = "servers/Azure.Mcp.Server/CHANGELOG.md";
+
+    /// <summary>Shared client to avoid socket exhaustion. Mirrors the pattern in BootstrapStep.</summary>
+    private static readonly HttpClient SharedHttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(30),
+        DefaultRequestHeaders = { { "User-Agent", "AzureMcpDocGen/1.0" } },
+    };
+
+    private readonly Func<string, CancellationToken, Task<string>>? _contentFetcher;
+
+    /// <summary>Production constructor — uses the shared <see cref="HttpClient"/>.</summary>
+    public ChangelogGate() { }
+
+    /// <summary>
+    /// Test constructor — injects a content fetcher so unit tests can provide canned CHANGELOG text
+    /// without making real HTTP calls.
+    /// </summary>
+    internal ChangelogGate(Func<string, CancellationToken, Task<string>> contentFetcher)
+    {
+        _contentFetcher = contentFetcher;
+    }
+
+    /// <summary>Builds the raw GitHub URL for the CHANGELOG on the given branch.</summary>
+    internal static string BuildChangelogUrl(string branch)
+        => $"https://raw.githubusercontent.com/microsoft/mcp/{branch}/{ChangelogRelativePath}";
+
+    /// <inheritdoc />
+    public async Task<ChangelogGateResult> EvaluateAsync(
+        string namespaceName,
+        string baselineVersion,
+        string mcpBranch,
+        bool hasExistingArticle,
+        CancellationToken cancellationToken)
+    {
+        // New namespaces (no existing article) are always processed regardless of CHANGELOG
+        if (!hasExistingArticle)
+        {
+            return ChangelogGateResult.Process($"namespace '{namespaceName}' has no existing article; processing as new namespace");
+        }
+
+        string content;
+        try
+        {
+            var url = BuildChangelogUrl(mcpBranch);
+            content = _contentFetcher is not null
+                ? await _contentFetcher(url, cancellationToken)
+                : await SharedHttpClient.GetStringAsync(url, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // Network or timeout failure — fall through and process (conservative)
+            return ChangelogGateResult.Process($"CHANGELOG unavailable ({ex.GetType().Name}: {ex.Message}); processing as safe fallback");
+        }
+
+        var sections = ChangelogParser.ParseSections(content);
+        var relevantSections = sections
+            .Where(s => ChangelogParser.IsVersionRelevantFor(s.Version, baselineVersion))
+            .ToArray();
+
+        if (relevantSections.Length == 0)
+        {
+            // No sections at or newer than baseline — all entries are older; process conservatively
+            return ChangelogGateResult.Process("no CHANGELOG sections at or newer than baseline version; processing as safe fallback");
+        }
+
+        var combinedContent = string.Join("\n", relevantSections.Select(s => s.Content));
+
+        if (ChangelogParser.HasMentionOf(combinedContent, namespaceName))
+        {
+            return ChangelogGateResult.Process($"namespace '{namespaceName}' found in CHANGELOG");
+        }
+
+        return ChangelogGateResult.Skip(
+            $"namespace '{namespaceName}' not mentioned in CHANGELOG for versions >= {baselineVersion}; skipping to avoid unnecessary PR");
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogGateResult.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogGateResult.cs
@@ -1,0 +1,13 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Result of a <see cref="IChangelogGate"/> evaluation for a namespace.
+/// </summary>
+public sealed record ChangelogGateResult(bool ShouldSkip, string Reason)
+{
+    /// <summary>Creates a result indicating the namespace should be skipped.</summary>
+    public static ChangelogGateResult Skip(string reason) => new(true, reason);
+
+    /// <summary>Creates a result indicating the namespace should be processed.</summary>
+    public static ChangelogGateResult Process(string reason) => new(false, reason);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogParser.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/ChangelogParser.cs
@@ -1,0 +1,94 @@
+using System.Text.RegularExpressions;
+
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Parses a Keep-a-Changelog style CHANGELOG.md into version sections
+/// and provides query helpers used by <see cref="ChangelogGate"/>.
+/// </summary>
+internal static partial class ChangelogParser
+{
+    [GeneratedRegex(@"^## \[([^\]]+)\]", RegexOptions.Multiline)]
+    private static partial Regex SectionHeaderPattern();
+
+    /// <summary>
+    /// Splits CHANGELOG content into (Version, Content) sections ordered by appearance.
+    /// </summary>
+    internal static IReadOnlyList<ChangelogSection> ParseSections(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return Array.Empty<ChangelogSection>();
+        }
+
+        var sections = new List<ChangelogSection>();
+        var matches = SectionHeaderPattern().Matches(content);
+
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var version = matches[i].Groups[1].Value.Trim();
+            var contentStart = matches[i].Index + matches[i].Length;
+            var contentEnd = i + 1 < matches.Count ? matches[i + 1].Index : content.Length;
+            var sectionContent = content[contentStart..contentEnd].Trim();
+            sections.Add(new ChangelogSection(version, sectionContent));
+        }
+
+        return sections;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="version"/> is relevant for the given <paramref name="baseline"/>:
+    /// i.e. the version is "Unreleased" or its numeric part is greater than or equal to the baseline.
+    /// Versions that cannot be parsed are treated as relevant (conservative fallback).
+    /// </summary>
+    internal static bool IsVersionRelevantFor(string version, string baseline)
+    {
+        if (string.Equals(version, "Unreleased", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (TryParseNumericVersion(version, out var v) && TryParseNumericVersion(baseline, out var b))
+        {
+            return v >= b;
+        }
+
+        // Cannot parse — be conservative and include the section
+        return true;
+    }
+
+    /// <summary>
+    /// Returns true when the namespace name appears (case-insensitive) anywhere in the section content.
+    /// </summary>
+    internal static bool HasMentionOf(string sectionContent, string namespaceName)
+    {
+        if (string.IsNullOrWhiteSpace(sectionContent) || string.IsNullOrWhiteSpace(namespaceName))
+        {
+            return false;
+        }
+
+        return sectionContent.Contains(namespaceName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Strips pre-release suffixes (e.g. "-rc.2.25502.107") and parses the numeric part.
+    /// </summary>
+    private static bool TryParseNumericVersion(string versionString, out Version? version)
+    {
+        var dashIndex = versionString.IndexOf('-', StringComparison.Ordinal);
+        var spaceIndex = versionString.IndexOf(' ', StringComparison.Ordinal);
+
+        // Use the earliest delimiter found (dash or space before date in CHANGELOG headers)
+        var cutIndex = dashIndex >= 0 && spaceIndex >= 0
+            ? Math.Min(dashIndex, spaceIndex)
+            : dashIndex >= 0 ? dashIndex
+            : spaceIndex >= 0 ? spaceIndex
+            : -1;
+
+        var numericPart = cutIndex >= 0 ? versionString[..cutIndex] : versionString;
+        return Version.TryParse(numericPart.Trim(), out version);
+    }
+}
+
+/// <summary>A parsed section from a CHANGELOG, identified by version tag and content.</summary>
+internal sealed record ChangelogSection(string Version, string Content);

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/FingerprintGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/FingerprintGate.cs
@@ -1,0 +1,105 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Compares current pipeline output fingerprints against the committed
+/// <c>fingerprint-baseline.json</c> to detect unintended output drift.
+///
+/// <para>Invokes the <c>DocGeneration.Tools.Fingerprint</c> project as a subprocess
+/// (snapshot phase then diff phase) to avoid a hard project reference between two
+/// Exe outputs.</para>
+/// </summary>
+public sealed class FingerprintGate : IFingerprintGate
+{
+    internal const string BaselineFileName = "fingerprint-baseline.json";
+    internal const string CandidateFileName = "fingerprint-candidate.json";
+    internal const string FingerprintProjectRelPath =
+        "DocGeneration.Tools.Fingerprint/DocGeneration.Tools.Fingerprint.csproj";
+
+    private readonly IProcessRunner _processRunner;
+    private readonly IReportWriter _reportWriter;
+
+    public FingerprintGate(IProcessRunner processRunner, IReportWriter reportWriter)
+    {
+        _processRunner = processRunner;
+        _reportWriter = reportWriter;
+    }
+
+    /// <inheritdoc />
+    public async Task<FingerprintGateResult> EvaluateAsync(
+        string repoRoot,
+        string mcpToolsRoot,
+        CancellationToken cancellationToken)
+    {
+        var baselinePath = Path.Combine(repoRoot, BaselineFileName);
+        if (!File.Exists(baselinePath))
+        {
+            return FingerprintGateResult.Pass(
+                $"Fingerprint baseline not found at '{baselinePath}'; skipping comparison as safe fallback.");
+        }
+
+        var candidatePath = Path.Combine(repoRoot, CandidateFileName);
+        var fingerprintProject = Path.Combine(mcpToolsRoot, FingerprintProjectRelPath);
+
+        try
+        {
+            // Phase 1: generate candidate snapshot of current generated-* output
+            _reportWriter.Info("  Fingerprint gate: generating candidate snapshot...");
+            var snapshotResult = await _processRunner.RunAsync(
+                new ProcessSpec(
+                    "dotnet",
+                    [
+                        "run", "--project", fingerprintProject,
+                        "--configuration", "Release", "--no-build", "--",
+                        "snapshot", "--output", candidatePath, "--repo-root", repoRoot
+                    ],
+                    repoRoot),
+                cancellationToken);
+
+            if (!snapshotResult.Succeeded)
+            {
+                return FingerprintGateResult.Fail(
+                    $"Fingerprint snapshot failed (exit {snapshotResult.ExitCode}): {snapshotResult.StandardError}");
+            }
+
+            if (!File.Exists(candidatePath))
+            {
+                return FingerprintGateResult.Fail(
+                    "Fingerprint snapshot produced no output file.");
+            }
+
+            // Phase 2: diff candidate against baseline
+            _reportWriter.Info("  Fingerprint gate: comparing against baseline...");
+            var diffResult = await _processRunner.RunAsync(
+                new ProcessSpec(
+                    "dotnet",
+                    [
+                        "run", "--project", fingerprintProject,
+                        "--configuration", "Release", "--no-build", "--",
+                        "diff", "--baseline", baselinePath, "--candidate", candidatePath
+                    ],
+                    repoRoot),
+                cancellationToken);
+
+            if (diffResult.Succeeded)
+            {
+                return FingerprintGateResult.Pass(
+                    "No quality regressions detected in fingerprint comparison.");
+            }
+
+            // Trim output to a reasonable summary size
+            var output = diffResult.StandardOutput;
+            var summary = output.Length > 500 ? output[..500] + "..." : output;
+            return FingerprintGateResult.Fail(
+                $"Fingerprint comparison detected quality regressions:\n{summary}");
+        }
+        finally
+        {
+            // Best-effort cleanup of temporary candidate snapshot
+            if (File.Exists(candidatePath))
+            {
+                try { File.Delete(candidatePath); }
+                catch { /* ignored */ }
+            }
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/FingerprintGateResult.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/FingerprintGateResult.cs
@@ -1,0 +1,10 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Outcome of the fingerprint baseline comparison gate.
+/// </summary>
+public sealed record FingerprintGateResult(bool Success, string Reason)
+{
+    public static FingerprintGateResult Pass(string reason) => new(true, reason);
+    public static FingerprintGateResult Fail(string reason) => new(false, reason);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/IChangelogGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/IChangelogGate.cs
@@ -1,0 +1,24 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Evaluates whether a namespace should be processed by checking the upstream CHANGELOG
+/// for entries mentioning it in versions at or newer than the current CLI version.
+/// </summary>
+public interface IChangelogGate
+{
+    /// <summary>
+    /// Evaluates the gate for the given namespace.
+    /// </summary>
+    /// <param name="namespaceName">Namespace to check (e.g. "compute").</param>
+    /// <param name="baselineVersion">Current CLI version string (e.g. "1.2.3"). Sections at or newer than this version are checked.</param>
+    /// <param name="mcpBranch">Branch of microsoft/mcp to fetch CHANGELOG from.</param>
+    /// <param name="hasExistingArticle">True when the namespace already has a generated article on disk. New namespaces always process.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="ChangelogGateResult"/> with ShouldSkip=true when no CHANGELOG entries are found.</returns>
+    Task<ChangelogGateResult> EvaluateAsync(
+        string namespaceName,
+        string baselineVersion,
+        string mcpBranch,
+        bool hasExistingArticle,
+        CancellationToken cancellationToken);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/IFingerprintGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/IFingerprintGate.cs
@@ -1,0 +1,9 @@
+namespace PipelineRunner.Services;
+
+public interface IFingerprintGate
+{
+    Task<FingerprintGateResult> EvaluateAsync(
+        string repoRoot,
+        string mcpToolsRoot,
+        CancellationToken cancellationToken);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/IPromptRegressionGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/IPromptRegressionGate.cs
@@ -1,0 +1,8 @@
+namespace PipelineRunner.Services;
+
+public interface IPromptRegressionGate
+{
+    Task<PromptRegressionGateResult> EvaluateAsync(
+        string mcpToolsRoot,
+        CancellationToken cancellationToken);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/PromptRegressionGate.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/PromptRegressionGate.cs
@@ -1,0 +1,67 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Runs the <c>DocGeneration.PromptRegression.Tests</c> xUnit suite as a pipeline
+/// validation gate to ensure that prompt templates still produce expected output
+/// after pipeline code changes (e.g., new flags, new gate logic).
+/// </summary>
+public sealed class PromptRegressionGate : IPromptRegressionGate
+{
+    internal const string RegressionTestsRelPath =
+        "DocGeneration.PromptRegression.Tests/DocGeneration.PromptRegression.Tests.csproj";
+
+    private readonly IProcessRunner _processRunner;
+    private readonly IReportWriter _reportWriter;
+
+    public PromptRegressionGate(IProcessRunner processRunner, IReportWriter reportWriter)
+    {
+        _processRunner = processRunner;
+        _reportWriter = reportWriter;
+    }
+
+    /// <inheritdoc />
+    public async Task<PromptRegressionGateResult> EvaluateAsync(
+        string mcpToolsRoot,
+        CancellationToken cancellationToken)
+    {
+        var testProject = Path.Combine(mcpToolsRoot, RegressionTestsRelPath);
+        if (!File.Exists(testProject))
+        {
+            return PromptRegressionGateResult.Fail(
+                $"Prompt regression test project not found at '{testProject}'.");
+        }
+
+        _reportWriter.Info("  Prompt regression gate: running test suite...");
+        var result = await _processRunner.RunAsync(
+            new ProcessSpec(
+                "dotnet",
+                ["test", testProject, "--no-build", "--configuration", "Release", "--verbosity", "quiet"],
+                mcpToolsRoot),
+            cancellationToken);
+
+        if (result.Succeeded)
+        {
+            var summary = ExtractTestSummary(result.StandardOutput);
+            return PromptRegressionGateResult.Pass(
+                $"Prompt regression suite passed.{(summary.Length > 0 ? " " + summary : string.Empty)}");
+        }
+
+        var failureOutput = result.StandardOutput;
+        var truncated = failureOutput.Length > 1000 ? failureOutput[..1000] + "..." : failureOutput;
+        return PromptRegressionGateResult.Fail(
+            $"Prompt regression suite failed (exit {result.ExitCode}):\n{truncated}");
+    }
+
+    /// <summary>
+    /// Extracts the xUnit test result summary line from stdout, e.g.
+    /// "Passed! - Failed: 0, Passed: 12, Skipped: 0, Total: 12, Duration: 1 s".
+    /// </summary>
+    private static string ExtractTestSummary(string output)
+    {
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var summaryLine = Array.FindLast(lines, l =>
+            l.Contains("Passed!", StringComparison.OrdinalIgnoreCase) ||
+            l.Contains("Total:", StringComparison.OrdinalIgnoreCase));
+        return summaryLine?.Trim() ?? string.Empty;
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/PromptRegressionGateResult.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/PromptRegressionGateResult.cs
@@ -1,0 +1,10 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Outcome of the prompt regression test suite gate.
+/// </summary>
+public sealed record PromptRegressionGateResult(bool Success, string Reason)
+{
+    public static PromptRegressionGateResult Pass(string reason) => new(true, reason);
+    public static PromptRegressionGateResult Fail(string reason) => new(false, reason);
+}

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser/config.json
@@ -1,5 +1,5 @@
 {
-  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/release/azure/2.x/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
+  "remoteUrl": "https://raw.githubusercontent.com/microsoft/mcp/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "remoteUrlTemplate": "https://raw.githubusercontent.com/microsoft/mcp/{branch}/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md",
   "localFileName": "e2eTestPrompts.md"
 }

--- a/mcp-tools/scripts/preflight.ps1
+++ b/mcp-tools/scripts/preflight.ps1
@@ -32,7 +32,7 @@ param(
     [string]$OutputPath = "",
     [switch]$SkipBuild,
     [switch]$SkipEnvValidation,
-    [string]$McpBranch = "release/azure/2.x"
+    [string]$McpBranch = "main"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Summary

Closes #571.

Adds a pre-processing gate in \PipelineRunner.RunAsync()\ that checks the upstream \servers/Azure.Mcp.Server/CHANGELOG.md\ before running namespace-scoped steps. Namespaces with no CHANGELOG entries for versions >= the current CLI version are skipped with an informational message, preventing wasted PRs on azure-dev-docs-pr.

## Changes

### New services
- \IChangelogGate\ / \ChangelogGate\ — fetches and evaluates upstream CHANGELOG; injectable for testability
- \ChangelogParser\ (internal) — parses \## [Version]\ sections, \HasMentionOf()\, \IsVersionRelevantFor()\
- \ChangelogGateResult\ — record with \ShouldSkip\ + \Reason\

### Pipeline integration
- Gate applied per-namespace in \PipelineRunner.RunAsync()\ before step execution
- New namespaces (no existing \	ool-family/\ article) always process
- Fetch failures fall through conservatively (no skipping)
- No relevant CHANGELOG sections found → falls through (safe fallback)

### CLI
- \--skip-changelog-gate\ flag bypasses the gate entirely
- \DefaultMcpBranch\ updated from \elease/azure/2.x\ to \main\

### Tests (37 new)
- \ChangelogParserTests\ — section parsing, mention matching, version comparison
- \ChangelogGateTests\ — new namespace pass-through, mention found, not found (skip), fetch failure, no sections fallback, cancellation propagation
- \ChangelogGateCliTests\ — CLI flag parsing
- \McpBranchResolutionTests\ updated for new default (\main\)

## Acceptance criteria

- [x] Pipeline skips namespaces with no CHANGELOG changes (informational message logged)
- [x] New namespaces (no existing article) are always processed
- [x] Gate can be disabled via \--skip-changelog-gate\
- [x] \DefaultMcpBranch\ updated from \elease/azure/2.x\ to \main\

## Test results

283/283 passing in DocGeneration.PipelineRunner.Tests (zero failures, zero regressions in full solution).