### PR TITLE
feat(bootstrap): install @azure/mcp@latest before pinned npm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Install latest @azure/mcp before tools-list generation** — Bootstrap step now runs `npm install @azure/mcp@latest --save` before the pinned `npm install`, ensuring the tools-list is always generated from the latest published package. Failure is fatal (the whole point is to use the latest). New `--skip-npm-update` CLI flag opts out for offline or reproducible builds. (#)
+
 - **Fingerprint baseline comparison gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline fingerprint gate (`--run-fingerprint-gate`) that snapshots `generated-*` output directories and diffs them against `fingerprint-baseline.json`. Detects unintended output drift (file count/size changes) across namespaces. Skips safely when no baseline exists. Implemented via `IFingerprintGate` / `FingerprintGate`, which invokes `DocGeneration.Tools.Fingerprint` as a subprocess.
 
 - **Prompt regression gate** — `PipelineRunner.RunAsync()` now supports an optional post-pipeline prompt regression gate (`--run-prompt-regression-gate`) that runs `DocGeneration.PromptRegression.Tests` as a subprocess. Catches prompt template regressions by running the full regression suite after generation. Implemented via `IPromptRegressionGate` / `PromptRegressionGate`.

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -255,10 +255,55 @@ public class BootstrapStepTests
         return path;
     }
 
+    [Fact]
+    public async Task ExecuteAsync_RunsNpmInstallLatestBeforePinnedInstall()
+    {
+        using var harness = CreateHarness();
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        var latestIdx = harness.ProcessRunner.Invocations.FindIndex(
+            s => s.Arguments.SequenceEqual(["install", "@azure/mcp@latest", "--save"]));
+        var pinnedIdx = harness.ProcessRunner.Invocations.FindIndex(
+            s => s.Arguments.SequenceEqual(["install", "--silent"]));
+        Assert.True(latestIdx >= 0, "Expected npm install @azure/mcp@latest --save to be invoked.");
+        Assert.True(pinnedIdx >= 0, "Expected npm install --silent to be invoked.");
+        Assert.True(latestIdx < pinnedIdx, "Latest install must run before pinned install.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipNpmUpdate_SkipsLatestInstallAndSucceeds()
+    {
+        using var harness = CreateHarness(skipNpmUpdate: true);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.DoesNotContain(
+            harness.ProcessRunner.Invocations,
+            s => s.Arguments.SequenceEqual(["install", "@azure/mcp@latest", "--save"]));
+        var messages = ((BufferedReportWriter)harness.Context.Reports).Messages;
+        Assert.Contains(messages, m => m.Contains("--skip-npm-update", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NpmLatestInstallFails_ReturnsFatal()
+    {
+        using var harness = CreateHarness(failNpmLatestInstall: true);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Warnings, w => w.Contains("latest @azure/mcp", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static TestHarness CreateHarness(
         bool skipBuild = false,
         bool skipValidation = false,
         bool skipEnvValidation = false,
+        bool skipNpmUpdate = false,
+        bool failNpmLatestInstall = false,
         bool requiresAiConfiguration = false,
         bool aiConfigured = true,
         ICliMetadataLoader? cliMetadataLoader = null,
@@ -274,7 +319,7 @@ public class BootstrapStepTests
         File.WriteAllText(Path.Combine(mcpToolsRoot, "data", "brand-to-server-mapping.json"), brandMappingJson ?? "[]");
         File.WriteAllText(Path.Combine(mcpToolsRoot, "azure-mcp", "azmcp-commands.md"), "# Commands");
 
-        var processRunner = new ScriptedProcessRunner();
+        var processRunner = new ScriptedProcessRunner { FailNpmLatestInstall = failNpmLatestInstall };
         var buildCoordinator = new RecordingBuildCoordinator();
         var aiCapabilityProbe = new RecordingAiCapabilityProbe(aiConfigured);
         var step = new BootstrapStep();
@@ -291,7 +336,8 @@ public class BootstrapStepTests
                 SkipBuild: skipBuild,
                 SkipValidation: skipValidation,
                 DryRun: false,
-                SkipEnvValidation: skipEnvValidation),
+                SkipEnvValidation: skipEnvValidation,
+                SkipNpmUpdate: skipNpmUpdate),
             RepoRoot = repoRoot,
             McpToolsRoot = mcpToolsRoot,
             OutputPath = Path.Combine(repoRoot, "generated-compute"),
@@ -424,11 +470,20 @@ public class BootstrapStepTests
             },
         });
 
+        public bool FailNpmLatestInstall { get; init; }
+
         public List<ProcessSpec> Invocations { get; } = new();
 
         public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
         {
             Invocations.Add(spec);
+
+            if (spec.Arguments.SequenceEqual(["install", "@azure/mcp@latest", "--save"]))
+            {
+                return FailNpmLatestInstall
+                    ? ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 1, string.Empty, "npm ERR! 404", TimeSpan.Zero))
+                    : ValueTask.FromResult(Success(spec));
+            }
 
             if (spec.Arguments.SequenceEqual(["install", "--silent"]))
             {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
@@ -48,4 +48,22 @@ public class CliArgumentParsingTests
         Assert.Equal(global::PipelineRunner.PipelineRunner.InvalidArgumentsExitCode, exitCode);
         Assert.Contains("Unsupported step identifiers", errorWriter.ToString(), StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Parse_SkipNpmUpdate_SetsFlag()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute", "--skip-npm-update"]);
+
+        Assert.NotNull(result.Request);
+        Assert.True(result.Request!.SkipNpmUpdate);
+    }
+
+    [Fact]
+    public void Parse_SkipNpmUpdateOmitted_DefaultsFalse()
+    {
+        var result = PipelineCli.Parse(["--namespace", "compute"]);
+
+        Assert.NotNull(result.Request);
+        Assert.False(result.Request!.SkipNpmUpdate);
+    }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -23,6 +23,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipChangelogGate);
         rootCommand.AddOption(options.RunFingerprintGate);
         rootCommand.AddOption(options.RunPromptRegressionGate);
+        rootCommand.AddOption(options.SkipNpmUpdate);
         return rootCommand;
     }
 
@@ -63,7 +64,8 @@ public static class PipelineCli
             parseResult.GetValueForOption(options.McpBranch),
             parseResult.GetValueForOption(options.SkipChangelogGate),
             parseResult.GetValueForOption(options.RunFingerprintGate),
-            parseResult.GetValueForOption(options.RunPromptRegressionGate));
+            parseResult.GetValueForOption(options.RunPromptRegressionGate),
+            parseResult.GetValueForOption(options.SkipNpmUpdate));
 
         var validationErrors = request.Validate();
         return validationErrors.Count > 0
