### PR TITLE
docs: clarify resource-group filtering rule and document source JSON structure

### DIFF
--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/README.md
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/README.md
@@ -58,7 +58,7 @@ DocumentationGenerator.TransformCliOutput()
 
 ### Key behaviors
 
-- **Common parameter filtering**: Parameters listed in `common-parameters.json` (e.g., `--tenant`, `--subscription`, `--resource-group`) are excluded from parameter tables unless they are marked `Required` for a specific tool.
+- **Common parameter filtering**: Parameters listed in `common-parameters.json` (e.g., `--tenant`, `--subscription`, `--resource-group`) are excluded from parameter tables unless they are marked `Required` for a specific tool. See `ParameterFilterHelper.cs` for the authoritative logic. ⚠️ `resource-group` is the most commonly misunderstood case — if source `required` field is blank, it must NOT appear in the published table.
 - **Three-tier filename resolution**: Include filenames are resolved through `brand-to-server-mapping.json` → `compound-words.json` → original area name (see `DocGeneration.Core.Shared/ToolFileNameBuilder`).
 - **Text cleanup**: Parameter names and descriptions pass through `DocGeneration.Core.NaturalLanguage.TextCleanup` for normalization (e.g., `--resource-group` → "Resource group"), static text replacement, and period normalization.
 - **Frontmatter**: Every generated file is prepended with YAML frontmatter containing `ms.topic`, `ms.date`, and version metadata.

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/docs/README.md
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/docs/README.md
@@ -38,15 +38,46 @@ Companion to the [root README](../README.md). This file documents the internal s
 
 Parameters in `data/common-parameters.json` (`--tenant`, `--subscription`, `--auth-method`, `--resource-group`, retry params) are excluded from parameter tables **unless** they are `Required` for a specific tool.
 
-Filtering is implemented in `ParameterGenerator.cs`:
+> **⚠️ IMPORTANT — Resource-group convention:** This filtering rule is frequently misunderstood during manual reviews. Reviewers and AI agents sometimes incorrectly add `resource-group` rows to parameter tables when the source marks them optional. The rule is: if `required` is empty/blank in `tools-list.json`, the parameter MUST NOT appear in the published table. This applies to ALL common parameters, but `resource-group` is the one most commonly added incorrectly because it "feels" required.
+
+Filtering is implemented in `ParameterFilterHelper.cs`:
 
 ```csharp
-var transformedOptions = allOptions
-    .Where(opt => !string.IsNullOrEmpty(opt.Name) && 
-                  (!commonParameterNames.Contains(opt.Name) || opt.Required == true))
-    .Select(opt => new { /* transform */ })
-    .ToList();
+// ParameterFilterHelper.cs — the authoritative inclusion logic
+public static bool ShouldInclude(Option opt, HashSet<string> commonParameterNames)
+{
+    return !string.IsNullOrEmpty(opt.Name)
+        && (!commonParameterNames.Contains(opt.Name) || opt.Required);
+}
 ```
+
+### Source JSON Structure (tools-list.json)
+
+The `tools-list.json` file is the source of truth for parameter verification:
+
+```json
+{
+  "status": "success",
+  "message": "...",
+  "results": [
+    {
+      "command": "compute vm get",       // namespace = first word ("compute")
+      "option": [
+        {
+          "name": "--resource-group",
+          "required": "True",            // "True" = Required; "" (blank) = Optional
+          "description": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Key fields for verification:**
+- `results[].command` — Full tool command. Namespace = first word.
+- `results[].option[].name` — CLI parameter name (e.g., `--resource-group`)
+- `results[].option[].required` — String `"True"` if required, empty string `""` if optional
 
 ## Configuration Files
 


### PR DESCRIPTION
## Summary

Updates verification documentation in the generation pipeline to prevent the resource-group inclusion mistake from recurring.

### Context

During today's PR triage on azure-dev-docs-pr, agents incorrectly added resource-group rows to parameter tables when the source marked them optional. This caused 3 commits that had to be reverted. The pipeline code already handles this correctly (ParameterFilterHelper.cs), but the documentation didn't emphasize the convention strongly enough for human/AI reviewers.

### Changes

- **docs/README.md**: Added warning callout about resource-group being the most commonly misunderstood case. Documented the tools-list.json JSON structure with field semantics. Pointed to ParameterFilterHelper.cs as authoritative logic.
- **README.md (parent)**: Strengthened the key behaviors bullet to reference ParameterFilterHelper.cs and add the caution note.

### No code changes

The pipeline code is already correct — \ParameterFilterHelper.ShouldInclude()\ properly excludes common params unless Required. This PR only improves documentation clarity.