### PR TITLE
feat: auto-expand parent namespace into sub-namespaces (#608)

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
@@ -113,3 +113,14 @@ internal sealed class SkipSpecificNamespaceGate(string namespaceToSkip) : IChang
                 : ChangelogGateResult.Process($"namespace '{namespaceName}' found in CHANGELOG (test stub)"));
     }
 }
+
+/// <summary>
+/// A brand mapping loader stub that returns a configurable set of entries.
+/// </summary>
+internal sealed class StubBrandMappingLoader(IReadOnlyList<BrandMappingEntry>? entries = null) : IBrandMappingLoader
+{
+    private readonly IReadOnlyList<BrandMappingEntry> _entries = entries ?? [];
+
+    public Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken)
+        => Task.FromResult(_entries);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceExpanderTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceExpanderTests.cs
@@ -1,0 +1,217 @@
+using PipelineRunner.Services;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="NamespaceExpander"/> — the service that resolves a requested
+/// namespace string to a list of concrete CLI namespace names.
+/// </summary>
+public class NamespaceExpanderTests
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static BrandMappingEntry Entry(string mcpServerName, string? composition = null)
+        => new(mcpServerName, $"Azure {mcpServerName}", mcpServerName, mcpServerName, composition);
+
+    // ── null / all ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_NullNamespace_ReturnsAllCliNamespaces()
+    {
+        var cli = new[] { "advisor", "compute" };
+        var result = NamespaceExpander.Expand(null, [], cli);
+
+        Assert.True(result.IsAll);
+        Assert.True(result.IsResolved);
+        Assert.Equal(cli, result.Namespaces);
+    }
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("ALL")]
+    [InlineData("All")]
+    public void Expand_AllKeyword_ReturnsAllCliNamespaces(string keyword)
+    {
+        var cli = new[] { "advisor", "compute" };
+        var result = NamespaceExpander.Expand(keyword, [], cli);
+
+        Assert.True(result.IsAll);
+        Assert.True(result.IsResolved);
+        Assert.Equal(cli, result.Namespaces);
+    }
+
+    // ── exact match ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_ExactBrandMatch_ReturnsSingleNamespace_NotExpanded()
+    {
+        var entries = new[] { Entry("functionapp", "standalone"), Entry("compute", "standalone") };
+        var cli = new[] { "functionapp", "compute" };
+
+        var result = NamespaceExpander.Expand("functionapp", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.False(result.IsExpanded);
+        Assert.Equal(["functionapp"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_ExactBrandMatch_CaseInsensitive()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("ADVISOR", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.False(result.IsExpanded);
+        Assert.Equal(["advisor"], result.Namespaces);
+    }
+
+    // ── prefix expansion ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_PrefixMatch_ExpandsToAllSubNamespaces()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+            Entry("extension_cli_install", "split"),
+            Entry("advisor", "standalone"),
+        };
+        var cli = new[] { "extension_azqr", "extension_cli_generate", "extension_cli_install", "advisor" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(3, result.Namespaces.Count);
+        Assert.Contains("extension_azqr", result.Namespaces);
+        Assert.Contains("extension_cli_generate", result.Namespaces);
+        Assert.Contains("extension_cli_install", result.Namespaces);
+        Assert.DoesNotContain("advisor", result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_FilteredToCliAvailable()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+            Entry("extension_cli_install", "split"),
+        };
+        // CLI only has 2 of the 3 sub-entries
+        var cli = new[] { "extension_azqr", "extension_cli_generate" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(2, result.Namespaces.Count);
+        Assert.DoesNotContain("extension_cli_install", result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_ResultIsSortedAlphabetically()
+    {
+        var entries = new[]
+        {
+            Entry("extension_cli_install", "split"),
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+        };
+        var cli = new[] { "extension_azqr", "extension_cli_generate", "extension_cli_install" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.Equal(["extension_azqr", "extension_cli_generate", "extension_cli_install"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_CaseInsensitive()
+    {
+        var entries = new[] { Entry("monitor_logs", "split"), Entry("monitor_metrics", "split") };
+        var cli = new[] { "monitor_logs", "monitor_metrics" };
+
+        var result = NamespaceExpander.Expand("MONITOR", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(2, result.Namespaces.Count);
+    }
+
+    // ── sub-entries not in CLI ────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_SubEntriesInBrandMappingButNotInCli_ReturnsSubEntriesNotInCli()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+        };
+        // CLI does not expose any of the sub-namespaces yet
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.False(result.IsResolved);
+        Assert.True(result.IsSubEntriesNotInCli);
+        Assert.Equal("extension", result.RequestedNamespace);
+        Assert.Contains("extension_azqr", result.SubEntriesFound);
+        Assert.Contains("extension_cli_generate", result.SubEntriesFound);
+    }
+
+    // ── not in brand mapping ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_NotInBrandMapping_ReturnsNotInBrandMapping()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("compute", entries, cli);
+
+        Assert.False(result.IsResolved);
+        Assert.True(result.IsNotInBrandMapping);
+        Assert.Equal("compute", result.RequestedNamespace);
+    }
+
+    [Fact]
+    public void Expand_EmptyBrandMapping_ReturnsNotInBrandMapping()
+    {
+        var result = NamespaceExpander.Expand("compute", [], ["compute"]);
+
+        Assert.True(result.IsNotInBrandMapping);
+    }
+
+    // ── edge cases ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_WhitespaceIsTrimmedFromNamespace()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("  advisor  ", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.Equal(["advisor"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_NoPrefixPartialMatch_DoesNotExpandUnintended()
+    {
+        // "ext" should NOT match "extension_azqr" because the separator "_" is required
+        var entries = new[] { Entry("extension_azqr", "split") };
+        var cli = new[] { "extension_azqr" };
+
+        var result = NamespaceExpander.Expand("ext", entries, cli);
+
+        // Not an exact match, not a prefix match (extension_azqr doesn't start with "ext_")
+        Assert.True(result.IsNotInBrandMapping);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceResolutionTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceResolutionTests.cs
@@ -111,6 +111,112 @@ public class NamespaceResolutionTests
         }
     }
 
+    /// <summary>
+    /// Issue #608: --namespace extension (parent prefix) should auto-expand to all three
+    /// extension sub-namespaces and run the pipeline for each of them.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ParentNamespacePrefix_ExpandsToAllSubNamespaces()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"ns-resolution-expand-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                new RecordingProcessRunner(),
+                new WorkspaceManager(),
+                new UnderscoredNamespaceCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            var brandEntries = new[]
+            {
+                new BrandMappingEntry("extension_azqr", "Azure Compliance Quick Review", "AZQR", "azure-compliance-quick-review", "split"),
+                new BrandMappingEntry("extension_cli_generate", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-generate", "split"),
+                new BrandMappingEntry("extension_cli_install", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-install", "split"),
+            };
+
+            var executedNamespaces = new List<string>();
+            var namespaceStep = new NamespaceCaptureStep(executedNamespaces);
+            var runner = new global::PipelineRunner.PipelineRunner(
+                new StepRegistry([namespaceStep]),
+                contextFactory,
+                brandMappingLoader: new StubBrandMappingLoader(brandEntries));
+
+            var request = new PipelineRequest(
+                "extension", [1], ".\\generated-extension",
+                SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(3, executedNamespaces.Count);
+            Assert.Contains("extension_azqr", executedNamespaces);
+            Assert.Contains("extension_cli_generate", executedNamespaces);
+            Assert.Contains("extension_cli_install", executedNamespaces);
+            Assert.Contains(reportWriter.Messages,
+                m => m.Contains("expanded", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Issue #608: --namespace all should run all available CLI namespaces.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AllKeyword_RunsAllCliNamespaces()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"ns-resolution-all-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                new RecordingProcessRunner(),
+                new WorkspaceManager(),
+                new UnderscoredNamespaceCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            var executedNamespaces = new List<string>();
+            var namespaceStep = new NamespaceCaptureStep(executedNamespaces);
+            var runner = new global::PipelineRunner.PipelineRunner(
+                new StepRegistry([namespaceStep]),
+                contextFactory,
+                brandMappingLoader: new StubBrandMappingLoader());
+
+            var request = new PipelineRequest(
+                "all", [1], ".\\generated-all",
+                SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            // UnderscoredNamespaceCliMetadataLoader returns 3 extension namespaces
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(3, executedNamespaces.Count);
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private sealed class NamespaceCaptureStep(List<string> captured)

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -15,6 +15,7 @@ public sealed class PipelineRunner
 
     private readonly StepRegistry _stepRegistry;
     private readonly PipelineContextFactory _contextFactory;
+    private readonly IBrandMappingLoader _brandMappingLoader;
     private readonly IChangelogGate? _changelogGate;
     private readonly IFingerprintGate? _fingerprintGate;
     private readonly IPromptRegressionGate? _promptRegressionGate;
@@ -24,13 +25,15 @@ public sealed class PipelineRunner
         PipelineContextFactory contextFactory,
         IChangelogGate? changelogGate = null,
         IFingerprintGate? fingerprintGate = null,
-        IPromptRegressionGate? promptRegressionGate = null)
+        IPromptRegressionGate? promptRegressionGate = null,
+        IBrandMappingLoader? brandMappingLoader = null)
     {
         _stepRegistry = stepRegistry;
         _contextFactory = contextFactory;
         _changelogGate = changelogGate;
         _fingerprintGate = fingerprintGate;
         _promptRegressionGate = promptRegressionGate;
+        _brandMappingLoader = brandMappingLoader ?? new BrandMappingLoader();
     }
 
     public static PipelineRunner CreateDefault(string? repoRoot = null, TextWriter? output = null, TextWriter? error = null)
@@ -116,7 +119,9 @@ public sealed class PipelineRunner
         context.CliVersion ??= await context.CliMetadataLoader.LoadCliVersionAsync(context.OutputPath, cancellationToken);
 
         var availableNamespaces = await context.CliMetadataLoader.LoadNamespacesAsync(context.OutputPath, cancellationToken);
-        if (!ResolveNamespaces(context, availableNamespaces, out var resolvedNamespaces, out var namespaceError))
+        var brandEntries = await _brandMappingLoader.LoadAsync(context.McpToolsRoot, cancellationToken);
+
+        if (!ResolveNamespaces(context, availableNamespaces, brandEntries, out var resolvedNamespaces, out var namespaceError))
         {
             context.Reports.Error(namespaceError!);
             context.Workspaces.DeleteAll();
@@ -421,31 +426,63 @@ public sealed class PipelineRunner
     private static bool ResolveNamespaces(
         PipelineContext context,
         IReadOnlyList<string> availableNamespaces,
+        IReadOnlyList<BrandMappingEntry> brandEntries,
         out IReadOnlyList<string> resolvedNamespaces,
         out string? error)
     {
-        if (!string.IsNullOrWhiteSpace(context.Request.Namespace))
+        if (string.IsNullOrWhiteSpace(context.Request.Namespace))
         {
-            var normalizedRequest = context.TargetMatcher.Normalize(context.Request.Namespace!);
-            // Normalize candidates too so underscored names (e.g. "extension_azqr") match their
-            // normalized form ("extension azqr") — the original candidate value is kept for downstream use.
-            var match = availableNamespaces.FirstOrDefault(candidate =>
-                string.Equals(context.TargetMatcher.Normalize(candidate), normalizedRequest, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
+            resolvedNamespaces = availableNamespaces;
+            error = null;
+            return true;
+        }
+
+        var expansion = NamespaceExpander.Expand(context.Request.Namespace, brandEntries, availableNamespaces);
+
+        if (expansion.IsAll)
+        {
+            resolvedNamespaces = expansion.Namespaces;
+            error = null;
+            return true;
+        }
+
+        if (expansion.IsResolved)
+        {
+            if (expansion.IsExpanded)
             {
-                resolvedNamespaces = [match];
-                error = null;
-                return true;
+                context.Reports.Info(
+                    $"Namespace '{context.Request.Namespace}' expanded to {expansion.Namespaces.Count} sub-namespace(s): " +
+                    string.Join(", ", expansion.Namespaces));
             }
 
+            resolvedNamespaces = expansion.Namespaces;
+            error = null;
+            return true;
+        }
+
+        if (expansion.IsSubEntriesNotInCli)
+        {
             resolvedNamespaces = Array.Empty<string>();
-            error = $"Unknown namespace '{context.Request.Namespace}'.";
+            error = $"Namespace prefix '{context.Request.Namespace}' matched brand mapping entries " +
+                    $"({string.Join(", ", expansion.SubEntriesFound)}) but none are available in the CLI namespace list.";
             return false;
         }
 
-        resolvedNamespaces = availableNamespaces;
-        error = null;
-        return true;
+        // Not found in brand mapping — fall back to normalized CLI exact match for backward compatibility
+        var normalizedRequest = context.TargetMatcher.Normalize(context.Request.Namespace!);
+        var cliMatch = availableNamespaces.FirstOrDefault(candidate =>
+            string.Equals(context.TargetMatcher.Normalize(candidate), normalizedRequest, StringComparison.OrdinalIgnoreCase));
+
+        if (cliMatch is not null)
+        {
+            resolvedNamespaces = [cliMatch];
+            error = null;
+            return true;
+        }
+
+        resolvedNamespaces = Array.Empty<string>();
+        error = $"Unknown namespace '{context.Request.Namespace}'.";
+        return false;
     }
 
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingEntry.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingEntry.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Represents a single entry from <c>mcp-tools/data/brand-to-server-mapping.json</c>.
+/// The file is an array of these entries.
+/// </summary>
+public sealed record BrandMappingEntry(
+    [property: JsonPropertyName("mcpServerName")] string McpServerName,
+    [property: JsonPropertyName("brandName")] string BrandName,
+    [property: JsonPropertyName("shortName")] string ShortName,
+    [property: JsonPropertyName("fileName")] string FileName,
+    [property: JsonPropertyName("composition")] string? Composition = null,
+    [property: JsonPropertyName("mergeGroup")] string? MergeGroup = null,
+    [property: JsonPropertyName("mergeOrder")] int? MergeOrder = null,
+    [property: JsonPropertyName("mergeRole")] string? MergeRole = null);

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+
+namespace PipelineRunner.Services;
+
+public sealed class BrandMappingLoader : IBrandMappingLoader
+{
+    private const string RelativePath = "data/brand-to-server-mapping.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken)
+    {
+        var filePath = Path.Combine(mcpToolsRoot, RelativePath);
+        if (!File.Exists(filePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(filePath);
+        var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
+        return entries ?? [];
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
@@ -20,7 +20,16 @@ public sealed class BrandMappingLoader : IBrandMappingLoader
         }
 
         await using var stream = File.OpenRead(filePath);
-        var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
-        return entries ?? [];
+
+        try
+        {
+            var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
+            return entries ?? [];
+        }
+        catch (JsonException exception)
+        {
+            Console.Error.WriteLine($"Warning: Failed to parse brand mapping file '{filePath}': {exception.Message}");
+            return [];
+        }
     }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/IBrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/IBrandMappingLoader.cs
@@ -1,0 +1,10 @@
+namespace PipelineRunner.Services;
+
+public interface IBrandMappingLoader
+{
+    /// <summary>
+    /// Loads all entries from <c>mcp-tools/data/brand-to-server-mapping.json</c>.
+    /// Returns an empty list if the file does not exist.
+    /// </summary>
+    Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
@@ -1,0 +1,119 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Resolves a requested namespace string to a list of concrete CLI namespace names,
+/// applying prefix-based expansion for decomposed (split) namespaces and supporting
+/// the special <c>all</c> keyword.
+/// </summary>
+public static class NamespaceExpander
+{
+    private const string AllKeyword = "all";
+
+    /// <summary>
+    /// Expands the requested namespace to a concrete list of CLI namespace names.
+    /// </summary>
+    /// <param name="requestedNamespace">Value of <c>--namespace</c>, or <c>null</c> to process all.</param>
+    /// <param name="brandEntries">All entries from <c>brand-to-server-mapping.json</c>.</param>
+    /// <param name="availableCliNamespaces">Namespaces reported by the installed MCP CLI.</param>
+    /// <returns>An <see cref="NamespaceExpansionResult"/> describing the outcome.</returns>
+    public static NamespaceExpansionResult Expand(
+        string? requestedNamespace,
+        IReadOnlyList<BrandMappingEntry> brandEntries,
+        IReadOnlyList<string> availableCliNamespaces)
+    {
+        // null or "all" → all available CLI namespaces
+        if (requestedNamespace is null
+            || string.Equals(requestedNamespace.Trim(), AllKeyword, StringComparison.OrdinalIgnoreCase))
+        {
+            return NamespaceExpansionResult.All(availableCliNamespaces);
+        }
+
+        var normalized = requestedNamespace.Trim();
+
+        // Exact match in brand mapping → return it as-is (standalone/existing behavior)
+        var exactMatch = brandEntries.FirstOrDefault(e =>
+            string.Equals(e.McpServerName, normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (exactMatch is not null)
+        {
+            return NamespaceExpansionResult.Resolved([exactMatch.McpServerName], isExpanded: false);
+        }
+
+        // Prefix match: namespace is a parent prefix — find all "namespace_*" sub-entries
+        var prefix = normalized + "_";
+        var subEntries = brandEntries
+            .Where(e => e.McpServerName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(e => e.McpServerName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (subEntries.Length > 0)
+        {
+            // Keep only sub-entries that are actually available in the CLI namespace list
+            var availableSet = new HashSet<string>(availableCliNamespaces, StringComparer.OrdinalIgnoreCase);
+            var resolved = subEntries
+                .Where(e => availableSet.Contains(e.McpServerName))
+                .Select(e => e.McpServerName)
+                .ToArray();
+
+            if (resolved.Length == 0)
+            {
+                // Brand mapping knows about them but CLI does not expose them yet
+                return NamespaceExpansionResult.SubEntriesNotInCli(
+                    normalized,
+                    subEntries.Select(e => e.McpServerName).ToArray());
+            }
+
+            return NamespaceExpansionResult.Resolved(resolved, isExpanded: true);
+        }
+
+        // Not found in brand mapping at all — signal caller to apply CLI exact-match fallback
+        return NamespaceExpansionResult.NotInBrandMapping(normalized);
+    }
+}
+
+/// <summary>
+/// Outcome of a <see cref="NamespaceExpander.Expand"/> call.
+/// </summary>
+public sealed class NamespaceExpansionResult
+{
+    private NamespaceExpansionResult() { }
+
+    /// <summary>Resolved namespace names to process (populated for All and Resolved outcomes).</summary>
+    public IReadOnlyList<string> Namespaces { get; private init; } = [];
+
+    /// <summary>True when the result covers all available CLI namespaces.</summary>
+    public bool IsAll { get; private init; }
+
+    /// <summary>True when one or more specific namespaces were resolved.</summary>
+    public bool IsResolved { get; private init; }
+
+    /// <summary>
+    /// True when the input was a parent prefix and multiple sub-namespaces were expanded.
+    /// Always false for exact-match and all-namespace cases.
+    /// </summary>
+    public bool IsExpanded { get; private init; }
+
+    /// <summary>True when the input was not found in brand-to-server-mapping.json.</summary>
+    public bool IsNotInBrandMapping { get; private init; }
+
+    /// <summary>True when brand-to-server-mapping.json has sub-entries but none are in the CLI list.</summary>
+    public bool IsSubEntriesNotInCli { get; private init; }
+
+    /// <summary>The namespace string that was requested (populated for error outcomes).</summary>
+    public string? RequestedNamespace { get; private init; }
+
+    /// <summary>Sub-entries found in brand mapping but absent from the CLI (populated for SubEntriesNotInCli).</summary>
+    public IReadOnlyList<string> SubEntriesFound { get; private init; } = [];
+
+    public static NamespaceExpansionResult All(IReadOnlyList<string> namespaces)
+        => new() { IsAll = true, IsResolved = true, Namespaces = namespaces };
+
+    public static NamespaceExpansionResult Resolved(IReadOnlyList<string> namespaces, bool isExpanded)
+        => new() { IsResolved = true, IsExpanded = isExpanded, Namespaces = namespaces };
+
+    public static NamespaceExpansionResult SubEntriesNotInCli(string requested, IReadOnlyList<string> subEntriesFound)
+        => new() { IsSubEntriesNotInCli = true, RequestedNamespace = requested, SubEntriesFound = subEntriesFound };
+
+    public static NamespaceExpansionResult NotInBrandMapping(string requested)
+        => new() { IsNotInBrandMapping = true, RequestedNamespace = requested };
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
@@ -42,6 +42,7 @@ public static class NamespaceExpander
         // Prefix match: namespace is a parent prefix — find all "namespace_*" sub-entries
         var prefix = normalized + "_";
         var subEntries = brandEntries
+            .Where(e => e.McpServerName is not null)
             .Where(e => e.McpServerName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             .OrderBy(e => e.McpServerName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -51,6 +52,7 @@ public static class NamespaceExpander
             // Keep only sub-entries that are actually available in the CLI namespace list
             var availableSet = new HashSet<string>(availableCliNamespaces, StringComparer.OrdinalIgnoreCase);
             var resolved = subEntries
+                .Where(e => e.McpServerName is not null)
                 .Where(e => availableSet.Contains(e.McpServerName))
                 .Select(e => e.McpServerName)
                 .ToArray();


### PR DESCRIPTION
## Summary

Implements #608: auto-expand a parent namespace prefix into all matching sub-namespaces when the user passes \--namespace X\.

## Changes

### New services
- \BrandMappingEntry\ — record matching the \rand-to-server-mapping.json\ array schema
- \IBrandMappingLoader\ / \BrandMappingLoader\ — loads the brand mapping file; returns empty list when file absent (test-safe)
- \NamespaceExpander\ — pure expansion logic (no I/O):
  - Exact \mcpServerName\ match → passthrough (existing behavior)
  - Prefix match (\xtension\ → \xtension_azqr\, \xtension_cli_generate\, \xtension_cli_install\) → batch expand
  - \ll\ keyword → all available CLI namespaces
  - Falls back to normalized CLI exact match for namespaces not in brand mapping

### Updated
- \PipelineRunner.cs\ — \ResolveNamespaces\ now consults \NamespaceExpander\; logs an info message when expansion occurs; \IBrandMappingLoader\ is optional constructor param (default: \BrandMappingLoader\)

### Tests
- \NamespaceExpanderTests\ — 14 unit tests covering all expansion paths
- \NamespaceResolutionTests\ — 2 new integration tests: prefix expansion and \ll\ keyword
- \StubBrandMappingLoader\ added to \TestDoubles\ for test isolation

## Acceptance criteria status

| Criterion | Status |
|---|---|
| \--namespace extension\ runs all 3 extension sub-namespaces | ✅ |
| \--namespace functionapp\ still works as before (exact match passthrough) | ✅ |
| \--namespace all\ runs all namespaces | ✅ |
| Progress reporting shows which sub-namespace is running | ✅ (existing loop logs each namespace; new expansion log added) |
| Non-zero exit if any sub-namespace fails | ✅ (existing behavior: first failure stops run) |