### PR TITLE
feat: Phase 3 - CoverageAuditStep + pipeline coverage validation

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
@@ -64,7 +64,7 @@ public class CliArgumentParsingTests
         var result = PipelineCli.Parse(["--namespace", "compute", "--steps", "0,9"]);
 
         Assert.Null(result.Request);
-        Assert.Contains(result.Errors, error => error.Contains("Unsupported step identifiers: 9. Valid step identifiers: 0-7.", StringComparison.Ordinal));
+        Assert.Contains(result.Errors, error => error.Contains("Unsupported step identifiers: 9. Valid step identifiers: 0-8.", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class CliArgumentParsingTests
 
         Assert.False(handlerCalled);
         Assert.Equal(global::PipelineRunner.PipelineRunner.InvalidArgumentsExitCode, exitCode);
-        Assert.Contains("Unsupported step identifiers: 9. Valid step identifiers: 0-7.", errorWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unsupported step identifiers: 9. Valid step identifiers: 0-8.", errorWriter.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CoverageAuditStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CoverageAuditStepTests.cs
@@ -10,78 +10,83 @@ using Xunit;
 namespace PipelineRunner.Tests.Unit;
 
 /// <summary>
-/// Unit tests for <see cref="ArticleHealthValidatorStep"/>.
-/// Each test wires a fully-resolved <see cref="PipelineContext"/> so the step
-/// runs its Execute path against a controlled file system and a
-/// <see cref="RecordingProcessRunner"/> or custom stub.
+/// Unit tests for <see cref="CoverageAuditStep"/>.
+/// Mirrors the <see cref="ArticleHealthValidatorStepTests"/> pattern with controlled
+/// file system and custom <see cref="IProcessRunner"/> stubs.
 /// </summary>
-public class ArticleHealthValidatorStepTests
+public class CoverageAuditStepTests
 {
     // ── Step contract ────────────────────────────────────────────────────────
 
     [Fact]
     public void Step_HasCorrectId()
     {
-        var step = new ArticleHealthValidatorStep();
-        Assert.Equal(7, step.Id);
+        var step = new CoverageAuditStep();
+        Assert.Equal(8, step.Id);
     }
 
     [Fact]
     public void Step_HasNamespaceScope()
     {
-        var step = new ArticleHealthValidatorStep();
+        var step = new CoverageAuditStep();
         Assert.Equal(StepScope.Namespace, step.Scope);
     }
 
     [Fact]
-    public void Step_DependsOnStep4()
+    public void Step_DependsOnStep0And4()
     {
-        var step = new ArticleHealthValidatorStep();
+        var step = new CoverageAuditStep();
+        Assert.Contains(0, step.DependsOn);
         Assert.Contains(4, step.DependsOn);
     }
 
     [Fact]
     public void Step_FailurePolicyIsWarn()
     {
-        var step = new ArticleHealthValidatorStep();
+        var step = new CoverageAuditStep();
         Assert.Equal(FailurePolicy.Warn, step.FailurePolicy);
     }
 
-    // ── No tool-family articles found ────────────────────────────────────────
+    // ── Missing cli-output.json ──────────────────────────────────────────────
 
     [Fact]
-    public async Task ValidationScriptRunner_BuildArguments_EmptyArticlePaths_DoesNotThrow()
-    {
-        var runner = new ValidationScriptRunner(new RecordingProcessRunner());
-        var request = new ValidationScriptRequest(
-            ScriptPath: "Test-ArticleHealth.ps1",
-            RunId: Guid.NewGuid().ToString(),
-            Namespace: "storage",
-            RepoRoot: Path.GetTempPath(),
-            OutputRoot: Path.GetTempPath(),
-            OutputJsonPath: Path.Combine(Path.GetTempPath(), "article-health.json"),
-            ArticlePaths: [],
-            AdditionalArguments: new Dictionary<string, string>());
-
-        // Empty ArticlePaths no longer throws — coverage step uses AdditionalArguments instead
-        var result = await runner.RunAsync(request, CancellationToken.None);
-        Assert.NotNull(result);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_NoToolFamilyArticles_ReturnsFalseWithWarning()
+    public async Task ExecuteAsync_NoCliOutput_ReturnsFalseWithWarning()
     {
         var env = SetupTestEnvironment();
         try
         {
-            // tool-family directory is intentionally empty
-            var step = new ArticleHealthValidatorStep();
+            // cli/cli-output.json is intentionally missing
+            CreateArticlesDirectory(env);
+
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, new RecordingProcessRunner());
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("No tool-family article files found"));
+            Assert.Contains(result.Warnings, w => w.Contains("CLI output not found") || w.Contains("cli-output.json"));
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── Missing articles directory ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_NoArticlesDir_ReturnsFalseWithWarning()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            // Create cli-output.json but no tool-family directory
+            CreateCliOutput(env);
+
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, new RecordingProcessRunner());
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, w => w.Contains("Articles directory not found") || w.Contains("tool-family"));
         }
         finally { TearDown(env); }
     }
@@ -94,10 +99,11 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
-            // PowerShell exits 1, writes no JSON
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new FailingProcessRunner(exitCode: 1);
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
@@ -108,7 +114,7 @@ public class ArticleHealthValidatorStepTests
         finally { TearDown(env); }
     }
 
-    // ── Missing JSON artifact (script succeeds but writes no file) ───────────
+    // ── Script succeeds but no artifact ──────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_ScriptSucceedsButNoJson_ReturnsFalseWithArtifactError()
@@ -116,21 +122,22 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
-            // Exit 0 but no JSON written
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new SucceedingProcessRunner();
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("artifact") || w.Contains("JSON") || w.Contains("missing") || w.Contains("not written"));
+            Assert.Contains(result.Warnings, w => w.Contains("artifact") || w.Contains("JSON") || w.Contains("not written"));
         }
         finally { TearDown(env); }
     }
 
