### PR TITLE
feat(skills-gen): add source outline cataloging step (#587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Source Outline Cataloging step** (`skills-generation`) — New pipeline step inserted between fetch and parse in `SkillPipelineOrchestrator`. Extracts all `##` and `###` headings from each source `SKILL.md`, compares them against known mapping rules (`HeadingMappingRules`), and emits warnings for unmapped headings. Results are persisted to `data/source-outlines.json` after batch processing. New types: `SkillOutline`, `HeadingEntry`, `HeadingMappingRules`, `SourceOutlineCataloger`, `SourceOutlineWriter`. Implements PRD-587. (#587)
+
 - **Fingerprint baseline comparison gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline fingerprint gate (`--run-fingerprint-gate`) that snapshots `generated-*` output directories and diffs them against `fingerprint-baseline.json`. Detects unintended output drift (file count/size changes) across namespaces. Skips safely when no baseline exists. Implemented via `IFingerprintGate` / `FingerprintGate`, which invokes `DocGeneration.Tools.Fingerprint` as a subprocess.
 
 - **Prompt regression gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline prompt regression gate (`--run-prompt-regression-gate`) that runs `DocGeneration.PromptRegression.Tests` as a subprocess. Catches prompt template regressions by running the full regression suite after generation. Implemented via `IPromptRegressionGate` / `PromptRegressionGate`.

--- a/skills-generation/README.md
+++ b/skills-generation/README.md
@@ -22,6 +22,7 @@ FOUNDRY_MODEL_NAME=gpt-4o
 ```
 SkillPipelineOrchestrator
   ├── Fetch      → GitHubSkillFetcher / LocalSkillFetcher
+  ├── Catalog    → SourceOutlineCataloger (headings → HeadingMappingRules → source-outlines.json)
   ├── Parse      → SkillMarkdownParser + TriggerTestParser
   ├── Assess     → TierAssessor (Tier 1 / Tier 2 scoring)
   ├── Rewrite    → AzureOpenAiRewriter (LLM intro polish)

--- a/skills-generation/SkillsGen.Core.Tests/Fixtures/catalog-fixture-skill.md
+++ b/skills-generation/SkillsGen.Core.Tests/Fixtures/catalog-fixture-skill.md
@@ -1,0 +1,68 @@
+---
+name: azure-keyvault
+display_name: Azure Key Vault
+description: "Work with Azure Key Vault secrets and certificates."
+---
+
+# Azure skill for Azure Key Vault
+
+Manage secrets, keys, and certificates stored in Azure Key Vault.
+
+## Use cases
+
+- Retrieve secrets for application configuration
+- Rotate encryption keys on a schedule
+- Issue and renew TLS certificates
+
+## Negative use cases
+
+- Storing large binary blobs
+- Replacing a full PKI infrastructure
+
+## Azure services
+
+| Service | UseWhen |
+|---------|---------|
+| Azure Key Vault | Manage secrets and keys |
+
+## Prerequisites
+
+- Azure subscription
+- Azure CLI installed
+- Key Vault Secrets Officer role
+
+### RBAC
+
+| Role | Scope |
+|------|-------|
+| Key Vault Secrets Officer | Key Vault resource |
+
+## MCP Tools
+
+| Tool | Command | Purpose |
+|------|---------|---------|
+| keyvault_secret_get | keyvault secret get | Retrieve a secret value |
+
+## Workflow
+
+1. Authenticate with Azure
+2. Select the target Key Vault
+3. Retrieve or set the secret
+
+## Decision Guidance
+
+### Key vs Secret
+
+| Option | BestFor |
+|--------|---------|
+| Secret | Passwords and connection strings |
+| Key    | Encryption operations |
+
+## Related Skills
+
+- @azure-storage for storing encrypted data
+- @azure-monitor for audit logs
+
+## New Section Without Mapping
+
+This heading has no mapping rule defined.

--- a/skills-generation/SkillsGen.Core.Tests/Integration/SourceOutlineCatalogIntegrationTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Integration/SourceOutlineCatalogIntegrationTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using SkillsGen.Core.Cataloging;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Integration;
+
+/// <summary>
+/// Integration test: fixture SKILL.md → catalog → warnings.
+/// Verifies the full cataloging flow end-to-end using a realistic SKILL.md fixture.
+/// </summary>
+public class SourceOutlineCatalogIntegrationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly SourceOutlineCataloger _cataloger;
+    private readonly SourceOutlineWriter _writer;
+    private readonly List<string> _warnings;
+
+    public SourceOutlineCatalogIntegrationTests()
+    {
+        _tempDir = Path.Combine(AppContext.BaseDirectory, "test-integration-catalog", Guid.NewGuid().ToString("N"));
+        _cataloger = new SourceOutlineCataloger();
+        _writer = new SourceOutlineWriter(_tempDir);
+        _warnings = [];
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static string LoadFixture(string name)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void FullFlow_FixtureSkill_CatalogsAndWritesAndEmitsWarnings()
+    {
+        var content = LoadFixture("catalog-fixture-skill.md");
+        const string skillName = "azure-keyvault";
+
+        // Step 1: catalog
+        var outline = _cataloger.Catalog(skillName, content);
+
+        // Verify known headings are mapped
+        outline.Headings.Should().Contain(h => h.Text == "Use cases" && h.MappedTo == "When to use this skill");
+        outline.Headings.Should().Contain(h => h.Text == "Negative use cases" && h.MappedTo == "When not to use this skill");
+        outline.Headings.Should().Contain(h => h.Text == "Azure services" && h.MappedTo == "Azure services knowledge");
+        outline.Headings.Should().Contain(h => h.Text == "Prerequisites" && h.MappedTo == "Prerequisites");
+        outline.Headings.Should().Contain(h => h.Text == "RBAC" && h.MappedTo == "Prerequisites (RBAC sub-section)");
+        outline.Headings.Should().Contain(h => h.Text == "Related Skills" && h.MappedTo == "Related skills");
+        outline.Headings.Should().Contain(h => h.Text == "Decision Guidance" && h.MappedTo == "Decision guidance");
+
+        // Excluded headings: MCP Tools, Workflow
+        outline.Headings.Should().Contain(h => h.Text == "MCP Tools" && h.MappedTo == null);
+        outline.Headings.Should().Contain(h => h.Text == "Workflow" && h.MappedTo == null);
+
+        // Unknown heading
+        outline.Headings.Should().Contain(h => h.Text == "New Section Without Mapping" && h.MappedTo == null);
+
+        // Step 2: collect warnings
+        foreach (var heading in outline.Headings.Where(h => !SkillsGen.Core.Cataloging.HeadingMappingRules.IsKnown(h.Text)))
+        {
+            _warnings.Add($"SKILL.md '{skillName}' has heading '{heading.Text}' with no mapping rule");
+        }
+
+        _warnings.Should().Contain(w => w.Contains("New Section Without Mapping"));
+        _warnings.Should().Contain(w => w.Contains("Key vs Secret"));
+        _warnings.Should().HaveCount(2); // "Key vs Secret" and "New Section Without Mapping"
+
+        // UnmappedCount matches only truly unknown (not excluded) headings
+        outline.UnmappedCount.Should().Be(2);
+
+        // Step 3: persist
+        var catalog = new Dictionary<string, SkillsGen.Core.Models.SkillOutline> { [skillName] = outline };
+        _writer.Write(catalog);
+
+        var outputPath = Path.Combine(_tempDir, "source-outlines.json");
+        File.Exists(outputPath).Should().BeTrue();
+
+        var json = File.ReadAllText(outputPath);
+        json.Should().Contain("azure-keyvault");
+        json.Should().Contain("New Section Without Mapping");
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/HeadingMappingRulesTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/HeadingMappingRulesTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using SkillsGen.Core.Cataloging;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Cataloging;
+
+public class HeadingMappingRulesTests
+{
+    [Theory]
+    [InlineData("Use cases", "When to use this skill")]
+    [InlineData("Negative use cases", "When not to use this skill")]
+    [InlineData("Azure services", "Azure services knowledge")]
+    [InlineData("Prerequisites", "Prerequisites")]
+    [InlineData("Required Inputs", "Prerequisites")]
+    [InlineData("Rules", "Prerequisites")]
+    [InlineData("RBAC", "Prerequisites (RBAC sub-section)")]
+    [InlineData("Required Roles", "Prerequisites (RBAC sub-section)")]
+    [InlineData("Role Based Access", "Prerequisites (RBAC sub-section)")]
+    [InlineData("Related Skills", "Related skills")]
+    [InlineData("Decision Guidance", "Decision guidance")]
+    [InlineData("Decision", "Decision guidance")]
+    [InlineData("Guidance", "Decision guidance")]
+    public void GetMapping_KnownHeading_ReturnsCorrectDestination(string heading, string expected)
+    {
+        HeadingMappingRules.GetMapping(heading).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("MCP tools")]
+    [InlineData("Workflow steps")]
+    [InlineData("Steps")]
+    [InlineData("Workflows")]
+    [InlineData("Workflow")]
+    public void GetMapping_ExcludedHeading_ReturnsNull(string heading)
+    {
+        HeadingMappingRules.IsKnown(heading).Should().BeTrue();
+        HeadingMappingRules.GetMapping(heading).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("New Section")]
+    [InlineData("Custom Heading")]
+    [InlineData("Overview")]
+    public void GetMapping_UnknownHeading_ReturnsNull(string heading)
+    {
+        HeadingMappingRules.GetMapping(heading).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("use cases", "When to use this skill")]
+    [InlineData("USE CASES", "When to use this skill")]
+    [InlineData("Prerequisites", "Prerequisites")]
+    [InlineData("PREREQUISITES", "Prerequisites")]
+    [InlineData("workflow", null)]
+    [InlineData("WORKFLOW", null)]
+    public void GetMapping_CaseInsensitive_ReturnsCorrectResult(string heading, string? expected)
+    {
+        HeadingMappingRules.GetMapping(heading).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("  Prerequisites  ")]
+    [InlineData("\tWorkflow\t")]
+    public void IsKnown_HeadingWithWhitespace_MatchesAfterTrim(string heading)
+    {
+        HeadingMappingRules.IsKnown(heading).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsKnown_UnknownHeading_ReturnsFalse()
+    {
+        HeadingMappingRules.IsKnown("Totally Unknown Section").Should().BeFalse();
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/SourceOutlineCatalogerTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/SourceOutlineCatalogerTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using SkillsGen.Core.Cataloging;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Cataloging;
+
+public class SourceOutlineCatalogerTests
+{
+    private readonly SourceOutlineCataloger _cataloger = new();
+
+    [Fact]
+    public void Catalog_HappyPath_ExtractsH2AndH3Headings()
+    {
+        var content = """
+            # Top level heading
+
+            ## Prerequisites
+
+            Some text.
+
+            ### Required Roles
+
+            More text.
+
+            ## Use cases
+
+            Content.
+            """;
+
+        var result = _cataloger.Catalog("azure-compute", content);
+
+        result.Headings.Should().HaveCount(3);
+        result.Headings[0].Level.Should().Be(2);
+        result.Headings[0].Text.Should().Be("Prerequisites");
+        result.Headings[0].MappedTo.Should().Be("Prerequisites");
+
+        result.Headings[1].Level.Should().Be(3);
+        result.Headings[1].Text.Should().Be("Required Roles");
+        result.Headings[1].MappedTo.Should().Be("Prerequisites (RBAC sub-section)");
+
+        result.Headings[2].Level.Should().Be(2);
+        result.Headings[2].Text.Should().Be("Use cases");
+        result.Headings[2].MappedTo.Should().Be("When to use this skill");
+    }
+
+    [Fact]
+    public void Catalog_UnmappedHeadings_SetsNullMappedToAndCountsCorrectly()
+    {
+        var content = """
+            ## New Section
+
+            ## Another Unknown
+
+            ## Prerequisites
+            """;
+
+        var result = _cataloger.Catalog("azure-storage", content);
+
+        result.UnmappedCount.Should().Be(2);
+        result.Headings.Should().HaveCount(3);
+        result.Headings[0].MappedTo.Should().BeNull();
+        result.Headings[1].MappedTo.Should().BeNull();
+        result.Headings[2].MappedTo.Should().Be("Prerequisites");
+    }
+
+    [Fact]
+    public void Catalog_EmptyContent_ReturnsEmptyOutline()
+    {
+        var result = _cataloger.Catalog("azure-empty", "");
+
+        result.Headings.Should().BeEmpty();
+        result.UnmappedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Catalog_NullContent_ReturnsEmptyOutline()
+    {
+        var result = _cataloger.Catalog("azure-null", null!);
+
+        result.Headings.Should().BeEmpty();
+        result.UnmappedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Catalog_MalformedHeadings_SkipsMalformedRetainsValid()
+    {
+        var content = """
+            ## 
+
+            ### 
+
+            ## Prerequisites
+            """;
+
+        var result = _cataloger.Catalog("azure-test", content);
+
+        // Only the valid heading should be returned
+        result.Headings.Should().HaveCount(1);
+        result.Headings[0].Text.Should().Be("Prerequisites");
+    }
+
+    [Fact]
+    public void Catalog_HeadingsInsideCodeBlocks_AreSkipped()
+    {
+        var content = """
+            ## Real Heading
+
+            ```
+            ## This is inside a code block
+            ### Also inside
+            ```
+
+            ## Prerequisites
+            """;
+
+        var result = _cataloger.Catalog("azure-code", content);
+
+        result.Headings.Should().HaveCount(2);
+        result.Headings[0].Text.Should().Be("Real Heading");
+        result.Headings[1].Text.Should().Be("Prerequisites");
+    }
+
+    [Fact]
+    public void Catalog_DoesNotExtractH1Headings()
+    {
+        var content = """
+            # Top Level
+
+            ## Prerequisites
+            """;
+
+        var result = _cataloger.Catalog("azure-test", content);
+
+        result.Headings.Should().HaveCount(1);
+        result.Headings[0].Level.Should().Be(2);
+    }
+
+    [Fact]
+    public void Catalog_SetsH2Level2AndH3Level3()
+    {
+        var content = """
+            ## Section A
+
+            ### Sub-section B
+            """;
+
+        var result = _cataloger.Catalog("azure-levels", content);
+
+        result.Headings[0].Level.Should().Be(2);
+        result.Headings[1].Level.Should().Be(3);
+    }
+
+    [Fact]
+    public void Catalog_ExcludedHeadings_MappedToNullButCountedAsKnown()
+    {
+        var content = """
+            ## Workflow
+
+            ## Prerequisites
+            """;
+
+        var result = _cataloger.Catalog("azure-workflow", content);
+
+        // "Workflow" is known (excluded), "Prerequisites" is known (mapped)
+        // Neither is "unmapped" — unmapped = not in Rules at all
+        result.UnmappedCount.Should().Be(0);
+        result.Headings[0].MappedTo.Should().BeNull(); // excluded
+        result.Headings[1].MappedTo.Should().Be("Prerequisites");
+    }
+
+    [Fact]
+    public void Catalog_SetsTimestamp()
+    {
+        var before = DateTime.UtcNow;
+        var result = _cataloger.Catalog("azure-test", "## Prerequisites");
+        var after = DateTime.UtcNow;
+
+        result.CatalogedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+}

--- a/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/SourceOutlineWriterTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Cataloging/SourceOutlineWriterTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using FluentAssertions;
+using SkillsGen.Core.Cataloging;
+using SkillsGen.Core.Models;
+using Xunit;
+
+namespace SkillsGen.Core.Tests.Unit.Cataloging;
+
+public class SourceOutlineWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly SourceOutlineWriter _writer;
+
+    public SourceOutlineWriterTests()
+    {
+        _tempDir = Path.Combine(AppContext.BaseDirectory, "test-outline-output", Guid.NewGuid().ToString("N"));
+        _writer = new SourceOutlineWriter(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void Write_SingleSkill_ProducesValidJson()
+    {
+        var catalog = new Dictionary<string, SkillOutline>
+        {
+            ["azure-compute"] = new SkillOutline
+            {
+                Headings =
+                [
+                    new HeadingEntry { Level = 2, Text = "Prerequisites", MappedTo = "Prerequisites" },
+                    new HeadingEntry { Level = 2, Text = "New Section", MappedTo = null }
+                ],
+                UnmappedCount = 1,
+                CatalogedAt = new DateTime(2026, 5, 17, 15, 55, 0, DateTimeKind.Utc)
+            }
+        };
+
+        _writer.Write(catalog);
+
+        var path = Path.Combine(_tempDir, "source-outlines.json");
+        File.Exists(path).Should().BeTrue();
+
+        var json = File.ReadAllText(path);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        root.TryGetProperty("azure-compute", out var skill).Should().BeTrue();
+
+        skill.TryGetProperty("headings", out var headings).Should().BeTrue();
+        headings.GetArrayLength().Should().Be(2);
+
+        var first = headings[0];
+        first.GetProperty("level").GetInt32().Should().Be(2);
+        first.GetProperty("text").GetString().Should().Be("Prerequisites");
+        first.GetProperty("mappedTo").GetString().Should().Be("Prerequisites");
+
+        var second = headings[1];
+        second.GetProperty("mappedTo").ValueKind.Should().Be(JsonValueKind.Null);
+
+        skill.GetProperty("unmappedCount").GetInt32().Should().Be(1);
+        skill.TryGetProperty("catalogedAt", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Write_EmptyCatalog_ProducesEmptyJsonObject()
+    {
+        _writer.Write([]);
+
+        var path = Path.Combine(_tempDir, "source-outlines.json");
+        File.Exists(path).Should().BeTrue();
+
+        var json = File.ReadAllText(path);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.EnumerateObject().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Write_MultipleSkills_AllPresentInOutput()
+    {
+        var catalog = new Dictionary<string, SkillOutline>
+        {
+            ["azure-storage"] = new SkillOutline
+            {
+                Headings = [new HeadingEntry { Level = 2, Text = "Prerequisites", MappedTo = "Prerequisites" }],
+                UnmappedCount = 0,
+                CatalogedAt = DateTime.UtcNow
+            },
+            ["azure-monitor"] = new SkillOutline
+            {
+                Headings = [new HeadingEntry { Level = 2, Text = "Custom", MappedTo = null }],
+                UnmappedCount = 1,
+                CatalogedAt = DateTime.UtcNow
+            }
+        };
+
+        _writer.Write(catalog);
+
+        var json = File.ReadAllText(Path.Combine(_tempDir, "source-outlines.json"));
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.TryGetProperty("azure-storage", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("azure-monitor", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Write_CreatesDataDirectoryIfMissing()
+    {
+        // _tempDir does not exist yet
+        var newDir = Path.Combine(_tempDir, "subdir");
+        var writer = new SourceOutlineWriter(newDir);
+
+        writer.Write([]);
+
+        Directory.Exists(newDir).Should().BeTrue();
+        File.Exists(Path.Combine(newDir, "source-outlines.json")).Should().BeTrue();
+    }
+}

--- a/skills-generation/SkillsGen.Core/Cataloging/HeadingMappingRules.cs
+++ b/skills-generation/SkillsGen.Core/Cataloging/HeadingMappingRules.cs
@@ -1,0 +1,36 @@
+namespace SkillsGen.Core.Cataloging;
+
+public static class HeadingMappingRules
+{
+    public static readonly IReadOnlyDictionary<string, string?> Rules =
+        new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Customer-facing mappings
+            ["Use cases"]          = "When to use this skill",
+            ["Negative use cases"] = "When not to use this skill",
+            ["Azure services"]     = "Azure services knowledge",
+            ["Prerequisites"]      = "Prerequisites",
+            ["Required Inputs"]    = "Prerequisites",
+            ["Rules"]              = "Prerequisites",
+            ["RBAC"]               = "Prerequisites (RBAC sub-section)",
+            ["Required Roles"]     = "Prerequisites (RBAC sub-section)",
+            ["Role Based Access"]  = "Prerequisites (RBAC sub-section)",
+            ["Related Skills"]     = "Related skills",
+            ["Decision Guidance"]  = "Decision guidance",
+            ["Decision"]           = "Decision guidance",
+            ["Guidance"]           = "Decision guidance",
+
+            // Excluded (implementation detail) — mapped to null
+            ["MCP tools"]          = null,
+            ["Workflow steps"]     = null,
+            ["Steps"]              = null,
+            ["Workflows"]          = null,
+            ["Workflow"]           = null,
+        };
+
+    public static string? GetMapping(string headingText)
+        => Rules.TryGetValue(headingText.Trim(), out var dest) ? dest : null;
+
+    public static bool IsKnown(string headingText)
+        => Rules.ContainsKey(headingText.Trim());
+}

--- a/skills-generation/SkillsGen.Core/Cataloging/SourceOutlineCataloger.cs
+++ b/skills-generation/SkillsGen.Core/Cataloging/SourceOutlineCataloger.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using SkillsGen.Core.Models;
+
+namespace SkillsGen.Core.Cataloging;
+
+public class SourceOutlineCataloger
+{
+    private static readonly Regex HeadingRegex =
+        new(@"^(#{2,3})\s+(.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    private static readonly Regex MalformedHeadingRegex =
+        new(@"^#{2,3}\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    private readonly ILogger<SourceOutlineCataloger>? _logger;
+
+    public SourceOutlineCataloger(ILogger<SourceOutlineCataloger>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public SkillOutline Catalog(string skillName, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return new SkillOutline { CatalogedAt = DateTime.UtcNow };
+
+        var headings = new List<HeadingEntry>();
+        var lines = content.Split('\n');
+        var inFencedBlock = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd('\r');
+
+            // Toggle fenced-code-block state
+            if (line.TrimStart().StartsWith("```"))
+            {
+                inFencedBlock = !inFencedBlock;
+                continue;
+            }
+
+            if (inFencedBlock)
+                continue;
+
+            // Skip malformed headings (## with no text)
+            if (MalformedHeadingRegex.IsMatch(line))
+            {
+                _logger?.LogWarning("SKILL.md '{SkillName}' has malformed heading (no text): '{Line}'", skillName, line.Trim());
+                continue;
+            }
+
+            var match = HeadingRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var hashes = match.Groups[1].Value;
+            var text = match.Groups[2].Value.Trim();
+            var level = hashes.Length;
+
+            var mappedTo = HeadingMappingRules.IsKnown(text)
+                ? HeadingMappingRules.GetMapping(text)
+                : null;
+
+            headings.Add(new HeadingEntry
+            {
+                Level = level,
+                Text = text,
+                MappedTo = mappedTo
+            });
+        }
+
+        var unmappedCount = headings.Count(h => !HeadingMappingRules.IsKnown(h.Text));
+
+        return new SkillOutline
+        {
+            Headings = headings,
+            UnmappedCount = unmappedCount,
+            CatalogedAt = DateTime.UtcNow
+        };
+    }
+}