@@ -120,6 +122,7 @@ public static class PipelineCli
         rootCommand.AddOption(options.SkipChangelogGate);
         rootCommand.AddOption(options.RunFingerprintGate);
         rootCommand.AddOption(options.RunPromptRegressionGate);
+        rootCommand.AddOption(options.SkipNpmUpdate);
         return rootCommand;
     }
 
@@ -136,7 +139,8 @@ public static class PipelineCli
             new Option<string?>("--mcp-branch", "Branch of microsoft/mcp to fetch upstream files from. Overrides MCP_BRANCH env var. Default: main."),
             new Option<bool>("--skip-changelog-gate", "Skip the CHANGELOG gate check and process all namespaces regardless of CHANGELOG entries."),
             new Option<bool>("--run-fingerprint-gate", "After pipeline steps, compare output fingerprints against fingerprint-baseline.json. Fails on quality regressions."),
-            new Option<bool>("--run-prompt-regression-gate", "After pipeline steps, run the DocGeneration.PromptRegression.Tests suite to verify prompt templates are unaffected."));
+            new Option<bool>("--run-prompt-regression-gate", "After pipeline steps, run the DocGeneration.PromptRegression.Tests suite to verify prompt templates are unaffected."),
+            new Option<bool>("--skip-npm-update", "Skip updating @azure/mcp to latest before installing. Use for offline runs or reproducible builds."));
 
     private sealed record CliOptions(
         Option<string?> Namespace,
@@ -150,5 +154,6 @@ public static class PipelineCli
         Option<string?> McpBranch,
         Option<bool> SkipChangelogGate,
         Option<bool> RunFingerprintGate,
-        Option<bool> RunPromptRegressionGate);
+        Option<bool> RunPromptRegressionGate,
+        Option<bool> SkipNpmUpdate);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -12,7 +12,8 @@ public sealed record PipelineRequest(
     string? McpBranch = null,
     bool SkipChangelogGate = false,
     bool RunFingerprintGate = false,
-    bool RunPromptRegressionGate = false)
+    bool RunPromptRegressionGate = false,
+    bool SkipNpmUpdate = false)
 {
     /// <summary>
     /// Default upstream branch for fetching files from the microsoft/mcp repository.

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -117,6 +117,27 @@ public sealed class BootstrapStep : StepDefinition
             }
 
             var npmExecutable = GetNpmExecutable();
+
+            if (!context.Request.SkipNpmUpdate)
+            {
+                context.Reports.Info("Updating @azure/mcp to latest version...");
+                var latestInstallResult = await context.ProcessRunner.RunAsync(
+                    new ProcessSpec(npmExecutable, ["install", "@azure/mcp@latest", "--save"], testNpmDirectory),
+                    cancellationToken);
+                processResults.Add(latestInstallResult);
+                if (!latestInstallResult.Succeeded)
+                {
+                    AddProcessIssue(latestInstallResult, warnings, "Failed to install latest @azure/mcp — use --skip-npm-update for offline or reproducible builds");
+                    return BuildResult(context, processResults, success: false, warnings);
+                }
+
+                context.Reports.Info("@azure/mcp updated to latest.");
+            }
+            else
+            {
+                context.Reports.Info("Skipping @azure/mcp latest update (--skip-npm-update).");
+            }
+
             var npmInstallResult = await context.ProcessRunner.RunAsync(
                 new ProcessSpec(npmExecutable, ["install", "--silent"], testNpmDirectory),
                 cancellationToken);


### PR DESCRIPTION
## Summary

Restores the "install latest @azure/mcp before generating tools list" behavior in the pipeline bootstrap.

## Changes

### \BootstrapStep.cs\
Adds \
pm install @azure/mcp@latest --save\ **before** the existing \
pm install --silent\. This updates \package.json\ to the latest published package, ensuring the tools-list is generated from the latest \@azure/mcp\ rather than the pinned version.

- **Fatal on failure** — if the latest-install fails, the step returns failure immediately. Use \--skip-npm-update\ to bypass.
- **Logging** — progress reported via \context.Reports.Info(...)\ so pipeline output shows what happened.

### \PipelineRequest.cs\ / \PipelineCli.cs\
New \--skip-npm-update\ CLI flag (maps to \SkipNpmUpdate\ on \PipelineRequest\). Allows opting out of the latest-fetch for offline or reproducible builds.

### Tests (3 new)
- \ExecuteAsync_RunsNpmInstallLatestBeforePinnedInstall\ — verifies ordering
- \ExecuteAsync_SkipNpmUpdate_SkipsLatestInstallAndSucceeds\ — verifies the flag works
- \ExecuteAsync_NpmLatestInstallFails_ReturnsFatal\ — verifies fatal behavior

## Documentation
CHANGELOG.md updated under \[Unreleased]\.

## Test results
All 24 bootstrap + CLI parsing tests pass.