### PR TITLE
fix: update stale Config_RemoteUrl test -- assert main branch not release/azure/2.x

### DIFF
--- a/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.E2eTestPromptParser.Tests/ParserConfigTests.cs
@@ -16,8 +16,11 @@ public class ParserConfigTests
     }
 
     [Fact]
-    public void Config_RemoteUrl_PointsTo2xBranch()
+    public void Config_RemoteUrl_PointsToMainBranch()
     {
+        // PR #584 deliberately moved the default branch from release/azure/2.x to main.
+        // The remoteUrl in config.json is the standalone-mode fallback; the pipeline
+        // overrides it via --branch / MCP_BRANCH.  The fallback must now point to main.
         var configPath = GetConfigPath();
         Assert.True(File.Exists(configPath), $"config.json not found at {configPath}");
 
@@ -25,8 +28,8 @@ public class ParserConfigTests
         var config = JsonSerializer.Deserialize<ParserConfig>(json);
 
         Assert.NotNull(config);
-        Assert.Contains("release/azure/2.x", config!.RemoteUrl, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("/main/", config.RemoteUrl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("/main/", config!.RemoteUrl, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("release/azure/2.x", config.RemoteUrl, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

CI `Build and Test` workflow failing on `main` due to:

> `E2eTestPromptParser.Tests.ParserConfigTests.Config_RemoteUrl_PointsTo2xBranch`

The test asserted `config.RemoteUrl` contains `release/azure/2.x` and **does not** contain `/main/`, but that is no longer true.

## Root Cause

PR #584 (`c1ba86a`) intentionally changed:
- `PipelineRequest.DefaultMcpBranch` to `main`
- `config.json remoteUrl` to point to the `main` branch

The `ParserConfigTests.cs` test was **not updated** when this change landed, leaving a stale assertion that now breaks CI.

## Fix

- Rename `Config_RemoteUrl_PointsTo2xBranch` to `Config_RemoteUrl_PointsToMainBranch`
- Assert `Contains("/main/")` and `DoesNotContain("release/azure/2.x")`
- Add a short comment explaining why the fallback is `main`

## Verification

- Test was **red** before fix (confirmed locally)
- Test is **green** after fix
- All 29 tests in `E2eTestPromptParser.Tests` pass
- `dotnet build mcp-doc-generation.sln --configuration Release` -- 0 errors, 0 new warnings

## No config change needed

The config (`config.json`) is **correct** -- it was deliberately updated in PR #584. Only the test needed updating.