-    // ── Malformed JSON artifact ───────────────────────────────────────────────
+    // ── Malformed JSON artifact ──────────────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_MalformedJson_ReturnsFalseWithArtifactError()
@@ -138,9 +145,11 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
-            var runner = new ArtifactWritingProcessRunner("THIS IS NOT JSON");
-            var step = new ArticleHealthValidatorStep();
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new ArtifactWritingProcessRunner("NOT VALID JSON!!!");
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
@@ -151,30 +160,7 @@ public class ArticleHealthValidatorStepTests
         finally { TearDown(env); }
     }
 
-    // ── RunId mismatch ────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task ExecuteAsync_RunIdMismatch_ReturnsFalseWithArtifactError()
-    {
-        var env = SetupTestEnvironment();
-        try
-        {
-            CreateToolFamilyArticle(env, "storage.md");
-            // Write an artifact with a different runId
-            var wrongRunId = Guid.NewGuid().ToString();
-            var runner = new ArtifactWritingProcessRunner(BuildValidArtifactJson(wrongRunId, "storage", "warn"));
-            var step = new ArticleHealthValidatorStep();
-            var context = await BuildContextAsync(env, runner);
-
-            var result = await step.ExecuteAsync(context, CancellationToken.None);
-
-            Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("mismatch") || w.Contains("run-id") || w.Contains("Run-id"));
-        }
-        finally { TearDown(env); }
-    }
-
-    // ── Successful execution — pass verdict ──────────────────────────────────
+    // ── Pass verdict ─────────────────────────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_PassVerdict_ReturnsTrue()
@@ -182,9 +168,11 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("pass");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
@@ -194,7 +182,7 @@ public class ArticleHealthValidatorStepTests
         finally { TearDown(env); }
     }
 
-    // ── Warn verdict in warn gate mode ────────────────────────────────────────
+    // ── Warn verdict in warn gate mode ───────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_WarnVerdict_WarnMode_ReturnsTrue()
@@ -202,20 +190,21 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment(gateMode: "warn");
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("warn");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
-            // In warn mode, warn findings are non-blocking
             Assert.True(result.Success);
         }
         finally { TearDown(env); }
     }
 
-    // ── Warn verdict in block gate mode ───────────────────────────────────────
+    // ── Warn verdict in block gate mode ──────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_WarnVerdict_BlockMode_ReturnsFalse()
@@ -223,20 +212,21 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment(gateMode: "block");
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("warn");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
-            // In block mode, warn findings are blocking
             Assert.False(result.Success);
         }
         finally { TearDown(env); }
     }
 
-    // ── Fail verdict ──────────────────────────────────────────────────────────
+    // ── Fail verdict ─────────────────────────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_FailVerdict_ReturnsFalse()
@@ -244,20 +234,22 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("fail");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("fail"));
+            Assert.Contains(result.Warnings, w => w.Contains("fail") || w.Contains("missing tools"));
         }
         finally { TearDown(env); }
     }
 
-    // ── Artifact written and path recorded in outputs ─────────────────────────
+    // ── Artifact path in outputs ─────────────────────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_PassVerdict_ArtifactPathInOutputs()
@@ -265,20 +257,22 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("pass");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Contains(result.Outputs, o => o.Contains("article-health.json"));
+            Assert.Contains(result.Outputs, o => o.Contains("coverage-audit.json"));
         }
         finally { TearDown(env); }
     }
 
-    // ── Missing gate config defaults to warn mode ─────────────────────────────
+    // ── Missing gate config defaults to warn mode ────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_MissingGateConfig_DefaultsToWarnMode()
@@ -286,20 +280,22 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment(writeGateConfig: false);
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
             var runner = new RunIdCapturingProcessRunner("warn");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
-            // Without gate config, should default to warn mode → warn verdict non-blocking
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
+            // Without gate config, defaults to warn mode → warn verdict non-blocking
             Assert.True(result.Success);
         }
         finally { TearDown(env); }
     }
 
-    // ── Stale artifact is cleaned before execution ────────────────────────────
+    // ── Stale artifact cleaned before execution ──────────────────────────────
 
     [Fact]
     public async Task ExecuteAsync_StaleArtifactPreExists_IsCleanedBeforeRun()
@@ -307,26 +303,136 @@ public class ArticleHealthValidatorStepTests
         var env = SetupTestEnvironment();
         try
         {
-            CreateToolFamilyArticle(env, "storage.md");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
 
-            // Write a stale artifact file before running
             var validationDir = Path.Combine(env.OutputPath, "validation");
             Directory.CreateDirectory(validationDir);
-            var staleArtifactPath = Path.Combine(validationDir, "article-health.json");
+            var staleArtifactPath = Path.Combine(validationDir, "coverage-audit.json");
             File.WriteAllText(staleArtifactPath, "STALE");
 
             var runner = new RunIdCapturingProcessRunner("pass");
-            var step = new ArticleHealthValidatorStep();
+            var step = new CoverageAuditStep();
             var context = await BuildContextAsync(env, runner);
 
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
-            // Stale file should be gone and replaced by fresh artifact
             Assert.True(result.Success);
             Assert.True(File.Exists(staleArtifactPath));
             Assert.NotEqual("STALE", File.ReadAllText(staleArtifactPath));
         }
         finally { TearDown(env); }
