### PR TITLE
feat(skills-gen): enforce content policy -- suppress implementation details

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/ExamplePromptsFallbackTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/ExamplePromptsFallbackTests.cs
@@ -51,8 +51,8 @@ public class ExamplePromptsFallbackTests
 
         var result = SkillPageGenerator.GenerateFallbackPrompts(items, "Test");
 
-        // MaxExamplePrompts is 10
-        result.Count.Should().BeLessOrEqualTo(10);
+        // MaxExamplePrompts is 8 (§7.3)
+        result.Count.Should().BeLessOrEqualTo(8);
     }
 
     [Fact]

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Generation/SkillPageGeneratorTests.cs
@@ -335,8 +335,9 @@ The skill provides knowledge about {{displayName}}.
     }
 
     [Fact]
-    public void Generate_WithToolsSection_RendersToolsTable()
+    public void Generate_WithToolsSection_DoesNotRenderToolsTable()
     {
+        // §7.1: Even with showToolsSection=true, hasMcpTools is always false
         var generator = CreateGenerator();
         var skill = CreateTestSkillData();
         var triggers = new TriggerData([], [], null);
@@ -345,8 +346,8 @@ The skill provides knowledge about {{displayName}}.
 
         var result = generator.Generate(skill, triggers, tier, prereqs);
 
-        result.Should().Contain("storage_list");
-        result.Should().Contain("`storage list`");
+        result.Should().NotContain("storage_list");
+        result.Should().NotContain("### Related tools");
     }
 
     [Fact]
@@ -380,13 +381,14 @@ The skill provides knowledge about {{displayName}}.
 }
 
 // === MCP Tools Template Rendering (Issue #369) ===
+// §7.1: MCP tools are implementation details and must NOT render in customer-facing articles
 
 public class McpToolsTemplateRenderingTests
 {
     private readonly ILogger<SkillPageGenerator> _logger = Substitute.For<ILogger<SkillPageGenerator>>();
 
     [Fact]
-    public void Generate_WithMcpTools_RendersMcpToolsSection()
+    public void Generate_WithMcpToolsData_DoesNotRenderMcpToolsSection()
     {
         var templatePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "templates", "skill-page-template.hbs");
         var template = File.ReadAllText(templatePath);
@@ -409,11 +411,10 @@ public class McpToolsTemplateRenderingTests
 
         var result = generator.Generate(skill, triggers, tier, prereqs);
 
-        result.Should().Contain("## MCP tools");
-        result.Should().Contain("mcp_azure_mcp_subscription_list");
-        result.Should().Contain("List available subscriptions");
-        result.Should().Contain("mcp_azure_mcp_azd");
-        result.Should().Contain("Execute AZD commands");
+        // §7.1: MCP tools section must NOT appear even when tool data exists
+        result.Should().NotContain("## MCP tools");
+        result.Should().NotContain("mcp_azure_mcp_subscription_list");
+        result.Should().NotContain("mcp_azure_mcp_azd");
     }
 
     [Fact]
@@ -1072,8 +1073,9 @@ public class TemplateRestructureTests
     }
 
     [Fact]
-    public void Template_McpToolsSection_UsesCallsLanguage()
+    public void Template_McpToolsSection_SuppressedByPolicy()
     {
+        // §7.1: MCP tools section must not render even when tool data exists
         var template = LoadRealTemplate();
         var gen = new SkillPageGenerator(template, _logger);
         var skill = CreateFullSkillData();
@@ -1083,8 +1085,8 @@ public class TemplateRestructureTests
 
         var result = gen.Generate(skill, triggers, tier, prereqs);
 
-        result.Should().Contain("uses the following Azure MCP tools");
-        result.Should().NotContain("available with this skill");
+        result.Should().NotContain("## MCP tools");
+        result.Should().NotContain("uses the following Azure MCP tools");
     }
 }
 

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Validation/SkillPageValidatorTests.cs
@@ -39,6 +39,11 @@ public class SkillPageValidatorTests
 
         The Azure Storage skill gives knowledge about storage services, blob operations, file shares, queues, and table storage access patterns in Azure.
 