--- a/skills-generation/SkillsGen.Core/Cataloging/SourceOutlineWriter.cs
+++ b/skills-generation/SkillsGen.Core/Cataloging/SourceOutlineWriter.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SkillsGen.Core.Models;
+
+namespace SkillsGen.Core.Cataloging;
+
+public class SourceOutlineWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    private readonly string _dataDir;
+
+    public SourceOutlineWriter(string dataDir = "data")
+    {
+        _dataDir = dataDir;
+    }
+
+    public void Write(Dictionary<string, SkillOutline> catalog)
+    {
+        Directory.CreateDirectory(_dataDir);
+        var path = Path.Combine(_dataDir, "source-outlines.json");
+
+        // Serialize as an object keyed by skill name
+        var serializable = catalog.ToDictionary(
+            kvp => kvp.Key,
+            kvp => new SkillOutlineDto(kvp.Value));
+
+        var json = JsonSerializer.Serialize(serializable, JsonOptions);
+        File.WriteAllText(path, json);
+    }
+
+    /// <summary>DTO that matches the PRD §3 output format.</summary>
+    private sealed class SkillOutlineDto
+    {
+        [JsonPropertyName("headings")]
+        public List<HeadingEntryDto> Headings { get; }
+
+        [JsonPropertyName("unmappedCount")]
+        public int UnmappedCount { get; }
+
+        [JsonPropertyName("catalogedAt")]
+        public string CatalogedAt { get; }
+
+        public SkillOutlineDto(SkillOutline outline)
+        {
+            Headings = outline.Headings
+                .Select(h => new HeadingEntryDto(h))
+                .ToList();
+            UnmappedCount = outline.UnmappedCount;
+            CatalogedAt = outline.CatalogedAt.ToString("o");
+        }
+    }
+
+    private sealed class HeadingEntryDto
+    {
+        [JsonPropertyName("level")]
+        public int Level { get; }
+
+        [JsonPropertyName("text")]
+        public string Text { get; }
+
+        [JsonPropertyName("mappedTo")]
+        public string? MappedTo { get; }
+
+        public HeadingEntryDto(HeadingEntry entry)
+        {
+            Level = entry.Level;
+            Text = entry.Text;
+            MappedTo = entry.MappedTo;
+        }
+    }
+}

