### PR TITLE
fix: strip 'Defaults to...' from Required parameter descriptions (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Strip "Defaults to..." from Required parameter descriptions** — `RequiredParameterDescriptionSanitizer` now removes contradictory default-value language (`Defaults to X.`, `Default is X.`, `Default: X.`, `If not specified, defaults to X.`, etc.) from parameter descriptions when the parameter is marked Required. Required parameters have no default — users must always provide a value — so including default language is confusing. Closes #593.
+
 ### Added
 
 - **Install latest @azure/mcp before tools-list generation** — Bootstrap step now runs `npm install @azure/mcp@latest --save` before the pinned `npm install`, ensuring the tools-list is always generated from the latest published package. Failure is fatal (the whole point is to use the latest). New `--skip-npm-update` CLI flag opts out for offline or reproducible builds. (#)

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
@@ -138,7 +138,10 @@ public class ParameterGenerator
                     IsConditionalRequired = conditionalParameters.Contains(parameterName),
                     Description = ParameterDescriptionBackticker.Apply(
                         Config.TextNormalizer.WrapExampleValues(
-                            Config.TextNormalizer.EnsureEndsPeriod(Config.TextNormalizer.ReplaceStaticText(opt.Description ?? string.Empty))))
+                            Config.TextNormalizer.EnsureEndsPeriod(
+                                RequiredParameterDescriptionSanitizer.Apply(
+                                    Config.TextNormalizer.ReplaceStaticText(opt.Description ?? string.Empty),
+                                    opt.Required))))
                 };
             })
             .ToList();

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
@@ -138,10 +138,10 @@ public class ParameterGenerator
                     IsConditionalRequired = conditionalParameters.Contains(parameterName),
                     Description = ParameterDescriptionBackticker.Apply(
                         Config.TextNormalizer.WrapExampleValues(
-                            Config.TextNormalizer.EnsureEndsPeriod(
-                                RequiredParameterDescriptionSanitizer.Apply(
-                                    Config.TextNormalizer.ReplaceStaticText(opt.Description ?? string.Empty),
-                                    opt.Required))))
+                            RequiredParameterDescriptionSanitizer.Apply(
+                                Config.TextNormalizer.EnsureEndsPeriod(
+                                    Config.TextNormalizer.ReplaceStaticText(opt.Description ?? string.Empty)),
+                                opt.Required)))
                 };
             })
             .ToList();

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/RequiredParameterDescriptionSanitizerTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/RequiredParameterDescriptionSanitizerTests.cs
@@ -174,4 +174,35 @@ public class RequiredParameterDescriptionSanitizerTests
         var result = RequiredParameterDescriptionSanitizer.Apply(input!, isRequired: true);
         Assert.Equal(input, result);
     }