+    }
+
+    // ── Validation summary markdown is written ───────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_PassVerdict_WritesSummaryMarkdown()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new RunIdCapturingProcessRunner("pass");
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            await step.ExecuteAsync(context, CancellationToken.None);
+
+            var summaryPath = Path.Combine(env.OutputPath, "validation", "validation-summary.md");
+            Assert.True(File.Exists(summaryPath));
+            var content = File.ReadAllText(summaryPath);
+            Assert.Contains("Coverage Audit", content);
+            Assert.Contains("pass", content);
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── ValidationScriptRunner.BuildArguments tests ──────────────────────────
+
+    [Fact]
+    public void BuildArguments_NullArticlePaths_WithAdditionalArgs_EmitsOnlyAdditionalArgs()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Scan-McpToolCoverage.ps1",
+            RunId: "test-run-id",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/coverage-audit.json",
+            AdditionalArguments: new Dictionary<string, string>
+            {
+                ["-ToolsJsonPath"] = "/output/cli/cli-output.json",
+                ["-ArticlesDir"] = "/output/tool-family"
+            });
+
+        var args = ValidationScriptRunner.BuildArguments(request);
+
+        Assert.Contains("-ToolsJsonPath", args);
+        Assert.Contains("/output/cli/cli-output.json", args);
+        Assert.Contains("-ArticlesDir", args);
+        Assert.Contains("/output/tool-family", args);
+        Assert.Contains("-RunId", args);
+        Assert.Contains("test-run-id", args);
+        Assert.DoesNotContain("-ArticlePath", args);
+    }
+
+    [Fact]
+    public void BuildArguments_SingleArticlePath_EmitsArticlePath()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Test-ArticleHealth.ps1",
+            RunId: "run-1",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/article-health.json",
+            ArticlePaths: ["/output/tool-family/storage.md"]);
+
+        var args = ValidationScriptRunner.BuildArguments(request);
+
+        Assert.Contains("-ArticlePath", args);
+        Assert.Contains("/output/tool-family/storage.md", args);
+        Assert.DoesNotContain("-ArticlesDir", args);
+    }
+
+    [Fact]
+    public void BuildArguments_MultipleArticlePaths_EmitsArticlesDir()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Test-ArticleHealth.ps1",
+            RunId: "run-1",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/article-health.json",
+            ArticlePaths: ["/output/tool-family/storage.md", "/output/tool-family/storage-blob.md"]);
+
+        var args = ValidationScriptRunner.BuildArguments(request);
+
+        Assert.Contains("-ArticlesDir", args);
+        Assert.DoesNotContain("-ArticlePath", args);
+    }
+
+    [Fact]
+    public void BuildArguments_ArticlePathsAndAdditionalArticlesDir_Throws()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Test-ArticleHealth.ps1",
+            RunId: "run-1",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/article-health.json",
+            ArticlePaths: ["/output/tool-family/storage.md"],
+            AdditionalArguments: new Dictionary<string, string>
+            {
+                ["-ArticlesDir"] = "/output/tool-family"
+            });
+
+        Assert.Throws<ArgumentException>(() => ValidationScriptRunner.BuildArguments(request));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -341,7 +447,7 @@ public class ArticleHealthValidatorStepTests
         string gateMode = "warn",
         bool writeGateConfig = true)
     {
-        var root = Path.Combine(Path.GetTempPath(), $"ah-step-test-{Guid.NewGuid():N}");
+        var root = Path.Combine(Path.GetTempPath(), $"cov-step-test-{Guid.NewGuid():N}");
         var mcpTools = Path.Combine(root, "mcp-tools");
         var output = Path.Combine(root, "generated-storage");
         var dataDir = Path.Combine(mcpTools, "data");
@@ -358,17 +464,26 @@ public class ArticleHealthValidatorStepTests
             File.WriteAllText(gateConfigPath, $"{{\"schemaVersion\":\"1.0\",\"gateMode\":\"{gateMode}\"}}");
         }
 
-        // Create a minimal solution file to satisfy the pipeline runner
         File.WriteAllText(Path.Combine(root, "mcp-doc-generation.sln"), string.Empty);
 
         return new TestEnvironment(root, mcpTools, output, gateConfigPath);
     }
 
-    private static void CreateToolFamilyArticle(TestEnvironment env, string fileName)
+    private static void CreateCliOutput(TestEnvironment env)
+    {
+        var cliDir = Path.Combine(env.OutputPath, "cli");
+        Directory.CreateDirectory(cliDir);
+        var cliOutput = new { results = new[] { new { command = "storage list" } } };
+        File.WriteAllText(
+            Path.Combine(cliDir, "cli-output.json"),
+            JsonSerializer.Serialize(cliOutput));
+    }
+
+    private static void CreateArticlesDirectory(TestEnvironment env)
     {
         var dir = Path.Combine(env.OutputPath, "tool-family");
         Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, fileName), "# Test Article\n\nContent.");
+        File.WriteAllText(Path.Combine(dir, "storage.md"), "# Storage\n\nContent.");
     }
 
     private static void TearDown(TestEnvironment env)
@@ -393,7 +508,7 @@ public class ArticleHealthValidatorStepTests
             env.RepoRoot);
 
         var context = await contextFactory.CreateAsync(
-            new PipelineRequest("storage", [7], env.OutputPath,
+            new PipelineRequest("storage", [8], env.OutputPath,
                 SkipBuild: true, SkipValidation: false, DryRun: false,
                 SkipChangelogGate: true),
             CancellationToken.None);
@@ -411,13 +526,19 @@ public class ArticleHealthValidatorStepTests
             @namespace = ns,
             generatedAt = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
             verdict,
-            articleFiles = new[] { "storage.md" },
-            filesChecked = 1,
-            summary = new { pass = verdict == "pass" ? 5 : 4, warn = verdict == "warn" ? 1 : 0, fail = verdict == "fail" ? 1 : 0 },
             checks = new[]
             {
-                new { name = "frontmatter.ms.date", status = verdict == "fail" ? "fail" : "pass", detail = "05/26/2026" },
-                new { name = "tokens.placeholder-detected", status = verdict == "warn" ? "warn" : "pass", detail = verdict == "warn" ? "Found 1 unresolved placeholder" : "" },
+                new { name = "tools_coverage", status = verdict == "fail" ? "fail" : "pass", detail = "5/5 tools documented" },
+                new { name = "params_coverage", status = verdict == "warn" ? "warn" : "pass", detail = "20/22 params documented" },
+                new { name = "annotation_accuracy", status = "pass", detail = "0 mismatches" },
+            },
+            summary = new
+            {
+                tools_documented = 5,
+                tools_missing = verdict == "fail" ? 2 : 0,
+                params_documented = 20,
+                params_missing = verdict == "warn" ? 2 : 0,
+                annotation_mismatches = 0,
             }
         };
         return JsonSerializer.Serialize(obj);
@@ -425,9 +546,6 @@ public class ArticleHealthValidatorStepTests
 
     // ── Process runner stubs ──────────────────────────────────────────────────
 