+        ## Example prompts
+
+        - "How do I create a storage account?"
+        - "List my blob containers"
+
         ## Related content
 
         - [Azure Storage documentation](/azure/storage)
@@ -65,6 +70,10 @@ public class SkillPageValidatorTests
         ## What it provides
 
         Knowledge about Azure quotas and usage limits for your subscriptions and resources.
+
+        ## Example prompts
+
+        - "What are my current quotas?"
 
         ## Related content
 
@@ -338,5 +347,118 @@ public class SkillPageValidatorTests
         var result = _validator.Validate(content, 1, CreateSkillData(), new TriggerData([], [], null));
 
         result.Warnings.Should().NotContain(w => w.Contains("LINK_TYPO"));
+    }
+
+    [Fact]
+    public void Validate_MissingExamplePrompts_ReturnsError()
+    {
+        var content = """
+            ---
+            title: Azure skill for Test
+            description: Test
+            ---
+            # Azure skill for Test
+
+            Some content about this skill with GitHub Copilot.
+
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ### When to use this skill
+
+            Use it.
+
+            ## What it provides
+
+            Things about stuff.
+
+            ## Related content
+
+            - [Docs](/azure/docs)
+            """;
+        var result = _validator.Validate(content, 2, CreateSkillData(), new TriggerData([], [], null));
+
+        result.Errors.Should().Contain(e => e.Contains("Example prompts"));
+    }
+
+    [Fact]
+    public void Validate_MissingRelatedContent_ReturnsError()
+    {
+        var content = """
+            ---
+            title: Azure skill for Test
+            description: Test
+            ---
+            # Azure skill for Test
+
+            Some content about this skill with GitHub Copilot.
+
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ### When to use this skill
+
+            Use it.
+
+            ## What it provides
+
+            Things about stuff.
+
+            ## Example prompts
+
+            - "How do I do things?"
+            """;
+        var result = _validator.Validate(content, 2, CreateSkillData(), new TriggerData([], [], null));
+
+        result.Errors.Should().Contain(e => e.Contains("Related content"));
+    }
+
+    // §7.1: Prohibited implementation-detail sections
+
+    [Theory]
+    [InlineData("## MCP tools")]
+    [InlineData("## Sub-skills")]
+    [InlineData("## Suggested workflow")]
+    public void Validate_ProhibitedSection_ReturnsError(string prohibitedSection)
+    {
+        var content = $"""
+            ---
+            title: Azure skill for Test
+            description: Test
+            ---
+            # Azure skill for Test
+
+            Content about this skill with GitHub Copilot.
+
+            ## Prerequisites
+
+            - GitHub Copilot
+
+            ### When to use this skill
+
+            Use it.
+
+            ## What it provides
+
+            Things.
+
+            {prohibitedSection}
+
+            Some prohibited content here.
+
+            ## Example prompts
+
+            - "How do I test?"
+
+            ## Related content
+
+            - [Docs](/azure/docs)
+            """;
+        var result = _validator.Validate(content, 1, CreateSkillData(), new TriggerData([], [], null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("POLICY") && e.Contains("Prohibited"));
     }
 }

--- a/skills-generation/SkillsGen.Core/Generation/AzureOpenAiRewriter.cs
+++ b/skills-generation/SkillsGen.Core/Generation/AzureOpenAiRewriter.cs
@@ -58,18 +58,9 @@ public class AzureOpenAiRewriter : ILlmRewriter
             ? string.Join(", ", skillData.Services.Select(s => s.Name))
             : "N/A";
 
-        var toolPurposes = skillData.McpTools.Count > 0
-            ? string.Join("\n", skillData.McpTools
-                .Where(t => !string.IsNullOrWhiteSpace(t.Purpose))
-                .Select(t => $"  - {t.ToolName}: {t.Purpose}"))
-            : "N/A";
-
+        // §7.9: Only customer-facing data — no MCP tool names or workflow steps (§4.2)
         var useCases = skillData.UseFor.Count > 0
             ? string.Join("\n", skillData.UseFor.Select(u => $"  - {u}"))