+
+    // ── Period-less input (before EnsureEndsPeriod runs in the real pipeline) ──
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultsTo_WithoutTrailingPeriod()
+    {
+        // In the pipeline, EnsureEndsPeriod runs before this sanitizer, so the
+        // sanitizer always receives a period-terminated string. But if a description
+        // has no trailing period on its defaults sentence (e.g., upstream data gap),
+        // the sanitizer should handle gracefully — it won't match (no period), so
+        // the rest of the description is preserved unchanged.
+        var input = "The region. Defaults to eastus";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        // Without a trailing period the regex cannot match the sentence boundary,
+        // so the string is returned as-is (no corruption, no crash).
+        Assert.False(string.IsNullOrWhiteSpace(result), "Should not return null/empty for period-less input");
+        Assert.Contains("The region.", result);
+    }
+
+    // ── Abbreviations with embedded periods — no false positive ───────────────
+
+    [Fact]
+    public void RequiredParameter_AbbreviationWithPeriods_NoFalsePositive()
+    {
+        // Abbreviations like "U.S." contain periods that are NOT sentence boundaries.
+        // The sanitizer must not truncate the description at the abbreviation period.
+        var input = "Used in the U.S. region. Defaults to eastus.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Contains("Used in the U.S. region.", result);
+        Assert.DoesNotContain("Defaults to eastus", result);
+    }
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/RequiredParameterDescriptionSanitizerTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/RequiredParameterDescriptionSanitizerTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+/// <summary>
+/// TDD tests for <see cref="RequiredParameterDescriptionSanitizer"/>.
+/// Validates that "Defaults to..." language is stripped from Required parameter descriptions.
+/// Uses diverse Azure service examples per the universal design principle.
+/// </summary>
+public class RequiredParameterDescriptionSanitizerTests
+{
+    // ── Optional parameter — no change ────────────────────────────────────────
+
+    [Fact]
+    public void OptionalParameter_PreservesDefaultsLanguage()
+    {
+        var input = "The VM image to use. Defaults to Ubuntu 24.04 LTS.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: false);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void OptionalParameter_PreservesDefaultIsLanguage()
+    {
+        var input = "Consistency level for Cosmos DB. Default is Session.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: false);
+        Assert.Equal(input, result);
+    }
+
+    // ── Required — "Defaults to {value}." ─────────────────────────────────────
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultsToSentence()
+    {
+        var input = "The VM image alias. Defaults to Ubuntu 24.04 LTS.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("The VM image alias.", result);
+        Assert.DoesNotContain("Defaults to", result);
+    }
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultsToIfNotSpecified()
+    {
+        var input = "Storage account SKU. Defaults to Standard_LRS if not specified.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("Storage account SKU.", result);
+        Assert.DoesNotContain("Defaults to", result);
+    }
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultsToWhenNotProvided()
+    {
+        var input = "Key Vault secret version. Defaults to the latest version when not provided.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("Key Vault secret version.", result);
+        Assert.DoesNotContain("Defaults to", result);
+    }
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultsToUnlessSpecified()
+    {
+        var input = "The AKS node pool count. Defaults to 3 unless specified.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("The AKS node pool count.", result);
+        Assert.DoesNotContain("Defaults to", result);
+    }
+
+    // ── Required — "Default is {value}." ──────────────────────────────────────
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultIsSentence()
+    {
+        var input = "Upgrade policy mode for the scale set. Default is Manual.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("Upgrade policy mode for the scale set.", result);
+        Assert.DoesNotContain("Default is", result);
+    }
+
+    // ── Required — "Default: {value}." ────────────────────────────────────────
+
+    [Fact]
+    public void RequiredParameter_StripsDefaultColonSentence()
+    {
+        var input = "SQL Server authentication type. Default: SqlAuthentication.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("SQL Server authentication type.", result);
+        Assert.DoesNotContain("Default:", result);
+    }
+
+    // ── Required — "If not specified, defaults to {value}." ───────────────────
+
+    [Fact]
+    public void RequiredParameter_StripsIfNotSpecifiedDefaults()
+    {
+        var input = "The App Service plan tier. If not specified, defaults to Free.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("The App Service plan tier.", result);
+        Assert.DoesNotContain("defaults to", result);
+    }
+
+    // ── Required — other content preserved ────────────────────────────────────
+
+    [Fact]
+    public void RequiredParameter_PreservesRestOfDescription()
+    {
+        var input = "The OS disk type for the VM. Accepted values: Premium_LRS, Standard_LRS. Defaults to Standard_LRS.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Contains("The OS disk type for the VM.", result);
+        Assert.Contains("Accepted values: Premium_LRS, Standard_LRS.", result);
+        Assert.DoesNotContain("Defaults to Standard_LRS", result);
+    }
+
+    [Fact]
+    public void RequiredParameter_NoDefaultsLanguage_Unchanged()
+    {
+        var input = "The name of the Azure resource group.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void RequiredParameter_MultiSentence_StripsOnlyDefault()
+    {
+        var input = "The container image to deploy. Must be a valid Docker image reference. Defaults to mcr.microsoft.com/azuredocs/aci-helloworld.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Contains("The container image to deploy.", result);
+        Assert.Contains("Must be a valid Docker image reference.", result);
+        Assert.DoesNotContain("Defaults to", result);
+    }
+
+    // ── Required — description is ONLY defaults sentence ──────────────────────
+
+    [Fact]
+    public void RequiredParameter_DescriptionIsOnlyDefaults_ReturnsEmpty()
+    {
+        var input = "Defaults to eastus.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.True(string.IsNullOrWhiteSpace(result) || !result.Contains("Defaults to"),
+            $"Expected defaults sentence removed but got: '{result}'");
+    }
+
+    // ── Cleanup — no trailing whitespace or double periods ────────────────────
+
+    [Fact]
+    public void RequiredParameter_CleansUpTrailingWhitespace()
+    {
+        var input = "The Cosmos DB throughput value. Defaults to 400.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.Equal("The Cosmos DB throughput value.", result);
+        Assert.DoesNotContain("  ", result);
+        Assert.DoesNotContain("..", result);
+    }
+
+    [Fact]
+    public void RequiredParameter_NoDoublePeriodsAfterStrip()
+    {
+        var input = "The region. Defaults to westus2.";
+        var result = RequiredParameterDescriptionSanitizer.Apply(input, isRequired: true);
+        Assert.DoesNotContain("..", result);
+    }
+
+    // ── Null / empty passthrough ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NullOrEmptyInput_ReturnsAsIs(string? input)
+    {
+        var result = RequiredParameterDescriptionSanitizer.Apply(input!, isRequired: true);
+        Assert.Equal(input, result);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/RequiredParameterDescriptionSanitizer.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/RequiredParameterDescriptionSanitizer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Strips "Defaults to..." language from Required parameter descriptions.
+/// Required parameters have no default — users must always provide a value —
+/// so including default-value language is contradictory and confusing.
+/// </summary>
+public static class RequiredParameterDescriptionSanitizer
+{
+    // Sentence-boundary lookahead: a period that is followed by space+uppercase or end-of-string.
+    // This prevents stopping at periods embedded in values like "24.04" or "v1.0".
+    private const string SentenceEnd = @"\.(?=\s+[A-Z]|\s*$)";
+
+    // "If not specified, defaults to {value}[...]."
+    private static readonly Regex IfNotSpecifiedDefaultsTo = new(
+        @"If not specified,\s+defaults to\s+.+?" + SentenceEnd,
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // "Defaults to {value}[ if not specified | when not provided | unless specified | ...]."
+    // Also covers plain "Defaults to {value}." — the lazy .+? handles both.
+    private static readonly Regex DefaultsTo = new(
+        @"Defaults to\s+.+?" + SentenceEnd,
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // "Default is {value}."
+    private static readonly Regex DefaultIs = new(
+        @"Default is\s+.+?" + SentenceEnd,
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // "Default: {value}."
+    private static readonly Regex DefaultColon = new(
+        @"Default:\s+.+?" + SentenceEnd,
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex MultipleSpaces = new(@"  +", RegexOptions.Compiled);
+    private static readonly Regex DoublePeriod = new(@"\.\.+", RegexOptions.Compiled);
+    private static readonly Regex TrailingWhitespace = new(@"\s+$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips "Defaults to..." language when the parameter is Required.
+    /// Returns the description unchanged when <paramref name="isRequired"/> is false.
+    /// </summary>
+    /// <param name="description">The parameter description text.</param>
+    /// <param name="isRequired">Whether the parameter is marked Required.</param>
+    /// <returns>Sanitized description.</returns>
+    public static string Apply(string description, bool isRequired)
+    {
+        if (!isRequired)
+            return description;
+
+        if (string.IsNullOrWhiteSpace(description))
+            return description;
+
+        var result = description;
+
+        // Order matters: most-specific patterns first to avoid partial matches.
+        result = IfNotSpecifiedDefaultsTo.Replace(result, string.Empty);
+        result = DefaultsTo.Replace(result, string.Empty);
+        result = DefaultIs.Replace(result, string.Empty);
+        result = DefaultColon.Replace(result, string.Empty);
+
+        // Clean up artefacts: collapse runs of spaces, fix double periods, trim.
+        result = MultipleSpaces.Replace(result, " ");
+        result = DoublePeriod.Replace(result, ".");
+        result = TrailingWhitespace.Replace(result, string.Empty);
+        result = result.Trim();
+
+        return result;
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/RequiredParameterDescriptionSanitizer.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/RequiredParameterDescriptionSanitizer.cs
@@ -58,7 +58,10 @@ public static class RequiredParameterDescriptionSanitizer
 
         var result = description;
 
-        // Order matters: most-specific patterns first to avoid partial matches.
+        // IfNotSpecifiedDefaultsTo MUST run before DefaultsTo.
+        // "If not specified, defaults to X." contains "defaults to" as a substring;
+        // running DefaultsTo first would match and consume only the inner part,
+        // leaving "If not specified," as an orphaned sentence fragment.
         result = IfNotSpecifiedDefaultsTo.Replace(result, string.Empty);
         result = DefaultsTo.Replace(result, string.Empty);
         result = DefaultIs.Replace(result, string.Empty);


### PR DESCRIPTION
## Summary

Fixes the contradiction where Required parameters have 'Defaults to X' in their descriptions. Required parameters have no default - users must always provide a value.

Identified in PR #9017 review by Jon Gallant for `compute_vm_create` `--image` parameter.

## Changes

- **New:** `RequiredParameterDescriptionSanitizer.cs` - strips defaults language when `Required=true`
- **Modified:** `ParameterGenerator.cs` - wires sanitizer into description pipeline
- **New tests:** 18 tests covering all known patterns and edge cases
- **Updated:** `CHANGELOG.md`

## Patterns Stripped (when Required=true)

- `Defaults to {value}.`
- `Defaults to {value} if not specified.`
- `Defaults to {value} when not provided.`
- `Defaults to {value} unless specified.`
- `Default is {value}.`
- `Default: {value}.`
- `If not specified, defaults to {value}.`

## Implementation Notes

Uses sentence-boundary lookahead to correctly handle version numbers with embedded periods (e.g., Ubuntu 24.04 LTS) without stopping at the decimal point.

## Test Results

- 18 new tests: all pass
- 357 Annotations tests: all pass
- 878 ToolFamilyCleanup tests: 878 pass, 1 pre-existing failure (R_CG2_AllNamespacesHaveGeneratedOutput - unrelated generated-skills namespace issue)

Closes #593