-    /// <summary>
-    /// Returns a non-zero exit code and writes no JSON artifact.
-    /// </summary>
     private sealed class FailingProcessRunner(int exitCode) : IProcessRunner
     {
         public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
@@ -445,9 +563,6 @@ public class ArticleHealthValidatorStepTests
             => ValueTask.FromResult(new ProcessExecutionResult("pwsh", ["-File", scriptPath], workingDirectory, exitCode, string.Empty, "Script failed.", TimeSpan.Zero));
     }
 
-    /// <summary>
-    /// Exits 0 but optionally does not write an artifact.
-    /// </summary>
     private sealed class SucceedingProcessRunner() : IProcessRunner
     {
         public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
@@ -457,16 +572,9 @@ public class ArticleHealthValidatorStepTests
         public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string p, IEnumerable<string> a, bool nb, string wd, CancellationToken ct) => RunAsync(new ProcessSpec("dotnet", [], wd), ct);
 
         public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
-        {
-            // Does not write the artifact — tests the missing-artifact path
-            return ValueTask.FromResult(new ProcessExecutionResult("pwsh", ["-File", scriptPath], workingDirectory, 0, "", "", TimeSpan.Zero));
-        }
+            => ValueTask.FromResult(new ProcessExecutionResult("pwsh", ["-File", scriptPath], workingDirectory, 0, "", "", TimeSpan.Zero));
     }
 
-    /// <summary>
-    /// Writes a fixed JSON string as the artifact, regardless of content validity.
-    /// Used to test malformed JSON and run-id mismatch paths.
-    /// </summary>
     private sealed class ArtifactWritingProcessRunner(string artifactContent) : IProcessRunner
     {
         public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
@@ -478,7 +586,7 @@ public class ArticleHealthValidatorStepTests
         public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
         {
             var argList = arguments.ToList();
-            var outputJsonPath = ExtractOutputJsonPath(argList);
+            var outputJsonPath = ExtractArg(argList, "-OutputJson");
             if (outputJsonPath is not null)
             {
                 var dir = Path.GetDirectoryName(outputJsonPath);
@@ -489,22 +597,16 @@ public class ArticleHealthValidatorStepTests
             return ValueTask.FromResult(new ProcessExecutionResult("pwsh", ["-File", scriptPath], workingDirectory, 0, "", "", TimeSpan.Zero));
         }
 
-        private static string? ExtractOutputJsonPath(List<string> args)
+        private static string? ExtractArg(List<string> args, string flag)
         {
             for (var i = 0; i < args.Count - 1; i++)
             {
-                if (args[i] == "-OutputJson") return args[i + 1];
+                if (args[i] == flag) return args[i + 1];
             }
-
             return null;
         }
     }
 
-    /// <summary>
-    /// Captures the <c>-RunId</c> argument from the script invocation and writes a
-    /// valid artifact JSON that echoes that same run-id. This ensures the step's
-    /// run-id verification logic succeeds.
-    /// </summary>
     private sealed class RunIdCapturingProcessRunner(string verdict) : IProcessRunner
     {
         public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
@@ -536,11 +638,7 @@ public class ArticleHealthValidatorStepTests
             {
                 if (args[i] == flag) return args[i + 1];
             }
-
             return null;
         }
     }
 }
-
-
-

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CoverageAuditStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CoverageAuditStepTests.cs
@@ -33,11 +33,12 @@ public class CoverageAuditStepTests
     }
 
     [Fact]
-    public void Step_DependsOnStep0And4()
+    public void Step_DependsOnSteps0_4_7()
     {
         var step = new CoverageAuditStep();
         Assert.Contains(0, step.DependsOn);
         Assert.Contains(4, step.DependsOn);
+        Assert.Contains(7, step.DependsOn);
     }
 
     [Fact]
@@ -435,6 +436,194 @@ public class CoverageAuditStepTests
         Assert.Throws<ArgumentException>(() => ValidationScriptRunner.BuildArguments(request));
     }
 
+    [Fact]
+    public void BuildArguments_ArticlePathsAndAdditionalArticlePath_Throws()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Test-ArticleHealth.ps1",
+            RunId: "run-1",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/article-health.json",
+            ArticlePaths: ["/output/tool-family/storage.md"],
+            AdditionalArguments: new Dictionary<string, string>
+            {
+                ["-ArticlePath"] = "/output/tool-family/storage.md"
+            });
+
+        Assert.Throws<ArgumentException>(() => ValidationScriptRunner.BuildArguments(request));
+    }
+
+    [Fact]
+    public void BuildArguments_EmptyArticlePathsList_SkipsArticleArgs()
+    {
+        var request = new ValidationScriptRequest(
+            ScriptPath: "Test-ArticleHealth.ps1",
+            RunId: "run-1",
+            Namespace: "storage",
+            RepoRoot: "/repo",
+            OutputRoot: "/output",
+            OutputJsonPath: "/output/validation/article-health.json",
+            ArticlePaths: []);
+
+        var args = ValidationScriptRunner.BuildArguments(request);
+
+        Assert.DoesNotContain("-ArticlePath", args);
+        Assert.DoesNotContain("-ArticlesDir", args);
+        Assert.Contains("-RunId", args);
+    }
+
+    // ── Cancellation propagation ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_CancellationRequested_ThrowsOperationCanceled()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new CancellingProcessRunner();
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => step.ExecuteAsync(context, CancellationToken.None).AsTask());
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── Script launch exception ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_ScriptThrowsException_ReturnsFalseWithLaunchError()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new ThrowingProcessRunner(new InvalidOperationException("Process not found"));
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, w => w.Contains("failed to launch") || w.Contains("Process not found"));
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── WriteSummaryMarkdown append path ─────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_ExistingSummary_AppendsWithSeparator()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            // Pre-create summary from Step 7
+            var validationDir = Path.Combine(env.OutputPath, "validation");
+            Directory.CreateDirectory(validationDir);
+            var summaryPath = Path.Combine(validationDir, "validation-summary.md");
+            File.WriteAllText(summaryPath, "# Validation Summary\n\n## Article Health\n\n**Verdict:** pass\n");
+
+            var runner = new RunIdCapturingProcessRunner("pass");
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            await step.ExecuteAsync(context, CancellationToken.None);
+
+            var content = File.ReadAllText(summaryPath);
+            Assert.Contains("Article Health", content);
+            Assert.Contains("---", content);
+            Assert.Contains("Coverage Audit", content);
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── Corrupt gate config ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_CorruptGateConfig_DefaultsToWarnMode()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            // Overwrite gate config with invalid JSON
+            File.WriteAllText(env.GateConfigPath, "NOT VALID JSON {{{");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new RunIdCapturingProcessRunner("warn");
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            // Should fall back to warn mode → warn verdict is non-blocking
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, w => w.Contains("Failed to read gate config"));
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── Invalid gateMode value ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidGateModeValue_DefaultsToWarnMode()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            // Write config with unrecognized gateMode
+            File.WriteAllText(env.GateConfigPath, "{\"gateMode\":\"invalid-mode\"}");
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            var runner = new RunIdCapturingProcessRunner("warn");
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            // Should fall back to warn mode → warn verdict is non-blocking
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, w => w.Contains("Unrecognized gateMode"));
+        }
+        finally { TearDown(env); }
+    }
+
+    // ── Unknown verdict default case ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownVerdict_ReturnsFalse()
+    {
+        var env = SetupTestEnvironment();
+        try
+        {
+            CreateCliOutput(env);
+            CreateArticlesDirectory(env);
+
+            // Write artifact with an unrecognized verdict
+            var runner = new RunIdCapturingProcessRunner("unknown-verdict");
+            var step = new CoverageAuditStep();
+            var context = await BuildContextAsync(env, runner);
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.Success);
+        }
+        finally { TearDown(env); }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private sealed record TestEnvironment(
@@ -640,5 +829,29 @@ public class CoverageAuditStepTests
             }
             return null;
         }
