### PR TITLE
Fix AzmcpRunner path resolution and migrate from npm to dotnet tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **`AzmcpRunner` Windows binary resolution** — On Windows, `azmcp` is installed as `azmcp.cmd` (a batch wrapper). `Process.Start` with `UseShellExecute=false` cannot locate `.cmd` files by bare name. `AzmcpRunner` now resolves the binary as `azmcp.cmd` on Windows and `azmcp` on all other platforms, matching the existing pattern in `PipelineRunner`. The generation pipeline is now fully PowerShell + .NET end-to-end with no npm dependency required. Updated `McpCliMetadata/README.md` to remove the npm installation instruction.
+- **`AzmcpRunner` PATH resolution on Windows** — `Process.Start` with `UseShellExecute=false` does not reliably resolve `.cmd` batch wrappers from `PATH`. `AzmcpRunner` now walks each `PATH` directory to locate `azmcp.cmd` (Windows) or `azmcp` (non-Windows) and passes the full absolute path to `Process.Start`, falling back to the bare name if not found. This fixes `azmcp` invocation failures when the `azure.mcp` dotnet global tool is installed at `~/.dotnet/tools/azmcp.cmd`. Extracted to `internal static ResolveBinaryPath()` for testability.
+- **`BootstrapStep` migrated from npm to dotnet tool** — The bootstrap step previously ran `npm install -g @azure/mcp@latest` to update the MCP CLI. This has been replaced with `dotnet tool update azure.mcp --global`, matching the current installation method. Removed the dead `GetNpmExecutable()` helper and unused `CaptureCommandOutputAsync` method. The `--skip-npm-update` / `SkipNpmUpdate` flag is preserved for backwards compatibility with existing CLI scripts.
+
 
 ### Changed
 - Added .NET CLI metadata extractor (`mcp-tools/McpCliMetadata/`) alongside existing Node.js scripts. The `azmcp` binary is now invoked via `Process.Start` in a typed C# console app; `preflight.ps1` calls the .NET project instead of npm. The folder `test-npm-azure-mcp/` was renamed to `mcp-cli-metadata/` (all Node.js scripts and version snapshot directories preserved). Closes #627, PR #628.

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -264,12 +264,12 @@ public class BootstrapStepTests
 
         Assert.True(result.Success);
         var latestIdx = harness.ProcessRunner.Invocations.FindIndex(
-            s => s.Arguments.SequenceEqual(["install", "-g", "@azure/mcp@latest"]));
+            s => s.FileName == "dotnet" && s.Arguments.SequenceEqual(["tool", "update", "azure.mcp", "--global"]));
         var metadataIdx = harness.ProcessRunner.Invocations.FindIndex(
             s => s.FileName == "dotnet" && s.Arguments.Any(a => a.EndsWith("McpCliMetadata.csproj", StringComparison.OrdinalIgnoreCase)));
-        Assert.True(latestIdx >= 0, "Expected npm install -g @azure/mcp@latest to be invoked.");
+        Assert.True(latestIdx >= 0, "Expected dotnet tool update azure.mcp --global to be invoked.");
         Assert.True(metadataIdx >= 0, "Expected McpCliMetadata dotnet run to be invoked.");
-        Assert.True(latestIdx < metadataIdx, "Latest install must run before metadata generation.");
+        Assert.True(latestIdx < metadataIdx, "dotnet tool update must run before metadata generation.");
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class BootstrapStepTests
         Assert.True(result.Success);
         Assert.DoesNotContain(
             harness.ProcessRunner.Invocations,
-            s => s.Arguments.SequenceEqual(["install", "-g", "@azure/mcp@latest"]));
+            s => s.FileName == "dotnet" && s.Arguments.SequenceEqual(["tool", "update", "azure.mcp", "--global"]));
         var messages = ((BufferedReportWriter)harness.Context.Reports).Messages;
         Assert.Contains(messages, m => m.Contains("--skip-npm-update", StringComparison.Ordinal));
     }
@@ -295,7 +295,7 @@ public class BootstrapStepTests
         var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
 
         Assert.False(result.Success);
-        Assert.Contains(result.Warnings, w => w.Contains("latest @azure/mcp", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Warnings, w => w.Contains("azure.mcp", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -509,10 +509,10 @@ public class BootstrapStepTests
         {
             Invocations.Add(spec);
 
-            if (spec.Arguments.SequenceEqual(["install", "-g", "@azure/mcp@latest"]))
+            if (spec.FileName == "dotnet" && spec.Arguments.SequenceEqual(["tool", "update", "azure.mcp", "--global"]))
             {
                 return FailNpmLatestInstall
-                    ? ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 1, string.Empty, "npm ERR! 404", TimeSpan.Zero))
+                    ? ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 1, string.Empty, "error: failed to update azure.mcp", TimeSpan.Zero))
                     : ValueTask.FromResult(Success(spec));
             }
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -120,26 +120,25 @@ public sealed class BootstrapStep : StepDefinition
                 return BuildResult(context, processResults, success: false, warnings);
             }
 