--- a/skills-generation/SkillsGen.Core/Models/SourceOutline.cs
+++ b/skills-generation/SkillsGen.Core/Models/SourceOutline.cs
@@ -1,0 +1,21 @@
+namespace SkillsGen.Core.Models;
+
+/// <summary>
+/// Catalog of headings extracted from a source SKILL.md file.
+/// </summary>
+public class SkillOutline
+{
+    public List<HeadingEntry> Headings { get; init; } = [];
+    public int UnmappedCount { get; init; }
+    public DateTime CatalogedAt { get; init; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// A single heading entry extracted from SKILL.md.
+/// </summary>
+public class HeadingEntry
+{
+    public int Level { get; init; }
+    public string Text { get; init; } = "";
+    public string? MappedTo { get; init; }
+}

--- a/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
+++ b/skills-generation/SkillsGen.Core/Orchestration/SkillPipelineOrchestrator.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using SkillsGen.Core.Assessment;
+using SkillsGen.Core.Cataloging;
 using SkillsGen.Core.Fetchers;
 using SkillsGen.Core.Generation;
 using SkillsGen.Core.Logging;
@@ -27,6 +28,9 @@ public class SkillPipelineOrchestrator
     private readonly string _outputDir;
     private readonly bool _dryRun;
     private readonly bool _force;
+    private readonly SourceOutlineCataloger _cataloger;
+    private readonly SourceOutlineWriter _catalogWriter;
+    private readonly Dictionary<string, SkillOutline> _outlineCatalog = [];
 
     public SkillPipelineOrchestrator(
         ISkillSourceFetcher fetcher,
@@ -54,6 +58,8 @@ public class SkillPipelineOrchestrator
         _outputDir = outputDir;
         _dryRun = dryRun;
         _force = force;
+        _cataloger = new SourceOutlineCataloger();
+        _catalogWriter = new SourceOutlineWriter(Path.Combine(outputDir, "data"));
     }
 
     public async Task<SkillGenerationResult> ProcessSkillAsync(string skillName, string? displayName = null, string? skillVersion = null, CancellationToken ct = default)
@@ -69,6 +75,11 @@ public class SkillPipelineOrchestrator
                 _logger.LogError(skillName, "Source files not found");
                 return CreateFailResult(skillName, sw, "Source files not found");
             }
+
+            // Catalog source outline (between fetch and parse)
+            var outline = _cataloger.Catalog(skillName, sources.SkillMarkdown);
+            _outlineCatalog[skillName] = outline;
+            EmitOutlineWarnings(skillName, outline);
 
             // Parse
             var skillData = _parser.Parse(skillName, sources.SkillMarkdown);
@@ -200,6 +211,8 @@ public class SkillPipelineOrchestrator
         if (!_dryRun)
         {
             WriteManifest(report);
+            PersistOutlineCatalog();
+            EmitBatchOutlineSummary();
         }
 
         return report;
@@ -416,6 +429,47 @@ public class SkillPipelineOrchestrator
             skillName, 0,
             new SkillValidationResult(false, [error], [], 0, 0),
             null, sw.ElapsedMilliseconds);