+    }
+
+    private sealed class CancellingProcessRunner : IProcessRunner
+    {
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
+            => ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 0, "", "", TimeSpan.Zero));
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken ct) => RunAsync(new ProcessSpec("dotnet", [], "."), ct);
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string p, IEnumerable<string> a, bool nb, string wd, CancellationToken ct) => RunAsync(new ProcessSpec("dotnet", [], wd), ct);
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
+            => throw new OperationCanceledException("Cancellation requested");
+    }
+
+    private sealed class ThrowingProcessRunner(Exception exception) : IProcessRunner
+    {
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken ct)
+            => ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 0, "", "", TimeSpan.Zero));
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken ct) => RunAsync(new ProcessSpec("dotnet", [], "."), ct);
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string p, IEnumerable<string> a, bool nb, string wd, CancellationToken ct) => RunAsync(new ProcessSpec("dotnet", [], wd), ct);
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken ct)
+            => throw exception;
     }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/StepContractTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/StepContractTests.cs
@@ -31,16 +31,16 @@ public class StepContractTests
     }
 
     [Fact]
-    public void AllSteps_IdsAreContiguousFromZeroToSeven()
+    public void AllSteps_IdsAreContiguousFromZeroToEight()
     {
         var ids = _allSteps.Select(s => s.Id).OrderBy(id => id).ToArray();
-        Assert.Equal(new[] { 0, 1, 2, 3, 4, 5, 6, 7 }, ids);
+        Assert.Equal(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }, ids);
     }
 
     [Fact]
-    public void Registry_ReturnsExactly8Steps()
+    public void Registry_ReturnsExactly9Steps()
     {
-        Assert.Equal(8, _allSteps.Count);
+        Assert.Equal(9, _allSteps.Count);
     }
 
     // ── Step scope ──────────────────────────────────────────────────────

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -44,13 +44,13 @@ public sealed record PipelineRequest(
     /// This includes Bootstrap (step 0) even though <see cref="DefaultSteps"/> omits it from the default run set.
     /// Keep this list aligned with <see cref="Registry.StepRegistry.CreateDefault(string)"/>.
     /// </summary>
-    public static IReadOnlyList<int> AllValidSteps { get; } = [0, 1, 2, 3, 4, 5, 6, 7];
+    public static IReadOnlyList<int> AllValidSteps { get; } = [0, 1, 2, 3, 4, 5, 6, 7, 8];
 
     /// <summary>
     /// Default namespace step run set used when <c>--steps</c> is omitted.
     /// Bootstrap (step 0) is not included because it is added automatically by the runner.
     /// </summary>
-    public static IReadOnlyList<int> DefaultSteps { get; } = [1, 2, 3, 4, 5, 6, 7];
+    public static IReadOnlyList<int> DefaultSteps { get; } = [1, 2, 3, 4, 5, 6, 7, 8];
 
     public static string GetDefaultOutputPath(string? targetNamespace, TimeProvider? timeProvider = null)
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/Registry/StepRegistry.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Registry/StepRegistry.cs
@@ -35,6 +35,7 @@ public sealed class StepRegistry
             new SkillsRelevanceStep(),
             new HorizontalArticlesStep(),
             new ArticleHealthValidatorStep(),
+            new CoverageAuditStep(),
         ]);
 
     public IReadOnlyList<IPipelineStep> GetAllSteps()

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/ValidationScriptRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/ValidationScriptRunner.cs
@@ -13,8 +13,8 @@ public sealed record ValidationScriptRequest(
     string RepoRoot,
     string OutputRoot,
     string OutputJsonPath,
-    IReadOnlyList<string> ArticlePaths,
-    IReadOnlyDictionary<string, string> AdditionalArguments);
+    IReadOnlyList<string>? ArticlePaths = null,
+    IReadOnlyDictionary<string, string>? AdditionalArguments = null);
 
 /// <summary>
 /// Result of a validation script invocation, capturing all observable execution data.
@@ -70,18 +70,26 @@ public sealed class ValidationScriptRunner(IProcessRunner processRunner) : IVali
             CompletedAt: completedAt);
     }
 