-            var npmExecutable = GetNpmExecutable();
 
             if (!context.Request.SkipNpmUpdate)
             {
-                context.Reports.Info("Updating @azure/mcp to latest version...");
+                context.Reports.Info("Updating azure.mcp dotnet tool to latest version...");
                 var latestInstallResult = await context.ProcessRunner.RunAsync(
-                    new ProcessSpec(npmExecutable, ["install", "-g", "@azure/mcp@latest"], context.RepoRoot),
+                    new ProcessSpec("dotnet", ["tool", "update", "azure.mcp", "--global"], context.RepoRoot),
                     cancellationToken);
                 processResults.Add(latestInstallResult);
                 if (!latestInstallResult.Succeeded)
                 {
-                    AddProcessIssue(latestInstallResult, warnings, "Failed to install latest @azure/mcp globally — use --skip-npm-update for offline or reproducible builds");
+                    AddProcessIssue(latestInstallResult, warnings, "Failed to update azure.mcp dotnet tool globally — use --skip-tool-update for offline or reproducible builds");
                     return BuildResult(context, processResults, success: false, warnings);
                 }
 
-                context.Reports.Info("@azure/mcp updated to latest.");
+                context.Reports.Info("azure.mcp dotnet tool updated to latest.");
             }
             else
             {
-                context.Reports.Info("Skipping @azure/mcp latest update (--skip-npm-update).");
+                context.Reports.Info("Skipping azure.mcp dotnet tool update (--skip-npm-update).");
             }
 
             var metadataGenerationResult = await context.ProcessRunner.RunDotNetProjectAsync(
@@ -383,9 +382,6 @@ public sealed class BootstrapStep : StepDefinition
         }
     }
 
-    private static string GetNpmExecutable()
-        => OperatingSystem.IsWindows() ? "npm.cmd" : "npm";
-
     /// <summary>
     /// Loads <c>brand-to-server-mapping.json</c> from the given path as a list of <see cref="BrandMappingEntry"/>.
     /// Returns an empty list if the file does not exist or contains malformed JSON.
@@ -444,30 +440,6 @@ public sealed class BootstrapStep : StepDefinition
         return requiredProjects
             .Select(project => Path.Combine(mcpToolsRoot, project, "bin", "Release", targetFramework, $"{project}.dll"))
             .ToArray();
-    }
-
-    private static async ValueTask<ProcessExecutionResult> CaptureCommandOutputAsync(
-        PipelineContext context,
-        ICollection<ProcessExecutionResult> processResults,
-        string workingDirectory,
-        string outputDirectory,
-        string scriptName,
-        string outputFileName,
-        CancellationToken cancellationToken)
-    {
-        var result = await context.ProcessRunner.RunAsync(
-            new ProcessSpec(GetNpmExecutable(), ["run", "--silent", scriptName], workingDirectory),
-            cancellationToken);
-        processResults.Add(result);
-
-        if (result.Succeeded)
-        {
-            var outputPath = Path.Combine(outputDirectory, outputFileName);
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            await File.WriteAllTextAsync(outputPath, result.StandardOutput.Trim(), Encoding.UTF8, cancellationToken);
-        }
-
-        return result;
     }
 
     /// <summary>

--- a/mcp-tools/McpCliMetadata.Tests/AzmcpRunnerTests.cs
+++ b/mcp-tools/McpCliMetadata.Tests/AzmcpRunnerTests.cs
@@ -113,7 +113,8 @@ public class AzmcpRunnerTests
         var runner = new AzmcpRunner(capturing);
         await runner.GetVersionAsync();
         var expected = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
-        Assert.Equal(expected, capturing.LastFileName);
+        // Binary may be a full path — just verify the filename portion matches
+        Assert.Equal(expected, Path.GetFileName(capturing.LastFileName));
     }
 
     [Fact]
@@ -123,7 +124,7 @@ public class AzmcpRunnerTests
         var runner = new AzmcpRunner(capturing);
         await runner.GetToolsJsonAsync();
         var expected = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
-        Assert.Equal(expected, capturing.LastFileName);
+        Assert.Equal(expected, Path.GetFileName(capturing.LastFileName));
     }
 
     [Fact]
@@ -133,7 +134,75 @@ public class AzmcpRunnerTests
         var runner = new AzmcpRunner(capturing);
         await runner.GetNamespaceJsonAsync();
         var expected = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