-            : "N/A";
-
-        var workflowSteps = skillData.WorkflowSteps.Count > 0
-            ? string.Join("\n", skillData.WorkflowSteps.Select((s, i) => $"  {i + 1}. {s}"))
             : "N/A";
 
         var systemPrompt = "You are a technical writer for Microsoft Azure documentation. Write clear, customer-facing content.";
@@ -79,12 +70,8 @@ public class AzureOpenAiRewriter : ILlmRewriter
             Context:
             - Description: {skillData.Description}
             - Services: {serviceNames}
-            - Tools:
-            {toolPurposes}
             - Use cases:
             {useCases}
-            - Workflow steps:
-            {workflowSteps}
 
             Rules:
             - Write from the customer's perspective (what THEY get, not what the system does)

--- a/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
+++ b/skills-generation/SkillsGen.Core/Generation/SkillPageGenerator.cs
@@ -29,7 +29,7 @@ public class SkillPageGenerator : ISkillPageGenerator
         return result;
     }
 
-    private static readonly int MaxExamplePrompts = 10;
+    private static readonly int MaxExamplePrompts = 8; // §7.3: Aligned to editorial standard per PR #8978
 
     internal static object BuildContext(SkillData skillData, TriggerData triggerData, TierAssessment tierAssessment, SkillPrerequisites prerequisites, Func<string, string>? triggerProcessor, Dictionary<string, CuratedSkillData>? curatedData, ILogger? logger = null, List<string>? translatedWorkflowSteps = null, string? whatItProvides = null, string? skillVersion = null)
     {
@@ -139,7 +139,7 @@ public class SkillPageGenerator : ISkillPageGenerator
             ["showToolsSection"] = tierAssessment.ShowToolsSection,
             ["showTriggersSection"] = tierAssessment.ShowTriggersSection,
             ["showDecisionGuidance"] = tierAssessment.ShowDecisionGuidance,
-            ["showWorkflow"] = tierAssessment.ShowWorkflow,
+            ["showWorkflow"] = false, // §7.1: Workflow steps are implementation details excluded by §4.2
             ["showDetailedPrompts"] = tierAssessment.ShowDetailedPrompts,
             ["prerequisites"] = new Dictionary<string, object?>
             {
@@ -170,7 +170,7 @@ public class SkillPageGenerator : ISkillPageGenerator
                 ["environmentRequirements"] = prerequisites.EnvironmentRequirements
             },
             ["hasServices"] = skillData.Services.Count > 0,
-            ["hasMcpTools"] = skillData.McpTools.Count > 0,
+            ["hasMcpTools"] = false, // §7.1: MCP tools are implementation details excluded by §4.2
             ["hasWorkflow"] = skillData.WorkflowSteps.Count > 0,
             ["hasDecisionGuidance"] = skillData.DecisionGuidance.Count > 0,
             ["hasRelatedSkills"] = skillData.RelatedSkills.Count > 0,
@@ -203,9 +203,9 @@ public class SkillPageGenerator : ISkillPageGenerator
                     ["command"] = t.Command,
                     ["purpose"] = t.Purpose
                 }).ToList(),
-                ["hasMcpTools"] = s.McpTools.Count > 0
+                ["hasMcpTools"] = false // §7.1: Sub-skill MCP tools excluded by §4.2
             }).ToList(),