-    private static IReadOnlyList<string> BuildArguments(ValidationScriptRequest request)
+    internal static IReadOnlyList<string> BuildArguments(ValidationScriptRequest request)
     {
-        if (request.ArticlePaths.Count == 0)
-            throw new ArgumentException("ArticlePaths cannot be empty.", nameof(request));
+        var additional = request.AdditionalArguments ?? new Dictionary<string, string>();
+
+        // Validate: ArticlePaths and AdditionalArguments must not both supply article path args
+        if (request.ArticlePaths is { Count: > 0 } &&
+            (additional.ContainsKey("-ArticlePath") || additional.ContainsKey("-ArticlesDir")))
+        {
+            throw new ArgumentException(
+                "ArticlePaths and AdditionalArguments must not both supply -ArticlePath/-ArticlesDir.",
+                nameof(request));
+        }
 
         var args = new List<string>();
 
-        if (request.ArticlePaths.Count == 1)
+        if (request.ArticlePaths is { Count: 1 })
         {
             args.AddRange(["-ArticlePath", request.ArticlePaths[0]]);
         }
-        else if (request.ArticlePaths.Count > 1)
+        else if (request.ArticlePaths is { Count: > 1 })
         {
             // Find the common directory for multi-file validation
             var directory = Path.GetDirectoryName(request.ArticlePaths[0]) ?? request.OutputRoot;
@@ -92,7 +100,7 @@ public sealed class ValidationScriptRunner(IProcessRunner processRunner) : IVali
         args.AddRange(["-Namespace", request.Namespace]);
         args.AddRange(["-OutputJson", request.OutputJsonPath]);
 
-        foreach (var (key, value) in request.AdditionalArguments)
+        foreach (var (key, value) in additional)
         {
             args.Add(key);
             if (!string.IsNullOrEmpty(value))

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/CoverageAuditStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/CoverageAuditStep.cs
@@ -28,7 +28,7 @@ public sealed class CoverageAuditStep : NamespaceStepBase
             8,
             "Validate tool coverage",
             FailurePolicy.Warn,
-            dependsOn: [0, 4],
+            dependsOn: [0, 4, 7],
             expectedOutputs: [$"{ValidationSubdir}/{ArtifactFileName}", $"{ValidationSubdir}/validation-summary.md"])
     {
     }
@@ -248,6 +248,9 @@ public sealed class CoverageAuditStep : NamespaceStepBase
         return "warn";
     }
 
+    // NOTE: Both Step 7 (ArticleHealthValidator) and Step 8 (CoverageAudit) write to
+    // validation-summary.md. Sequential execution is guaranteed by the dependsOn: [0, 4, 7]
+    // declaration. If parallelization is ever introduced, a file-locking mechanism must be added.
     private static void WriteSummaryMarkdown(
         string validationDir,
         string currentNamespace,

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/CoverageAuditStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/CoverageAuditStep.cs
@@ -1,0 +1,308 @@
+using System.Text.Json;
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Services;
+
+namespace PipelineRunner.Steps;
+
+/// <summary>
+/// Pipeline step that invokes <c>Scan-McpToolCoverage.ps1</c> to verify that all tools
+/// in the CLI metadata have corresponding documentation in the assembled tool-family articles.
+/// <para>
+/// Gate mode is read from <c>mcp-tools/data/validation-gate-config.json</c>.
+/// In <c>warn</c> mode, <c>warn</c> findings (missing params/annotation mismatches) do not
+/// fail the step; <c>fail</c> (missing tools) always fails.
+/// In <c>block</c> mode, both <c>warn</c> and <c>fail</c> findings fail the step.
+/// </para>
+/// </summary>
+public sealed class CoverageAuditStep : NamespaceStepBase
+{
+    private const string ScriptRelativePath = "validation/Scan-McpToolCoverage.ps1";
+    private const string GateConfigRelativePath = "data/validation-gate-config.json";
+    private const string ValidationSubdir = "validation";
+    private const string ArtifactFileName = "coverage-audit.json";
+    private const string CliOutputRelativePath = "cli/cli-output.json";
+
+    public CoverageAuditStep()
+        : base(
+            8,
+            "Validate tool coverage",
+            FailurePolicy.Warn,
+            dependsOn: [0, 4],
+            expectedOutputs: [$"{ValidationSubdir}/{ArtifactFileName}", $"{ValidationSubdir}/validation-summary.md"])
+    {
+    }
+
+    public override async ValueTask<StepResult> ExecuteAsync(
+        PipelineContext context,
+        CancellationToken cancellationToken)
+    {
+        var currentNamespace = GetCurrentNamespace(context);
+        var processResults = new List<ProcessExecutionResult>();
+        var warnings = new List<string>();
+        var artifactFailures = new List<ArtifactFailure>();
+
+        // Resolve paths
+        var scriptPath = Path.GetFullPath(
+            Path.Combine(context.McpToolsRoot, ScriptRelativePath));
+
+        var toolsJsonPath = Path.Combine(context.OutputPath, CliOutputRelativePath);
+        var articlesDir = Path.Combine(context.OutputPath, "tool-family");
+        var validationDir = Path.Combine(context.OutputPath, ValidationSubdir);
+        var outputJsonPath = Path.Combine(validationDir, ArtifactFileName);
+
+        // Verify prerequisites exist
+        if (!File.Exists(toolsJsonPath))
+        {
+            warnings.Add($"CLI output not found at '{toolsJsonPath}'. Coverage audit skipped (bootstrap may not have run).");
+            artifactFailures.Add(CreateArtifactFailure(
+                "coverage-audit",
+                ArtifactFileName,
+                $"CLI metadata (cli-output.json) not found for namespace '{currentNamespace}'.",
+                warnings,
+                [toolsJsonPath]));
+            return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+        }
+
+        if (!Directory.Exists(articlesDir))
+        {
+            warnings.Add($"Articles directory not found at '{articlesDir}'. Coverage audit skipped.");
+            artifactFailures.Add(CreateArtifactFailure(
+                "coverage-audit",
+                ArtifactFileName,
+                $"Tool-family articles directory not found for namespace '{currentNamespace}'.",
+                warnings,
+                [articlesDir]));
+            return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+        }
+
+        // Read gate mode from config
+        var gateMode = ReadGateMode(context.McpToolsRoot, warnings);
+
+        // Generate a run identifier for this invocation
+        var runId = Guid.NewGuid().ToString();
+
+        // Clean stale artifacts before running
+        EnsureValidationDirectory(validationDir, outputJsonPath);
+
+        // Build and execute the script request
+        var request = new ValidationScriptRequest(
+            ScriptPath: scriptPath,
+            RunId: runId,
+            Namespace: currentNamespace,
+            RepoRoot: context.RepoRoot,
+            OutputRoot: context.OutputPath,
+            OutputJsonPath: outputJsonPath,
+            AdditionalArguments: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["-ToolsJsonPath"] = toolsJsonPath,
+                ["-ArticlesDir"] = articlesDir,
+            });
+
+        var scriptRunner = new ValidationScriptRunner(context.ProcessRunner);
+        ValidationScriptResult scriptResult;
+        try
+        {
+            scriptResult = await scriptRunner.RunAsync(request, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Coverage audit script failed to launch: {ex.Message}");
+            artifactFailures.Add(CreateArtifactFailure(
+                "coverage-audit",
+                ArtifactFileName,
+                "Script launch exception.",
+                [$"Exception: {ex.Message}"],
+                [scriptPath]));
+            return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+        }
+
+        // Record a synthetic ProcessExecutionResult for the display command
+        processResults.Add(new ProcessExecutionResult(
+            "pwsh",
+            ["-File", scriptPath, "-RunId", runId, "-Namespace", currentNamespace, "-OutputJson", outputJsonPath],
+            context.RepoRoot,
+            scriptResult.ExitCode,
+            scriptResult.StdOut,
+            scriptResult.StdErr,
+            scriptResult.CompletedAt - scriptResult.StartedAt));
+
+        // Normalize the result
+        var normalized = ValidationResultNormalizer.Normalize(scriptResult, runId, currentNamespace);
+
+        // Emit diagnostic warnings regardless of verdict
+        foreach (var diagnostic in normalized.Diagnostics)
+        {
+            warnings.Add(diagnostic);
+        }
+
+        // Determine step success based on gate mode and verdict
+        var success = DetermineSuccess(normalized.Verdict, gateMode, warnings, artifactFailures, outputJsonPath);
+
+        // Write the validation summary
+        WriteSummaryMarkdown(
+            validationDir,
+            currentNamespace,
+            gateMode,
+            normalized,
+            outputJsonPath);
+
+        return BuildResult(context, processResults, success, warnings, artifactFailures: artifactFailures);
+    }
+
+    private static bool DetermineSuccess(
+        ValidationVerdict verdict,
+        string gateMode,
+        List<string> warnings,
+        List<ArtifactFailure> artifactFailures,
+        string outputJsonPath)
+    {
+        switch (verdict)
+        {
+            case ValidationVerdict.Pass:
+                return true;
+
+            case ValidationVerdict.Warn:
+                if (string.Equals(gateMode, "block", StringComparison.OrdinalIgnoreCase))
+                {
+                    warnings.Add("Coverage audit verdict is 'warn' and gate mode is 'block'. Step failed.");
+                    artifactFailures.Add(CreateBlockingFailure(verdict, outputJsonPath));
+                    return false;
+                }
+                // warn mode: param/annotation gaps are non-blocking
+                return true;
+
+            case ValidationVerdict.Fail:
+                warnings.Add("Coverage audit verdict is 'fail' (missing tools detected). Step failed.");
+                artifactFailures.Add(CreateBlockingFailure(verdict, outputJsonPath));
+                return false;
+
+            case ValidationVerdict.ScriptError:
+                warnings.Add("Coverage audit script encountered an execution error.");
+                artifactFailures.Add(CreateBlockingFailure(verdict, outputJsonPath));
+                return false;
+
+            case ValidationVerdict.ArtifactError:
+                warnings.Add("Coverage audit artifact is missing, malformed, or stale.");
+                artifactFailures.Add(CreateBlockingFailure(verdict, outputJsonPath));
+                return false;
+
+            default:
+                warnings.Add($"Unknown validation verdict: {verdict}.");
+                return false;
+        }
+    }
+
+    private static ArtifactFailure CreateBlockingFailure(ValidationVerdict verdict, string outputJsonPath)
+        => ArtifactFailure.Create(
+            "coverage-audit",
+            ArtifactFileName,
+            $"Coverage audit validation returned '{verdict.ToString().ToLowerInvariant()}' verdict.",
+            relatedPaths: [outputJsonPath]);
+
+    private static void EnsureValidationDirectory(string validationDir, string artifactPath)
+    {
+        Directory.CreateDirectory(validationDir);
+        if (File.Exists(artifactPath))
+        {
+            File.Delete(artifactPath);
+        }
+    }
+
+    private static string ReadGateMode(string mcpToolsRoot, List<string> warnings)
+    {
+        var configPath = Path.Combine(mcpToolsRoot, GateConfigRelativePath);
+        if (!File.Exists(configPath))
+        {
+            warnings.Add($"Gate config not found at '{configPath}'; defaulting to 'warn' mode.");
+            return "warn";
+        }
+
+        try
+        {
+            var json = File.ReadAllText(configPath);
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("gateMode", out var gm))
+            {
+                var mode = gm.GetString()?.ToLowerInvariant() ?? "";
+                if (mode is "warn" or "block")
+                {
+                    return mode;
+                }
+
+                warnings.Add($"Unrecognized gateMode value '{gm.GetString()}' in '{configPath}'; defaulting to 'warn'.");
+                return "warn";
+            }
+
+            warnings.Add($"Gate config at '{configPath}' missing 'gateMode' property; defaulting to 'warn'.");
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Failed to read gate config at '{configPath}': {ex.Message}. Defaulting to 'warn' mode.");
+        }
+
+        return "warn";
+    }
+
+    private static void WriteSummaryMarkdown(
+        string validationDir,
+        string currentNamespace,
+        string gateMode,
+        ValidationNormalizedResult normalized,
+        string artifactJsonPath)
+    {
+        try
+        {
+            var summaryPath = Path.Combine(validationDir, "validation-summary.md");
+
+            // Append to summary if article health already wrote it
+            var lines = new List<string>();
+            if (File.Exists(summaryPath))
+            {
+                lines.AddRange(File.ReadAllLines(summaryPath));
+                lines.Add(string.Empty);
+                lines.Add("---");
+                lines.Add(string.Empty);
+            }
+            else
+            {
+                lines.Add("# Validation Summary");
+                lines.Add(string.Empty);
+                lines.Add($"**Namespace:** {currentNamespace}");
+                lines.Add($"**Gate mode:** {gateMode}");
+                lines.Add(string.Empty);
+            }
+
+            lines.Add("## Coverage Audit");
+            lines.Add(string.Empty);
+            lines.Add($"**Verdict:** {normalized.Verdict.ToString().ToLowerInvariant()}");
+            lines.Add(string.Empty);
+
+            if (normalized.Diagnostics.Count > 0)
+            {
+                lines.Add("### Diagnostics");
+                lines.Add(string.Empty);
+                foreach (var d in normalized.Diagnostics)
+                {
+                    lines.Add($"- {d}");
+                }
+
+                lines.Add(string.Empty);
+            }
+
+            lines.Add("### Artifacts");
+            lines.Add(string.Empty);
+            lines.Add($"- Coverage audit JSON: `{artifactJsonPath}`");
+
+            File.WriteAllLines(summaryPath, lines);
+        }
+        catch
+        {
+            // Non-critical: summary write failure should not affect step success
+        }
+    }
+}

--- a/mcp-tools/validation/Scan-McpToolCoverage.ps1
+++ b/mcp-tools/validation/Scan-McpToolCoverage.ps1
@@ -31,7 +31,11 @@ param(
     [string]$OpenPRsJson,
 
     # Git repo root for the articles repo (used with OpenPRsJson to read PR branch files via git show)
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    # Pipeline contract mode: when provided, emits a schemaVersion 1.0 artifact
+    # compatible with ValidationResultNormalizer (same shape as Test-ArticleHealth.ps1).
+    [string]$RunId = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -599,8 +603,54 @@ if ($paramIssues) {
 
 Write-Host "═══════════════════════════════════════════════════════════════" -ForegroundColor Cyan
 
-# ─── JSON Output ─────────────────────────────────────────────────────────────
-if ($OutputJson) {
+# ─── Pipeline Contract Output (schemaVersion 1.0) ────────────────────────────
+# When -RunId is provided, emit the standardized artifact that ValidationResultNormalizer reads.
+if ($RunId) {
+    # Determine verdict: pass/warn/fail based on coverage gaps
+    $coverageVerdict = if ($report.summary.tools_missing -gt 0) {
+        "fail"
+    } elseif ($report.summary.params_missing -gt 0 -or $report.summary.annotation_mismatches -gt 0) {
+        "warn"
+    } else {
+        "pass"
+    }
+
+    $checks = @(
+        [PSCustomObject]@{
+            name   = "tools_coverage"
+            status = if ($report.summary.tools_missing -gt 0) { "fail" } else { "pass" }
+            detail = "$($report.summary.tools_documented)/$($report.summary.tools_documented + $report.summary.tools_missing) tools documented"
+        },
+        [PSCustomObject]@{
+            name   = "params_coverage"
+            status = if ($report.summary.params_missing -gt 0) { "warn" } else { "pass" }
+            detail = "$($report.summary.params_documented)/$($report.summary.params_documented + $report.summary.params_missing) params documented"
+        },
+        [PSCustomObject]@{
+            name   = "annotation_accuracy"
+            status = if ($report.summary.annotation_mismatches -gt 0) { "warn" } else { "pass" }
+            detail = "$($report.summary.annotation_mismatches) mismatches"
+        }
+    )
+
+    $contractArtifact = [PSCustomObject]@{
+        schemaVersion = "1.0"
+        runId         = $RunId
+        namespace     = if ($Namespace) { $Namespace } else { "all" }
+        generatedAt   = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+        verdict       = $coverageVerdict
+        checks        = $checks
+        summary       = $report.summary
+    }
+
+    # Write to -OutputJson path (required in pipeline contract mode)
+    if ($OutputJson) {
+        $contractArtifact | ConvertTo-Json -Depth 10 | Set-Content $OutputJson -Encoding UTF8
+        Write-Host "  Pipeline contract artifact saved to: $OutputJson" -ForegroundColor Green
+    }
+}
+# ─── Legacy JSON Output (when no -RunId) ─────────────────────────────────────
+elseif ($OutputJson) {
     $report | ConvertTo-Json -Depth 10 | Set-Content $OutputJson -Encoding UTF8
     Write-Host "  JSON report saved to: $OutputJson" -ForegroundColor Green
 }


### PR DESCRIPTION
## Summary

Phase 3 of PRD #574: Adds CoverageAuditStep (Step 8) that invokes Scan-McpToolCoverage.ps1 as a pipeline step to verify all CLI tools have corresponding documentation.

### Key Changes

- **Pipeline-contract mode** for Scan-McpToolCoverage.ps1: When \-RunId\ is provided, emits a \schemaVersion: 1.0\ artifact (same shape as \Test-ArticleHealth.ps1\) with verdict logic based on coverage gaps
- **\CoverageAuditStep.cs\** (Step 8): Extends \NamespaceStepBase\, depends on \[0, 4]\, uses \ValidationScriptRunner\ and \ValidationResultNormalizer\
- **Generalized \ValidationScriptRequest\**: \ArticlePaths\ now nullable; \AdditionalArguments\ used for script-specific params (\-ToolsJsonPath\, \-ArticlesDir\); duplicate-argument validation added
- **16 new tests** in \CoverageAuditStepTests.cs\ + \BuildArguments\ unit tests

### Verdict Logic

| Condition | Verdict |
|-----------|---------|
| 0 missing tools + 0 missing params + 0 mismatches | \pass\ |
| 0 missing tools, but param gaps or annotation mismatches | \warn\ |
| Missing tools detected | \ail\ |

### Test Results

All tests pass: 440 PipelineRunner tests + full solution green.

Refs #574 (Phase 3)