-        Assert.Equal(expected, capturing.LastFileName);
+        Assert.Equal(expected, Path.GetFileName(capturing.LastFileName));
+    }
+
+    // --- ResolveBinaryPath tests ---
+
+    [Fact]
+    public void ResolveBinaryPath_EmptyPath_ReturnsFallbackName()
+    {
+        var result = AzmcpRunner.ResolveBinaryPath(string.Empty);
+        var expected = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ResolveBinaryPath_PathWithNonExistentDirs_ReturnsFallbackName()
+    {
+        var fakePath = OperatingSystem.IsWindows()
+            ? @"C:\no-such-dir-abc123;C:\another-fake-dir"
+            : "/no-such-dir-abc123:/another-fake-dir";
+        var result = AzmcpRunner.ResolveBinaryPath(fakePath);
+        var expected = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ResolveBinaryPath_BinaryExistsInPathDir_ReturnsFullPath()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"azmcp-path-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var binaryName = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+        var binaryPath = Path.Combine(tempDir, binaryName);
+        File.WriteAllText(binaryPath, string.Empty);
+        try
+        {
+            var separator = OperatingSystem.IsWindows() ? ';' : ':';
+            var fakePath = $"/no-such-dir-abc123{separator}{tempDir}";
+            var result = AzmcpRunner.ResolveBinaryPath(fakePath);
+            Assert.Equal(binaryPath, result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveBinaryPath_ReturnsFirstMatchWhenMultipleDirsContainBinary()
+    {
+        var tempDir1 = Path.Combine(Path.GetTempPath(), $"azmcp-path-test-first-{Guid.NewGuid():N}");
+        var tempDir2 = Path.Combine(Path.GetTempPath(), $"azmcp-path-test-second-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir1);
+        Directory.CreateDirectory(tempDir2);
+        var binaryName = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+        var binaryPath1 = Path.Combine(tempDir1, binaryName);
+        var binaryPath2 = Path.Combine(tempDir2, binaryName);
+        File.WriteAllText(binaryPath1, string.Empty);
+        File.WriteAllText(binaryPath2, string.Empty);
+        try
+        {
+            var separator = OperatingSystem.IsWindows() ? ';' : ':';
+            var fakePath = $"{tempDir1}{separator}{tempDir2}";
+            var result = AzmcpRunner.ResolveBinaryPath(fakePath);
+            Assert.Equal(binaryPath1, result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir1, recursive: true);
+            Directory.Delete(tempDir2, recursive: true);
+        }
     }
 }
 

--- a/mcp-tools/McpCliMetadata/AzmcpRunner.cs
+++ b/mcp-tools/McpCliMetadata/AzmcpRunner.cs
@@ -37,8 +37,27 @@ internal sealed class ProcessRunner : IProcessRunner
 
 internal sealed class AzmcpRunner
 {
-    private static string Binary => OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+    private static string Binary => ResolveBinaryPath(Environment.GetEnvironmentVariable("PATH") ?? string.Empty);
     private const int DefaultTimeoutMs = 30_000;
+
+    /// <summary>
+    /// Resolves the full path to the azmcp binary by searching each directory in <paramref name="pathVar"/>.
+    /// Returns the first matching full path if found; otherwise falls back to the bare binary name.
+    /// This is required because <see cref="System.Diagnostics.ProcessStartInfo"/> with
+    /// <c>UseShellExecute=false</c> does not reliably resolve <c>.cmd</c> wrappers from PATH on Windows.
+    /// </summary>
+    internal static string ResolveBinaryPath(string pathVar)
+    {
+        var name = OperatingSystem.IsWindows() ? "azmcp.cmd" : "azmcp";
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        foreach (var dir in pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(dir, name);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+        return name;
+    }
     private readonly IProcessRunner _runner;
 
     internal AzmcpRunner(IProcessRunner? runner = null)


### PR DESCRIPTION
## Problem

AzmcpRunner.cs called Process.Start("azmcp.cmd") with UseShellExecute=false. When the zure.mcp dotnet global tool is installed at ~/.dotnet/tools/azmcp.cmd, Process.Start cannot find it even though it's on PATH — because .cmd batch wrappers are not resolved by the Windows process loader the same way a shell resolves them.

## Changes

### AzmcpRunner.cs
- Binary property now calls ResolveBinaryPath(pathVar) which walks each PATH directory and returns the first full path to zmcp.cmd (Windows) or zmcp (non-Windows). Falls back to the bare name if not found.
- Extracted as internal static ResolveBinaryPath(string pathVar) for testability.

### McpCliMetadata.Tests/AzmcpRunnerTests.cs
- Updated \UsesCorrectBinaryNameForPlatform\ tests to compare Path.GetFileName() (handles full-path return).
- Added 4 new \ResolveBinaryPath\ tests: empty PATH fallback, non-existent dirs fallback, full-path resolution, first-match-wins.

### BootstrapStep.cs
- Replaced 
pm install -g @azure/mcp@latest with dotnet tool update azure.mcp --global.
- Removed dead GetNpmExecutable() helper.
- Removed unused CaptureCommandOutputAsync method.
- --skip-npm-update / SkipNpmUpdate flag preserved for backwards compatibility.

### BootstrapStepTests.cs
- Updated all three npm-related tests to assert on the dotnet tool update invocation.

### CHANGELOG.md
- Added entries under \## [Unreleased]\ for both fixes.

## Test results
- 19/19 McpCliMetadata tests pass (4 new)
- 20/20 BootstrapStep tests pass (3 updated)
- Full solution build: 0 errors