-            ["hasSubSkills"] = skillData.SubSkills.Count > 0,
+            ["hasSubSkills"] = false, // §7.1: Sub-skills are implementation details excluded by §4.2
             // Activation triggers
             ["activation"] = skillData.Activation != null ? new Dictionary<string, object?>
             {

--- a/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
+++ b/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
@@ -99,16 +99,8 @@ public class SkillPipelineOrchestrator
 
             var updatedSkillData = skillData with { Description = rewrittenDescription };
 
-            // LLM workflow translation (optional)
+            // LLM workflow translation — SKIPPED (§7.1: workflow steps are excluded by §4.2 content policy)
             List<string>? translatedSteps = null;
-            if (updatedSkillData.WorkflowSteps.Count > 0)
-            {
-                var wfSw = Stopwatch.StartNew();
-                translatedSteps = await _llmRewriter.TranslateWorkflowStepsAsync(
-                    skillName, updatedSkillData.WorkflowSteps, updatedSkillData.McpTools, ct);
-                wfSw.Stop();
-                _logger.LogLlmCall(skillName, "TranslateWorkflowSteps", wfSw.ElapsedMilliseconds);
-            }
 
             // LLM "What it provides" synthesis (optional)
             var wipSw = Stopwatch.StartNew();

--- a/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
+++ b/skills-generation/SkillsGen.Core/Validation/SkillPageValidator.cs
@@ -9,7 +9,17 @@ public class SkillPageValidator : ISkillPageValidator
     [
         "## Prerequisites",
         "## When to use",
-        "## What it provides"
+        "## What it provides",
+        "## Example prompts",   // §7.2: Required by content policy §4.2
+        "## Related content"    // §7.2: Required by content policy §4.2
+    ];
+
+    // §7.1: Implementation detail sections that must NOT appear in customer-facing articles
+    private static readonly string[] ProhibitedSections =
+    [
+        "## MCP tools",
+        "## Sub-skills",
+        "## Suggested workflow"
     ];
 
     // Known typo patterns in generated links
@@ -39,6 +49,15 @@ public class SkillPageValidator : ISkillPageValidator
             if (!renderedContent.Contains(section, StringComparison.OrdinalIgnoreCase))
             {
                 errors.Add($"COMPLETENESS: Missing required section '{section}'");
+            }
+        }
+
+        // POLICY: Prohibited implementation-detail sections must NOT appear (§7.1, §4.2)
+        foreach (var section in ProhibitedSections)
+        {
+            if (renderedContent.Contains(section, StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add($"POLICY: Prohibited section '{section}' found — implementation details must not appear in customer-facing articles (§4.2)");
             }
         }
 


### PR DESCRIPTION
## Summary

Implements 4 SYNTHESIS-SPEC TODOs to enforce content policy in the Azure Skills generation pipeline.

### Changes

| Spec Item | What | Impact |
|-----------|------|--------|
| §7.1 | Suppress MCP tools, sub-skills, workflow sections | Generator forces flags to \alse\; validator rejects prohibited sections |
| §7.2 | Add \Example prompts\ + \Related content\ to RequiredSections | Validator now checks all 5 required H2 sections |
| §7.3 | MaxExamplePrompts 10 → 8 | Aligns with editorial standard (PR #8978) |
| §7.9 | Remove MCP tool names/workflow from LLM prompt | \SynthesizeWhatItProvidesAsync\ only gets customer-facing context |

### Files changed (7)

**Core:**
- \SkillPageGenerator.cs\ — Force \hasMcpTools\, \hasSubSkills\, \showWorkflow\ to false; cap prompts at 8
- \SkillPageValidator.cs\ — Add 2 required sections + \ProhibitedSections\ enforcement
- \AzureOpenAiRewriter.cs\ — Remove tool/workflow context from LLM prompt
- \SkillPipelineOrchestrator.cs\ — Skip \TranslateWorkflowStepsAsync\ (serves excluded content)

**Tests:**
- \SkillPageValidatorTests.cs\ — Add prohibited section tests, update fixtures with \Example prompts\
- \SkillPageGeneratorTests.cs\ — Update MCP tools tests to assert NOT rendered
- \ExamplePromptsFallbackTests.cs\ — Update cap assertion (10 → 8)

### Verification
- ✅ 374 skills-gen tests pass
- ✅ 861 MCP tests pass (zero cross-impact)
- ✅ Only \skills-generation/\ files touched — complete isolation from MCP pipeline

### Related
- Governed by: [SYNTHESIS-SPEC.md](skills-generation/docs/SYNTHESIS-SPEC.md) (PR #586)
- Tracking: Issue #585, Issue #587 (source outline cataloging — separate PR)