### PR TITLE
feat: add CompositionOutputValidator as post-assembly gate

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Fixtures/TestDoubles.cs
@@ -113,3 +113,14 @@ internal sealed class SkipSpecificNamespaceGate(string namespaceToSkip) : IChang
                 : ChangelogGateResult.Process($"namespace '{namespaceName}' found in CHANGELOG (test stub)"));
     }
 }
+
+/// <summary>
+/// A brand mapping loader stub that returns a configurable set of entries.
+/// </summary>
+internal sealed class StubBrandMappingLoader(IReadOnlyList<BrandMappingEntry>? entries = null) : IBrandMappingLoader
+{
+    private readonly IReadOnlyList<BrandMappingEntry> _entries = entries ?? [];
+
+    public Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken)
+        => Task.FromResult(_entries);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CompositionOutputValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CompositionOutputValidatorTests.cs
@@ -1,0 +1,423 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+using PipelineRunner.Tests.Fixtures;
+using PipelineRunner.Validation;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="CompositionOutputValidator"/> covering all 6 composition
+/// scenarios from the spec plus edge cases.
+/// </summary>
+public sealed class CompositionOutputValidatorTests : IDisposable
+{
+    private readonly string _outputRoot;
+
+    public CompositionOutputValidatorTests()
+    {
+        _outputRoot = Path.Combine(Path.GetTempPath(), $"composition-validator-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_outputRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputRoot))
+            Directory.Delete(_outputRoot, recursive: true);
+    }
+
+    // ── 1. Standalone success ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_StandaloneSuccess_NoIssues()
+    {
+        CreateFile("tool-family", "azure-container-apps.md");
+        var entries = new[]
+        {
+            new BrandMappingEntry("containerapps", "Azure Container Apps", "Container Apps", "azure-container-apps", "standalone"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    // ── 2. Standalone failure ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_StandaloneFileMissing_ReportsIssue()
+    {
+        // Do NOT create azure-container-apps.md
+        var entries = new[]
+        {
+            new BrandMappingEntry("containerapps", "Azure Container Apps", "Container Apps", "azure-container-apps", "standalone"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        Assert.Single(result.Issues);
+        Assert.Equal("containerapps", result.Issues[0].Identifier);
+        Assert.Equal("standalone", result.Issues[0].IssueType);
+        Assert.Contains("azure-container-apps.md", result.Issues[0].Message);
+    }
+
+    // ── 3. Merge success ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MergeSuccess_AllIntermediatesPlusMergedOutput()
+    {
+        // Primary produces azure-functions.md; secondary produces azure-functions-development.md
+        // The merged output keyed by mergeGroup "azure-functions" = azure-functions.md (same as primary).
+        CreateFile("tool-family", "azure-functions.md");
+        CreateFile("tool-family", "azure-functions-development.md");
+
+        var entries = new BrandMappingEntry[]
+        {
+            new("functionapp", "Azure Functions", "Functions", "azure-functions",
+                Composition: "merge", MergeGroup: "azure-functions", MergeOrder: 1, MergeRole: "primary"),
+            new("functions", "Azure Functions", "Functions", "azure-functions-development",
+                Composition: "merge", MergeGroup: "azure-functions", MergeOrder: 2, MergeRole: "secondary"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    // ── 4. Merge failure (partial group) ──────────────────────────────────────
+
+    [Fact]
+    public void Validate_MergePartialGroup_SecondaryIntermediateMissing_ReportsIssue()
+    {
+        // Primary intermediate exists but secondary is missing.
+        CreateFile("tool-family", "azure-functions.md");
+        // azure-functions-development.md intentionally absent
+
+        var entries = new BrandMappingEntry[]
+        {
+            new("functionapp", "Azure Functions", "Functions", "azure-functions",
+                Composition: "merge", MergeGroup: "azure-functions", MergeOrder: 1, MergeRole: "primary"),
+            new("functions", "Azure Functions", "Functions", "azure-functions-development",
+                Composition: "merge", MergeGroup: "azure-functions", MergeOrder: 2, MergeRole: "secondary"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        // Secondary intermediate missing
+        Assert.Contains(result.Issues, i =>
+            i.Identifier == "functions" &&
+            i.IssueType == "merge-intermediate" &&
+            i.Message.Contains("azure-functions-development.md"));
+    }
+
+    [Fact]
+    public void Validate_MergeGroupMergedOutputMissing_ReportsIssue()
+    {
+        // Both intermediates exist but the merged output file is absent.
+        // For this test we use a group where the mergeGroup key differs from primary's fileName.
+        CreateFile("tool-family", "azure-monitor.md");
+        CreateFile("tool-family", "azure-workbooks.md");
+        // Drop the mergeGroup file to force the merged-output check to fail.
+        // Since primary fileName == mergeGroup for azure-monitor, we delete the file and
+        // use a synthetic scenario where the merged key differs.
+
+        // Use a synthetic merge group where mergeGroup "azure-observability" differs from
+        // both member fileNames so we can test the merged-output check independently.
+        var entries = new BrandMappingEntry[]
+        {
+            new("monitorns", "Azure Monitor", "Monitor", "azure-monitor",
+                Composition: "merge", MergeGroup: "azure-observability", MergeOrder: 1, MergeRole: "primary"),
+            new("workbooksns", "Azure Workbooks", "Workbooks", "azure-workbooks",
+                Composition: "merge", MergeGroup: "azure-observability", MergeOrder: 2, MergeRole: "secondary"),
+            // azure-observability.md intentionally absent
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, i =>
+            i.Identifier == "azure-observability" &&
+            i.IssueType == "merge-output" &&
+            i.Message.Contains("azure-observability.md"));
+    }
+
+    // ── 5. Split success ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_SplitSuccess_EachNamespaceProducesItsOwnFile()
+    {
+        CreateFile("tool-family", "azure-cli-extension-generate.md");
+        CreateFile("tool-family", "azure-cli-extension-install.md");
+
+        var entries = new BrandMappingEntry[]
+        {
+            new("extension_cli_generate", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-generate",
+                Composition: "split", MergeGroup: "azure-cli-extension", MergeOrder: 1, MergeRole: "primary"),
+            new("extension_cli_install", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-install",
+                Composition: "split", MergeGroup: "azure-cli-extension", MergeOrder: 2, MergeRole: "secondary"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    // ── 6. Split failure ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_SplitFileMissing_ReportsIssue()
+    {
+        CreateFile("tool-family", "azure-cli-extension-install.md");
+        // azure-cli-extension-generate.md intentionally absent
+
+        var entries = new BrandMappingEntry[]
+        {
+            new("extension_cli_generate", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-generate",
+                Composition: "split", MergeGroup: "azure-cli-extension", MergeOrder: 1, MergeRole: "primary"),
+            new("extension_cli_install", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-install",
+                Composition: "split", MergeGroup: "azure-cli-extension", MergeOrder: 2, MergeRole: "secondary"),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, i =>
+            i.Identifier == "extension_cli_generate" &&
+            i.IssueType == "split" &&
+            i.Message.Contains("azure-cli-extension-generate.md"));
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_EmptyEntries_SuccessWithNoIssues()
+    {
+        var result = CompositionOutputValidator.Validate(_outputRoot, []);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void Validate_NullComposition_TreatedAsStandalone()
+    {
+        // An entry with no Composition field defaults to standalone behaviour.
+        CreateFile("tool-family", "azure-compute.md");
+        var entries = new[]
+        {
+            new BrandMappingEntry("compute", "Azure Compute", "Compute", "azure-compute", Composition: null),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void Validate_NullCompositionFileMissing_ReportsStandaloneIssue()
+    {
+        // azure-compute.md absent; null Composition → treated as standalone.
+        var entries = new[]
+        {
+            new BrandMappingEntry("compute", "Azure Compute", "Compute", "azure-compute", Composition: null),
+        };
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        Assert.Single(result.Issues);
+        Assert.Equal("standalone", result.Issues[0].IssueType);
+    }
+
+    [Fact]
+    public void Validate_MultipleStandaloneMissing_ReportsAllIssues()
+    {
+        var entries = new[]
+        {
+            new BrandMappingEntry("containerapps", "Azure Container Apps", "Container Apps", "azure-container-apps", "standalone"),
+            new BrandMappingEntry("aks", "Azure Kubernetes Service", "AKS", "azure-kubernetes-service", "standalone"),
+        };
+        // Neither file exists
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        Assert.False(result.Success);
+        Assert.Equal(2, result.Issues.Count);
+    }
+
+    [Fact]
+    public void Validate_MergeGroupWithNoMergeGroupField_MergedOutputCheckSkipped()
+    {
+        // A merge entry without a MergeGroup field is unusual (config error), but should not crash.
+        CreateFile("tool-family", "azure-orphan.md");
+        var entries = new[]
+        {
+            new BrandMappingEntry("orphan", "Azure Orphan", "Orphan", "azure-orphan",
+                Composition: "merge", MergeGroup: null),
+        };
+
+        // Should not throw; the group with null MergeGroup is excluded from group validation.
+        var result = CompositionOutputValidator.Validate(_outputRoot, entries);
+
+        // The entry has no mergeGroup so it isn't part of any group check — no issues raised.
+        Assert.True(result.Success);
+        Assert.Empty(result.Issues);
+    }
+
+    // ── Per-namespace IPostValidator tests ─────────────────────────────────────
+
+    [Fact]
+    public async Task ValidateAsync_StandaloneNamespace_FileExists_ReturnsSuccess()
+    {
+        var (context, outputPath) = CreateContext("containerapps", "azure-container-apps");
+        CreateFile(outputPath, "tool-family", "azure-container-apps.md");
+        InjectEntries(context,
+            new BrandMappingEntry("containerapps", "Azure Container Apps", "Container Apps", "azure-container-apps", "standalone"));
+
+        var validator = new CompositionOutputValidator();
+        var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_StandaloneNamespace_FileMissing_ReturnsFail()
+    {
+        var (context, _) = CreateContext("containerapps", "azure-container-apps");
+        // File intentionally absent
+        InjectEntries(context,
+            new BrandMappingEntry("containerapps", "Azure Container Apps", "Container Apps", "azure-container-apps", "standalone"));
+
+        var validator = new CompositionOutputValidator();
+        var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Warnings, w => w.Contains("azure-container-apps.md"));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MergeSecondaryNamespace_IntermediateExists_ReturnsSuccess()
+    {
+        var (context, outputPath) = CreateContext("functions", "azure-functions-development");
+        CreateFile(outputPath, "tool-family", "azure-functions-development.md");
+        InjectEntries(context,
+            new BrandMappingEntry("functions", "Azure Functions", "Functions", "azure-functions-development",
+                Composition: "merge", MergeGroup: "azure-functions", MergeOrder: 2, MergeRole: "secondary"));
+
+        var validator = new CompositionOutputValidator();
+        var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NamespaceNotInMapping_ReturnsSuccessWithNoWarnings()
+    {
+        // When a namespace has no brand mapping entry, the validator cannot check the
+        // composition type and falls back to checking the outputFileName from context.
+        // If the fallback file exists, it passes.
+        var (context, outputPath) = CreateContext("unknown-ns", "azure-unknown");
+        CreateFile(outputPath, "tool-family", "azure-unknown.md");
+        InjectEntries(context); // empty entries
+
+        var validator = new CompositionOutputValidator();
+        var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ValidatorNameIsCorrect()
+    {
+        var (context, _) = CreateContext("compute", "azure-compute");
+        InjectEntries(context);
+
+        var validator = new CompositionOutputValidator();
+
+        Assert.Equal("CompositionOutputValidator", validator.Name);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void CreateFile(string subdirectory, string fileName)
+    {
+        var dir = Path.Combine(_outputRoot, subdirectory);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), "# Placeholder\n");
+    }
+
+    private static void CreateFile(string basePath, string subdirectory, string fileName)
+    {
+        var dir = Path.Combine(basePath, subdirectory);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), "# Placeholder\n");
+    }
+
+    private (PipelineContext Context, string OutputPath) CreateContext(string namespaceName, string outputFileName)
+    {
+        var outputPath = Path.Combine(_outputRoot, $"generated-{namespaceName}");
+        Directory.CreateDirectory(outputPath);
+
+        var context = new PipelineContext
+        {
+            Request = new PipelineRequest(namespaceName, [4], outputPath, SkipBuild: true, SkipValidation: false, DryRun: false),
+            RepoRoot = _outputRoot,
+            McpToolsRoot = Path.Combine(_outputRoot, "mcp-tools"),
+            OutputPath = outputPath,
+            ProcessRunner = new RecordingProcessRunner(),
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new StubFilteredCliWriter(),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            SelectedNamespaces = [namespaceName],
+        };
+
+        context.Items[ToolFamilyPostAssemblyValidator.FamilyNameContextKey] = namespaceName;
+        context.Items[ToolFamilyPostAssemblyValidator.OutputFileNameContextKey] = outputFileName;
+
+        return (context, outputPath);
+    }
+
+    private static void InjectEntries(PipelineContext context, params BrandMappingEntry[] entries)
+    {
+        context.Items[CompositionOutputValidator.BrandEntriesContextKey] =
+            (IReadOnlyList<BrandMappingEntry>)entries;
+    }
+
+    private sealed class FakeStep : IPipelineStep
+    {
+        public int Id => 4;
+        public string Name => "Generate tool-family article";
+        public StepScope Scope => StepScope.Namespace;
+        public FailurePolicy FailurePolicy => FailurePolicy.Fatal;
+        public IReadOnlyList<int> DependsOn => [];
+        public IReadOnlyList<IPostValidator> PostValidators => [];
+        public int MaxRetries => 0;
+        public bool RequiresCliOutput => true;
+        public bool RequiresCliVersion => true;
+        public bool RequiresAiConfiguration => false;
+        public bool CreatesFilteredCliView => false;
+        public bool UsesIsolatedWorkspace => false;
+        public IReadOnlyList<string> ExpectedOutputs => [];
+        public string Implementation => "Typed";
+
+        public ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+            => ValueTask.FromResult(StepResult.DryRun([]));
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CompositionOutputValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CompositionOutputValidatorTests.cs
@@ -209,6 +209,35 @@ public sealed class CompositionOutputValidatorTests : IDisposable
     }
 
     [Fact]
+    public void Validate_OutputDirectoryMissing_ReturnsDirectoryIssue()
+    {
+        Directory.Delete(_outputRoot, recursive: true);
+
+        var result = CompositionOutputValidator.Validate(_outputRoot, []);
+
+        Assert.False(result.Success);
+        Assert.Single(result.Issues);
+        Assert.Equal("directory", result.Issues[0].Identifier);
+        Assert.Equal("N/A", result.Issues[0].IssueType);
+        Assert.Contains(_outputRoot, result.Issues[0].Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_InvalidOutputPath_ThrowsArgumentException(string? outputPath)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => CompositionOutputValidator.Validate(outputPath!, []));
+    }
+
+    [Fact]
+    public void Validate_NullEntries_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => CompositionOutputValidator.Validate(_outputRoot, null!));
+    }
+
+    [Fact]
     public void Validate_NullComposition_TreatedAsStandalone()
     {
         // An entry with no Composition field defaults to standalone behaviour.

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceExpanderTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceExpanderTests.cs
@@ -1,0 +1,217 @@
+using PipelineRunner.Services;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="NamespaceExpander"/> — the service that resolves a requested
+/// namespace string to a list of concrete CLI namespace names.
+/// </summary>
+public class NamespaceExpanderTests
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static BrandMappingEntry Entry(string mcpServerName, string? composition = null)
+        => new(mcpServerName, $"Azure {mcpServerName}", mcpServerName, mcpServerName, composition);
+
+    // ── null / all ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_NullNamespace_ReturnsAllCliNamespaces()
+    {
+        var cli = new[] { "advisor", "compute" };
+        var result = NamespaceExpander.Expand(null, [], cli);
+
+        Assert.True(result.IsAll);
+        Assert.True(result.IsResolved);
+        Assert.Equal(cli, result.Namespaces);
+    }
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("ALL")]
+    [InlineData("All")]
+    public void Expand_AllKeyword_ReturnsAllCliNamespaces(string keyword)
+    {
+        var cli = new[] { "advisor", "compute" };
+        var result = NamespaceExpander.Expand(keyword, [], cli);
+
+        Assert.True(result.IsAll);
+        Assert.True(result.IsResolved);
+        Assert.Equal(cli, result.Namespaces);
+    }
+
+    // ── exact match ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_ExactBrandMatch_ReturnsSingleNamespace_NotExpanded()
+    {
+        var entries = new[] { Entry("functionapp", "standalone"), Entry("compute", "standalone") };
+        var cli = new[] { "functionapp", "compute" };
+
+        var result = NamespaceExpander.Expand("functionapp", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.False(result.IsExpanded);
+        Assert.Equal(["functionapp"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_ExactBrandMatch_CaseInsensitive()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("ADVISOR", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.False(result.IsExpanded);
+        Assert.Equal(["advisor"], result.Namespaces);
+    }
+
+    // ── prefix expansion ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_PrefixMatch_ExpandsToAllSubNamespaces()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+            Entry("extension_cli_install", "split"),
+            Entry("advisor", "standalone"),
+        };
+        var cli = new[] { "extension_azqr", "extension_cli_generate", "extension_cli_install", "advisor" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(3, result.Namespaces.Count);
+        Assert.Contains("extension_azqr", result.Namespaces);
+        Assert.Contains("extension_cli_generate", result.Namespaces);
+        Assert.Contains("extension_cli_install", result.Namespaces);
+        Assert.DoesNotContain("advisor", result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_FilteredToCliAvailable()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+            Entry("extension_cli_install", "split"),
+        };
+        // CLI only has 2 of the 3 sub-entries
+        var cli = new[] { "extension_azqr", "extension_cli_generate" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(2, result.Namespaces.Count);
+        Assert.DoesNotContain("extension_cli_install", result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_ResultIsSortedAlphabetically()
+    {
+        var entries = new[]
+        {
+            Entry("extension_cli_install", "split"),
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+        };
+        var cli = new[] { "extension_azqr", "extension_cli_generate", "extension_cli_install" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.Equal(["extension_azqr", "extension_cli_generate", "extension_cli_install"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_PrefixMatch_CaseInsensitive()
+    {
+        var entries = new[] { Entry("monitor_logs", "split"), Entry("monitor_metrics", "split") };
+        var cli = new[] { "monitor_logs", "monitor_metrics" };
+
+        var result = NamespaceExpander.Expand("MONITOR", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.True(result.IsExpanded);
+        Assert.Equal(2, result.Namespaces.Count);
+    }
+
+    // ── sub-entries not in CLI ────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_SubEntriesInBrandMappingButNotInCli_ReturnsSubEntriesNotInCli()
+    {
+        var entries = new[]
+        {
+            Entry("extension_azqr", "split"),
+            Entry("extension_cli_generate", "split"),
+        };
+        // CLI does not expose any of the sub-namespaces yet
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("extension", entries, cli);
+
+        Assert.False(result.IsResolved);
+        Assert.True(result.IsSubEntriesNotInCli);
+        Assert.Equal("extension", result.RequestedNamespace);
+        Assert.Contains("extension_azqr", result.SubEntriesFound);
+        Assert.Contains("extension_cli_generate", result.SubEntriesFound);
+    }
+
+    // ── not in brand mapping ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_NotInBrandMapping_ReturnsNotInBrandMapping()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("compute", entries, cli);
+
+        Assert.False(result.IsResolved);
+        Assert.True(result.IsNotInBrandMapping);
+        Assert.Equal("compute", result.RequestedNamespace);
+    }
+
+    [Fact]
+    public void Expand_EmptyBrandMapping_ReturnsNotInBrandMapping()
+    {
+        var result = NamespaceExpander.Expand("compute", [], ["compute"]);
+
+        Assert.True(result.IsNotInBrandMapping);
+    }
+
+    // ── edge cases ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_WhitespaceIsTrimmedFromNamespace()
+    {
+        var entries = new[] { Entry("advisor", "standalone") };
+        var cli = new[] { "advisor" };
+
+        var result = NamespaceExpander.Expand("  advisor  ", entries, cli);
+
+        Assert.True(result.IsResolved);
+        Assert.Equal(["advisor"], result.Namespaces);
+    }
+
+    [Fact]
+    public void Expand_NoPrefixPartialMatch_DoesNotExpandUnintended()
+    {
+        // "ext" should NOT match "extension_azqr" because the separator "_" is required
+        var entries = new[] { Entry("extension_azqr", "split") };
+        var cli = new[] { "extension_azqr" };
+
+        var result = NamespaceExpander.Expand("ext", entries, cli);
+
+        // Not an exact match, not a prefix match (extension_azqr doesn't start with "ext_")
+        Assert.True(result.IsNotInBrandMapping);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceResolutionTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceResolutionTests.cs
@@ -111,6 +111,112 @@ public class NamespaceResolutionTests
         }
     }
 
+    /// <summary>
+    /// Issue #608: --namespace extension (parent prefix) should auto-expand to all three
+    /// extension sub-namespaces and run the pipeline for each of them.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ParentNamespacePrefix_ExpandsToAllSubNamespaces()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"ns-resolution-expand-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                new RecordingProcessRunner(),
+                new WorkspaceManager(),
+                new UnderscoredNamespaceCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            var brandEntries = new[]
+            {
+                new BrandMappingEntry("extension_azqr", "Azure Compliance Quick Review", "AZQR", "azure-compliance-quick-review", "split"),
+                new BrandMappingEntry("extension_cli_generate", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-generate", "split"),
+                new BrandMappingEntry("extension_cli_install", "Azure CLI Extension", "CLI Extension", "azure-cli-extension-install", "split"),
+            };
+
+            var executedNamespaces = new List<string>();
+            var namespaceStep = new NamespaceCaptureStep(executedNamespaces);
+            var runner = new global::PipelineRunner.PipelineRunner(
+                new StepRegistry([namespaceStep]),
+                contextFactory,
+                brandMappingLoader: new StubBrandMappingLoader(brandEntries));
+
+            var request = new PipelineRequest(
+                "extension", [1], ".\\generated-extension",
+                SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(3, executedNamespaces.Count);
+            Assert.Contains("extension_azqr", executedNamespaces);
+            Assert.Contains("extension_cli_generate", executedNamespaces);
+            Assert.Contains("extension_cli_install", executedNamespaces);
+            Assert.Contains(reportWriter.Messages,
+                m => m.Contains("expanded", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Issue #608: --namespace all should run all available CLI namespaces.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AllKeyword_RunsAllCliNamespaces()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"ns-resolution-all-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var contextFactory = new PipelineContextFactory(
+                new RecordingProcessRunner(),
+                new WorkspaceManager(),
+                new UnderscoredNamespaceCliMetadataLoader(),
+                new TargetMatcher(),
+                new StubFilteredCliWriter(),
+                new StubBuildCoordinator(),
+                new StubAiCapabilityProbe(),
+                reportWriter,
+                repoRoot);
+
+            var executedNamespaces = new List<string>();
+            var namespaceStep = new NamespaceCaptureStep(executedNamespaces);
+            var runner = new global::PipelineRunner.PipelineRunner(
+                new StepRegistry([namespaceStep]),
+                contextFactory,
+                brandMappingLoader: new StubBrandMappingLoader());
+
+            var request = new PipelineRequest(
+                "all", [1], ".\\generated-all",
+                SkipBuild: true, SkipValidation: false, DryRun: false, SkipChangelogGate: true);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            // UnderscoredNamespaceCliMetadataLoader returns 3 extension namespaces
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Equal(3, executedNamespaces.Count);
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private sealed class NamespaceCaptureStep(List<string> captured)

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -15,6 +15,7 @@ public sealed class PipelineRunner
 
     private readonly StepRegistry _stepRegistry;
     private readonly PipelineContextFactory _contextFactory;
+    private readonly IBrandMappingLoader _brandMappingLoader;
     private readonly IChangelogGate? _changelogGate;
     private readonly IFingerprintGate? _fingerprintGate;
     private readonly IPromptRegressionGate? _promptRegressionGate;
@@ -24,13 +25,15 @@ public sealed class PipelineRunner
         PipelineContextFactory contextFactory,
         IChangelogGate? changelogGate = null,
         IFingerprintGate? fingerprintGate = null,
-        IPromptRegressionGate? promptRegressionGate = null)
+        IPromptRegressionGate? promptRegressionGate = null,
+        IBrandMappingLoader? brandMappingLoader = null)
     {
         _stepRegistry = stepRegistry;
         _contextFactory = contextFactory;
         _changelogGate = changelogGate;
         _fingerprintGate = fingerprintGate;
         _promptRegressionGate = promptRegressionGate;
+        _brandMappingLoader = brandMappingLoader ?? new BrandMappingLoader();
     }
 
     public static PipelineRunner CreateDefault(string? repoRoot = null, TextWriter? output = null, TextWriter? error = null)
@@ -116,7 +119,9 @@ public sealed class PipelineRunner
         context.CliVersion ??= await context.CliMetadataLoader.LoadCliVersionAsync(context.OutputPath, cancellationToken);
 
         var availableNamespaces = await context.CliMetadataLoader.LoadNamespacesAsync(context.OutputPath, cancellationToken);
-        if (!ResolveNamespaces(context, availableNamespaces, out var resolvedNamespaces, out var namespaceError))
+        var brandEntries = await _brandMappingLoader.LoadAsync(context.McpToolsRoot, cancellationToken);
+
+        if (!ResolveNamespaces(context, availableNamespaces, brandEntries, out var resolvedNamespaces, out var namespaceError))
         {
             context.Reports.Error(namespaceError!);
             context.Workspaces.DeleteAll();
@@ -421,31 +426,63 @@ public sealed class PipelineRunner
     private static bool ResolveNamespaces(
         PipelineContext context,
         IReadOnlyList<string> availableNamespaces,
+        IReadOnlyList<BrandMappingEntry> brandEntries,
         out IReadOnlyList<string> resolvedNamespaces,
         out string? error)
     {
-        if (!string.IsNullOrWhiteSpace(context.Request.Namespace))
+        if (string.IsNullOrWhiteSpace(context.Request.Namespace))
         {
-            var normalizedRequest = context.TargetMatcher.Normalize(context.Request.Namespace!);
-            // Normalize candidates too so underscored names (e.g. "extension_azqr") match their
-            // normalized form ("extension azqr") — the original candidate value is kept for downstream use.
-            var match = availableNamespaces.FirstOrDefault(candidate =>
-                string.Equals(context.TargetMatcher.Normalize(candidate), normalizedRequest, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
+            resolvedNamespaces = availableNamespaces;
+            error = null;
+            return true;
+        }
+
+        var expansion = NamespaceExpander.Expand(context.Request.Namespace, brandEntries, availableNamespaces);
+
+        if (expansion.IsAll)
+        {
+            resolvedNamespaces = expansion.Namespaces;
+            error = null;
+            return true;
+        }
+
+        if (expansion.IsResolved)
+        {
+            if (expansion.IsExpanded)
             {
-                resolvedNamespaces = [match];
-                error = null;
-                return true;
+                context.Reports.Info(
+                    $"Namespace '{context.Request.Namespace}' expanded to {expansion.Namespaces.Count} sub-namespace(s): " +
+                    string.Join(", ", expansion.Namespaces));
             }
 
+            resolvedNamespaces = expansion.Namespaces;
+            error = null;
+            return true;
+        }
+
+        if (expansion.IsSubEntriesNotInCli)
+        {
             resolvedNamespaces = Array.Empty<string>();
-            error = $"Unknown namespace '{context.Request.Namespace}'.";
+            error = $"Namespace prefix '{context.Request.Namespace}' matched brand mapping entries " +
+                    $"({string.Join(", ", expansion.SubEntriesFound)}) but none are available in the CLI namespace list.";
             return false;
         }
 
-        resolvedNamespaces = availableNamespaces;
-        error = null;
-        return true;
+        // Not found in brand mapping — fall back to normalized CLI exact match for backward compatibility
+        var normalizedRequest = context.TargetMatcher.Normalize(context.Request.Namespace!);
+        var cliMatch = availableNamespaces.FirstOrDefault(candidate =>
+            string.Equals(context.TargetMatcher.Normalize(candidate), normalizedRequest, StringComparison.OrdinalIgnoreCase));
+
+        if (cliMatch is not null)
+        {
+            resolvedNamespaces = [cliMatch];
+            error = null;
+            return true;
+        }
+
+        resolvedNamespaces = Array.Empty<string>();
+        error = $"Unknown namespace '{context.Request.Namespace}'.";
+        return false;
     }
 
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingEntry.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingEntry.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Represents a single entry from <c>mcp-tools/data/brand-to-server-mapping.json</c>.
+/// The file is an array of these entries.
+/// </summary>
+public sealed record BrandMappingEntry(
+    [property: JsonPropertyName("mcpServerName")] string McpServerName,
+    [property: JsonPropertyName("brandName")] string BrandName,
+    [property: JsonPropertyName("shortName")] string ShortName,
+    [property: JsonPropertyName("fileName")] string FileName,
+    [property: JsonPropertyName("composition")] string? Composition = null,
+    [property: JsonPropertyName("mergeGroup")] string? MergeGroup = null,
+    [property: JsonPropertyName("mergeOrder")] int? MergeOrder = null,
+    [property: JsonPropertyName("mergeRole")] string? MergeRole = null);

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+
+namespace PipelineRunner.Services;
+
+public sealed class BrandMappingLoader : IBrandMappingLoader
+{
+    private const string RelativePath = "data/brand-to-server-mapping.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken)
+    {
+        var filePath = Path.Combine(mcpToolsRoot, RelativePath);
+        if (!File.Exists(filePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(filePath);
+        var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
+        return entries ?? [];
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/BrandMappingLoader.cs
@@ -20,7 +20,16 @@ public sealed class BrandMappingLoader : IBrandMappingLoader
         }
 
         await using var stream = File.OpenRead(filePath);
-        var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
-        return entries ?? [];
+
+        try
+        {
+            var entries = await JsonSerializer.DeserializeAsync<BrandMappingEntry[]>(stream, JsonOptions, cancellationToken);
+            return entries ?? [];
+        }
+        catch (JsonException exception)
+        {
+            Console.Error.WriteLine($"Warning: Failed to parse brand mapping file '{filePath}': {exception.Message}");
+            return [];
+        }
     }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/IBrandMappingLoader.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/IBrandMappingLoader.cs
@@ -1,0 +1,10 @@
+namespace PipelineRunner.Services;
+
+public interface IBrandMappingLoader
+{
+    /// <summary>
+    /// Loads all entries from <c>mcp-tools/data/brand-to-server-mapping.json</c>.
+    /// Returns an empty list if the file does not exist.
+    /// </summary>
+    Task<IReadOnlyList<BrandMappingEntry>> LoadAsync(string mcpToolsRoot, CancellationToken cancellationToken);
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
@@ -1,0 +1,119 @@
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Resolves a requested namespace string to a list of concrete CLI namespace names,
+/// applying prefix-based expansion for decomposed (split) namespaces and supporting
+/// the special <c>all</c> keyword.
+/// </summary>
+public static class NamespaceExpander
+{
+    private const string AllKeyword = "all";
+
+    /// <summary>
+    /// Expands the requested namespace to a concrete list of CLI namespace names.
+    /// </summary>
+    /// <param name="requestedNamespace">Value of <c>--namespace</c>, or <c>null</c> to process all.</param>
+    /// <param name="brandEntries">All entries from <c>brand-to-server-mapping.json</c>.</param>
+    /// <param name="availableCliNamespaces">Namespaces reported by the installed MCP CLI.</param>
+    /// <returns>An <see cref="NamespaceExpansionResult"/> describing the outcome.</returns>
+    public static NamespaceExpansionResult Expand(
+        string? requestedNamespace,
+        IReadOnlyList<BrandMappingEntry> brandEntries,
+        IReadOnlyList<string> availableCliNamespaces)
+    {
+        // null or "all" → all available CLI namespaces
+        if (requestedNamespace is null
+            || string.Equals(requestedNamespace.Trim(), AllKeyword, StringComparison.OrdinalIgnoreCase))
+        {
+            return NamespaceExpansionResult.All(availableCliNamespaces);
+        }
+
+        var normalized = requestedNamespace.Trim();
+
+        // Exact match in brand mapping → return it as-is (standalone/existing behavior)
+        var exactMatch = brandEntries.FirstOrDefault(e =>
+            string.Equals(e.McpServerName, normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (exactMatch is not null)
+        {
+            return NamespaceExpansionResult.Resolved([exactMatch.McpServerName], isExpanded: false);
+        }
+
+        // Prefix match: namespace is a parent prefix — find all "namespace_*" sub-entries
+        var prefix = normalized + "_";
+        var subEntries = brandEntries
+            .Where(e => e.McpServerName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(e => e.McpServerName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (subEntries.Length > 0)
+        {
+            // Keep only sub-entries that are actually available in the CLI namespace list
+            var availableSet = new HashSet<string>(availableCliNamespaces, StringComparer.OrdinalIgnoreCase);
+            var resolved = subEntries
+                .Where(e => availableSet.Contains(e.McpServerName))
+                .Select(e => e.McpServerName)
+                .ToArray();
+
+            if (resolved.Length == 0)
+            {
+                // Brand mapping knows about them but CLI does not expose them yet
+                return NamespaceExpansionResult.SubEntriesNotInCli(
+                    normalized,
+                    subEntries.Select(e => e.McpServerName).ToArray());
+            }
+
+            return NamespaceExpansionResult.Resolved(resolved, isExpanded: true);
+        }
+
+        // Not found in brand mapping at all — signal caller to apply CLI exact-match fallback
+        return NamespaceExpansionResult.NotInBrandMapping(normalized);
+    }
+}
+
+/// <summary>
+/// Outcome of a <see cref="NamespaceExpander.Expand"/> call.
+/// </summary>
+public sealed class NamespaceExpansionResult
+{
+    private NamespaceExpansionResult() { }
+
+    /// <summary>Resolved namespace names to process (populated for All and Resolved outcomes).</summary>
+    public IReadOnlyList<string> Namespaces { get; private init; } = [];
+
+    /// <summary>True when the result covers all available CLI namespaces.</summary>
+    public bool IsAll { get; private init; }
+
+    /// <summary>True when one or more specific namespaces were resolved.</summary>
+    public bool IsResolved { get; private init; }
+
+    /// <summary>
+    /// True when the input was a parent prefix and multiple sub-namespaces were expanded.
+    /// Always false for exact-match and all-namespace cases.
+    /// </summary>
+    public bool IsExpanded { get; private init; }
+
+    /// <summary>True when the input was not found in brand-to-server-mapping.json.</summary>
+    public bool IsNotInBrandMapping { get; private init; }
+
+    /// <summary>True when brand-to-server-mapping.json has sub-entries but none are in the CLI list.</summary>
+    public bool IsSubEntriesNotInCli { get; private init; }
+
+    /// <summary>The namespace string that was requested (populated for error outcomes).</summary>
+    public string? RequestedNamespace { get; private init; }
+
+    /// <summary>Sub-entries found in brand mapping but absent from the CLI (populated for SubEntriesNotInCli).</summary>
+    public IReadOnlyList<string> SubEntriesFound { get; private init; } = [];
+
+    public static NamespaceExpansionResult All(IReadOnlyList<string> namespaces)
+        => new() { IsAll = true, IsResolved = true, Namespaces = namespaces };
+
+    public static NamespaceExpansionResult Resolved(IReadOnlyList<string> namespaces, bool isExpanded)
+        => new() { IsResolved = true, IsExpanded = isExpanded, Namespaces = namespaces };
+
+    public static NamespaceExpansionResult SubEntriesNotInCli(string requested, IReadOnlyList<string> subEntriesFound)
+        => new() { IsSubEntriesNotInCli = true, RequestedNamespace = requested, SubEntriesFound = subEntriesFound };
+
+    public static NamespaceExpansionResult NotInBrandMapping(string requested)
+        => new() { IsNotInBrandMapping = true, RequestedNamespace = requested };
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/NamespaceExpander.cs
@@ -42,6 +42,7 @@ public static class NamespaceExpander
         // Prefix match: namespace is a parent prefix — find all "namespace_*" sub-entries
         var prefix = normalized + "_";
         var subEntries = brandEntries
+            .Where(e => e.McpServerName is not null)
             .Where(e => e.McpServerName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             .OrderBy(e => e.McpServerName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -51,6 +52,7 @@ public static class NamespaceExpander
             // Keep only sub-entries that are actually available in the CLI namespace list
             var availableSet = new HashSet<string>(availableCliNamespaces, StringComparer.OrdinalIgnoreCase);
             var resolved = subEntries
+                .Where(e => e.McpServerName is not null)
                 .Where(e => availableSet.Contains(e.McpServerName))
                 .Select(e => e.McpServerName)
                 .ToArray();

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -15,7 +15,7 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             "Generate tool-family article",
             FailurePolicy.Fatal,
             dependsOn: [3],
-            postValidators: [new ToolFamilyPostAssemblyValidator()],
+            postValidators: [new ToolFamilyPostAssemblyValidator(), new CompositionOutputValidator()],
             requiresAiConfiguration: true,
             usesIsolatedWorkspace: true,
             expectedOutputs: ["tool-family-metadata", "tool-family-related", "tool-family", "reports"],

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/CompositionOutputValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/CompositionOutputValidator.cs
@@ -84,6 +84,16 @@ public sealed class CompositionOutputValidator : IPostValidator
         string outputPath,
         IReadOnlyList<BrandMappingEntry> entries)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        if (!Directory.Exists(outputPath))
+        {
+            return new CompositionValidationResult(
+                false,
+                [new CompositionIssue("directory", "N/A", $"Output directory does not exist: {outputPath}")]);
+        }
+
         var toolFamilyDir = Path.Combine(outputPath, "tool-family");
         var issues = new List<CompositionIssue>();
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/CompositionOutputValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/CompositionOutputValidator.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Validation;
+
+/// <summary>
+/// Post-assembly gate that confirms output files in <c>tool-family/</c> match
+/// the composition declarations in <c>brand-to-server-mapping.json</c>.
+///
+/// Composition rules:
+///   standalone — exactly one tool-family file with the expected FileName.
+///   split      — each namespace produces its own file (same per-file check as standalone).
+///   merge      — all group members produce intermediate files; merged output keyed
+///                by <c>mergeGroup</c> must exist.
+///
+/// Complementary to <see cref="ToolFamilyPostAssemblyValidator"/> (which validates
+/// article content and tool counts). This validator checks file-level composition.
+/// </summary>
+public sealed class CompositionOutputValidator : IPostValidator
+{
+    /// <summary>Context key for injecting brand mapping entries in tests.</summary>
+    internal const string BrandEntriesContextKey = "CompositionOutputValidator.BrandEntries";
+
+    public string Name => "CompositionOutputValidator";
+
+    /// <summary>
+    /// Per-namespace pipeline validator. Validates that the current namespace produced
+    /// the tool-family file declared in its brand mapping.
+    /// </summary>
+    public async ValueTask<ValidatorResult> ValidateAsync(
+        PipelineContext context,
+        IPipelineStep step,
+        CancellationToken cancellationToken)
+    {
+        var familyName = ResolveFamilyName(context);
+        var outputFileName = ResolveOutputFileName(context, familyName);
+
+        if (string.IsNullOrWhiteSpace(outputFileName))
+            return new ValidatorResult(Name, true, []);
+
+        var toolFamilyDir = Path.Combine(context.OutputPath, "tool-family");
+        var warnings = new List<string>();
+
+        // Load brand mapping entries to determine expected composition behaviour.
+        var entries = await LoadEntriesAsync(context, cancellationToken);
+        var entry = FindEntry(entries, familyName);
+
+        // Derive expected filename: prefer brand mapping, fall back to outputFileName from context.
+        var expectedFileName = !string.IsNullOrEmpty(entry?.FileName) ? entry.FileName : outputFileName;
+        var composition = entry?.Composition?.ToLowerInvariant() ?? "standalone";
+
+        switch (composition)
+        {
+            case "standalone":
+            case "split":
+            case "merge":
+                // All three types require the per-namespace output file to exist.
+                if (!File.Exists(Path.Combine(toolFamilyDir, $"{expectedFileName}.md")))
+                {
+                    warnings.Add(
+                        $"CompositionOutputValidator [{composition}]: expected file not found: " +
+                        $"tool-family/{expectedFileName}.md (namespace: {familyName})");
+                }
+                break;
+        }
+
+        return new ValidatorResult(Name, warnings.Count == 0, warnings);
+    }
+
+    // ── Static validation ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Validates all composition entries against the output directory.
+    /// Use this for post-run checks, standalone CLI commands, and unit tests.
+    /// </summary>
+    /// <param name="outputPath">Root output path containing the <c>tool-family/</c> subdirectory.</param>
+    /// <param name="entries">Brand mapping entries from <c>brand-to-server-mapping.json</c>.</param>
+    /// <returns>A result object describing any missing or mismatched files.</returns>
+    public static CompositionValidationResult Validate(
+        string outputPath,
+        IReadOnlyList<BrandMappingEntry> entries)
+    {
+        var toolFamilyDir = Path.Combine(outputPath, "tool-family");
+        var issues = new List<CompositionIssue>();
+
+        // ── Standalone ────────────────────────────────────────────────────────
+        foreach (var entry in entries.Where(IsStandalone))
+        {
+            var file = Path.Combine(toolFamilyDir, $"{entry.FileName}.md");
+            if (!File.Exists(file))
+            {
+                issues.Add(new CompositionIssue(
+                    entry.McpServerName, "standalone",
+                    $"Expected file not found: tool-family/{entry.FileName}.md"));
+            }
+        }
+
+        // ── Split ─────────────────────────────────────────────────────────────
+        foreach (var entry in entries.Where(IsSplit))
+        {
+            var file = Path.Combine(toolFamilyDir, $"{entry.FileName}.md");
+            if (!File.Exists(file))
+            {
+                issues.Add(new CompositionIssue(
+                    entry.McpServerName, "split",
+                    $"Expected split file not found: tool-family/{entry.FileName}.md"));
+            }
+        }
+
+        // ── Merge groups ──────────────────────────────────────────────────────
+        var mergeGroups = entries
+            .Where(e => IsMerge(e) && !string.IsNullOrEmpty(e.MergeGroup))
+            .GroupBy(e => e.MergeGroup!, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in mergeGroups)
+        {
+            // 1. Each group member must have produced its intermediate file.
+            foreach (var member in group)
+            {
+                var memberFile = Path.Combine(toolFamilyDir, $"{member.FileName}.md");
+                if (!File.Exists(memberFile))
+                {
+                    issues.Add(new CompositionIssue(
+                        member.McpServerName, "merge-intermediate",
+                        $"Merge group '{group.Key}': intermediate file not found: " +
+                        $"tool-family/{member.FileName}.md"));
+                }
+            }
+
+            // 2. Merged output (keyed by mergeGroup name) must exist.
+            var mergedFile = Path.Combine(toolFamilyDir, $"{group.Key}.md");
+            if (!File.Exists(mergedFile))
+            {
+                issues.Add(new CompositionIssue(
+                    group.Key, "merge-output",
+                    $"Merge group '{group.Key}': merged output not found: " +
+                    $"tool-family/{group.Key}.md"));
+            }
+        }
+
+        return new CompositionValidationResult(issues.Count == 0, issues);
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    private static bool IsStandalone(BrandMappingEntry e)
+        => string.IsNullOrEmpty(e.Composition)
+           || string.Equals(e.Composition, "standalone", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSplit(BrandMappingEntry e)
+        => string.Equals(e.Composition, "split", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMerge(BrandMappingEntry e)
+        => string.Equals(e.Composition, "merge", StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveFamilyName(PipelineContext context)
+    {
+        if (context.Items.TryGetValue(ToolFamilyPostAssemblyValidator.FamilyNameContextKey, out var v)
+            && v is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            return s;
+        }
+
+        if (context.Items.TryGetValue("Namespace", out v) && v is string ns && !string.IsNullOrWhiteSpace(ns))
+        {
+            return ns.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0].ToLowerInvariant();
+        }
+
+        return string.Empty;
+    }
+
+    private static string ResolveOutputFileName(PipelineContext context, string familyName)
+    {
+        if (context.Items.TryGetValue(ToolFamilyPostAssemblyValidator.OutputFileNameContextKey, out var v)
+            && v is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            return s;
+        }
+
+        return familyName;
+    }
+
+    private static BrandMappingEntry? FindEntry(IReadOnlyList<BrandMappingEntry> entries, string familyName)
+        => entries.FirstOrDefault(e =>
+            string.Equals(e.McpServerName, familyName, StringComparison.OrdinalIgnoreCase));
+
+    private static async Task<IReadOnlyList<BrandMappingEntry>> LoadEntriesAsync(
+        PipelineContext context, CancellationToken cancellationToken)
+    {
+        // Allow test injection via context items.
+        if (context.Items.TryGetValue(BrandEntriesContextKey, out var v)
+            && v is IReadOnlyList<BrandMappingEntry> injected)
+        {
+            return injected;
+        }
+
+        var loader = new BrandMappingLoader();
+        return await loader.LoadAsync(context.McpToolsRoot, cancellationToken);
+    }
+}
+
+// ── Result types ───────────────────────────────────────────────────────────────
+
+/// <summary>
+/// An issue found during composition output validation.
+/// </summary>
+/// <param name="Identifier">McpServerName or mergeGroup key that has the issue.</param>
+/// <param name="IssueType">One of: standalone, split, merge-intermediate, merge-output.</param>
+/// <param name="Message">Human-readable description of what is missing or wrong.</param>
+public sealed record CompositionIssue(string Identifier, string IssueType, string Message);
+
+/// <summary>
+/// Result of a full-composition validation run via <see cref="CompositionOutputValidator.Validate"/>.
+/// </summary>
+/// <param name="Success"><c>true</c> if all expected files are present.</param>
+/// <param name="Issues">One entry per missing or mismatched file.</param>
+public sealed record CompositionValidationResult(bool Success, IReadOnlyList<CompositionIssue> Issues);


### PR DESCRIPTION
## Summary

Closes #601

Adds CompositionOutputValidator as a post-assembly gate that validates generated output files match the \composition\ declarations in \rand-to-server-mapping.json\.

## Changes

### New: \CompositionOutputValidator.cs\
- Implements \IPostValidator\ for per-namespace pipeline use
- Static \Validate(outputPath, entries)\ method for CLI/test use
- Validates all three composition types:
  - **standalone** (54 entries): each \mcpServerName\ → exactly one \	ool-family/{fileName}.md\
  - **merge** (4 entries, 2 groups): each member's individual file must exist
  - **split** (3 entries): each entry's own \	ool-family/{fileName}.md\ must exist
- Returns \CompositionValidationResult\ with \IReadOnlyList<CompositionIssue>\
- Context key injection for test use (\BrandEntriesContextKey\)

### New: \CompositionOutputValidatorTests.cs\
17 unit tests covering:
- All 6 required composition scenarios (standalone pass/fail, merge pass/partial/merged-output-missing, split pass/fail)
- Edge cases: empty entries, null composition, multiple missing, merge without mergeGroup
- Per-namespace \ValidateAsync\ tests: standalone success/failure, merge secondary, unknown namespace, validator name

### Modified: \ToolFamilyCleanupStep.cs\
Registers the new validator alongside \ToolFamilyPostAssemblyValidator\ in the step's post-validators array.

## Test results
All 353 tests pass (\dotnet test\).