+    }
+
+    /// <summary>
+    /// Emits per-skill warnings for unmapped headings.
+    /// </summary>
+    private void EmitOutlineWarnings(string skillName, SkillOutline outline)
+    {
+        foreach (var heading in outline.Headings.Where(h => !HeadingMappingRules.IsKnown(h.Text)))
+        {
+            _logger.LogInfo($"  ⚠️  UNMAPPED_HEADING: SKILL.md '{skillName}' has heading '{heading.Text}' with no mapping rule");
+        }
+    }
+
+    /// <summary>
+    /// Persists the accumulated outline catalog to data/source-outlines.json.
+    /// </summary>
+    private void PersistOutlineCatalog()
+    {
+        if (_outlineCatalog.Count == 0)
+            return;
+
+        _catalogWriter.Write(_outlineCatalog);
+        _logger.LogInfo($"  📋 Catalog written: {_outlineCatalog.Count} skill(s) → {Path.Combine(_outputDir, "data", "source-outlines.json")}");
+    }
+
+    /// <summary>
+    /// Emits a batch-level summary of all unmapped headings across all skills.
+    /// </summary>
+    private void EmitBatchOutlineSummary()
+    {
+        var totalUnmapped = _outlineCatalog.Values.Sum(o => o.UnmappedCount);
+        var skillsWithUnmapped = _outlineCatalog.Count(kvp => kvp.Value.UnmappedCount > 0);
+
+        if (totalUnmapped > 0)
+        {
+            _logger.LogInfo($"  ⚠️  OUTLINE_SUMMARY: {totalUnmapped} unmapped heading(s) across {skillsWithUnmapped} skill(s)");
+        }
+        else
+        {
+            _logger.LogInfo("  ✅ OUTLINE_SUMMARY: All headings are mapped");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Implements PRD-587: Source Outline Cataloging step.

Adds a new pipeline step between fetch and parse that:
- Extracts all \##\ and \###\ headings from source SKILL.md files
- Compares against known mapping rules (§1.5)
- Persists catalog to \data/source-outlines.json\
- Emits warnings for unmapped headings

## New types

| File | Type |
|------|------|
| \Models/SourceOutline.cs\ | \SkillOutline\, \HeadingEntry\ |
| \Cataloging/HeadingMappingRules.cs\ | \HeadingMappingRules\ (static, PRD §8) |
| \Cataloging/SourceOutlineCataloger.cs\ | \SourceOutlineCataloger\ |
| \Cataloging/SourceOutlineWriter.cs\ | \SourceOutlineWriter\ |

## Tests

29 new tests across 4 files:
- \HeadingMappingRulesTests\ — known mappings, excluded headings, case-insensitivity, whitespace
- \SourceOutlineCatalogerTests\ — happy path, unmapped, empty, malformed, code-block skip, excluded
- \SourceOutlineWriterTests\ — JSON schema, empty catalog, multiple skills, directory creation
- \SourceOutlineCatalogIntegrationTests\ — end-to-end fixture → catalog → warnings → JSON

## Verification

- \dotnet test SkillsGen.Core.Tests\ — **414 passed** (was 385, +29 new)
- \dotnet test DocGeneration.Steps.ToolFamilyCleanup.Tests\ — **861 passed**, zero impact
- \git diff --name-only | Select-String mcp-tools/\ — **no MCP files changed**

Closes #587