### PR TITLE
Restructure tool-family pipeline output

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -1,0 +1,24 @@
+# Tool family output format
+
+Tool sections in generated family articles follow this structure:
+
+## H2 heading
+
+Each tool starts with a `##` heading for the tool name.
+
+## Description paragraph
+
+Place one plain-language description paragraph immediately below the H2 heading. Do not duplicate that paragraph inside either tab.
+
+## Tab block
+
+Emit the tabs in this order:
+
+1. `#### [Azure MCP CLI](#tab/azure-mcp-cli)`
+2. `#### [MCP Server](#tab/mcp-server)`
+
+The CLI tab is the deterministic command view derived from tools JSON. The MCP tab is the AI-improved server view with the leading description removed.
+
+## Annotation block
+
+Close the tab group with `---`, then place any tool annotation block after that separator so annotations appear once per tool and remain outside both tabs.

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/prompts/system-prompt-example-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/prompts/system-prompt-example-prompt.txt
@@ -1,6 +1,8 @@
 # Prompt Template for Generating Tool Example Prompts
 
-You are an expert technical writer specializing in Azure cloud services and Microsoft documentation standards. Your task is to generate natural, conversational example prompts that developers would use to interact with Azure MCP (Model Context Protocol) tools.
+You are an expert technical writer specializing in Azure cloud services and Microsoft documentation standards. Your task is to generate natural, conversational example prompts that developers would use to interact with Azure tools.
+
+IMPORTANT: Never mention "Model Context Protocol", "MCP", or any protocol-level terminology in generated prompts or descriptions. Focus on what the tool does, not what protocol it uses.
 
 You will receive tool information including the tool name, command, action verb, resource type, and parameters. You may also receive **reference prompts** from the tool's developers (e2e test prompts). These represent the authoritative style, complexity, parameter usage, and prompt count for that tool.
 
@@ -80,9 +82,12 @@ This means:
      * For `--question` ΓåÆ phrase as a question or say "question: ..."
      * **GENERAL RULE**: Use the core word(s) from the parameter name in your prompt text
 
-5. **PARAMETER VALUE FORMAT ΓÇö Single-Quoted Concrete Values ONLY**:
-   - **ALL parameter values MUST be wrapped in single straight quotes (')** with concrete, realistic example values ΓÇö NO EXCEPTIONS
+5. **PARAMETER VALUE FORMAT — Single-Quoted Concrete Values ONLY**:
+   - **ALL parameter values MUST be wrapped in single straight quotes (')** with concrete, realistic example values — NO EXCEPTIONS
    - Use descriptive but short values: 'my-appconfig', 'my-key', 'prod-rg', 'my-storage'
+   - **SINGLE LINE ONLY**: ALL parameter values (including YAML, JSON, scripts, or any multi-line content) MUST fit on a single line. Use a compact inline representation — NEVER embed literal newlines or multi-line blocks inside a quoted value.
+     * ✅ "Validate workflow YAML content 'apiVersion: v1 kind: Workflow steps: []'."
+     * ❌ "Validate workflow YAML content 'apiVersion: v1\nkind: Workflow\n...'" (multi-line)
    - **FORBIDDEN FORMATS** (will cause rejection):
      * Angle brackets: `<account>`, `<key>` ΓÇö invisible when rendered as HTML
      * Backticks: `` `account` ``, `` `key` `` ΓÇö renders as code, not values

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/prompts/system-prompt-example-prompt-validation.txt
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Validation/prompts/system-prompt-example-prompt-validation.txt
@@ -1,6 +1,8 @@
 # System Prompt for Validating Generated Example Prompts
 
-You are an expert technical validator specializing in Azure MCP (Model Context Protocol) tool documentation. Your task is to validate that generated example prompts correctly include all required parameters for a specific Azure tool.
+You are an expert technical validator specializing in Azure tool documentation. Your task is to validate that generated example prompts correctly include all required parameters for a specific Azure tool.
+
+IMPORTANT: Never mention "Model Context Protocol", "MCP", or any protocol-level terminology in output. Focus on what the tool does, not what protocol it uses.
 
 ## Your Role
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabValidatorTests.cs
@@ -14,13 +14,13 @@ public class CliTabValidatorTests
         var markdown = """
             ## Tool A
 
-            #### [MCP Server](#tab/mcp-server)
-
-            MCP content here.
-
             #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
             CLI content here.
+
+            #### [MCP Server](#tab/mcp-server)
+
+            MCP content here.
 
             ---
 
@@ -36,9 +36,9 @@ public class CliTabValidatorTests
     public void Validate_MismatchedTabCounts_ReturnsError()
     {
         var markdown = """
-            #### [MCP Server](#tab/mcp-server)
+            #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
-            MCP content.
+            CLI content.
 
             ---
             """;
@@ -53,13 +53,13 @@ public class CliTabValidatorTests
     public void Validate_UnterminatedTabGroup_ReturnsError()
     {
         var markdown = """
-            #### [MCP Server](#tab/mcp-server)
-
-            MCP content.
-
             #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
             CLI content.
+
+            #### [MCP Server](#tab/mcp-server)
+
+            MCP content.
             """;
 
         var result = CliTabValidator.Validate(markdown);
@@ -72,17 +72,13 @@ public class CliTabValidatorTests
     public void Validate_NestedTabGroup_ReturnsError()
     {
         var markdown = """
-            #### [MCP Server](#tab/mcp-server)
-
-            MCP content.
-
-            #### [MCP Server](#tab/mcp-server)
-
-            Nested MCP content.
-
             #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
             CLI content.
+
+            #### [Azure MCP CLI](#tab/azure-mcp-cli)
+
+            Nested CLI content.
 
             ---
             """;
@@ -94,12 +90,12 @@ public class CliTabValidatorTests
     }
 
     [Fact]
-    public void Validate_CliTabWithoutMcpTab_ReturnsError()
+    public void Validate_McpTabWithoutCliTab_ReturnsError()
     {
         var markdown = """
-            #### [Azure MCP CLI](#tab/azure-mcp-cli)
+            #### [MCP Server](#tab/mcp-server)
 
-            CLI content without MCP tab.
+            MCP content without CLI tab.
 
             ---
             """;
@@ -107,7 +103,7 @@ public class CliTabValidatorTests
         var result = CliTabValidator.Validate(markdown);
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("CLI tab opened without preceding MCP Server tab"));
+        Assert.Contains(result.Errors, e => e.Contains("MCP Server tab opened without preceding Azure MCP CLI tab"));
     }
 
     [Fact]
@@ -132,25 +128,25 @@ public class CliTabValidatorTests
         var markdown = """
             ## Tool A
 
-            #### [MCP Server](#tab/mcp-server)
-
-            MCP A content.
-
             #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
             CLI A content.
+
+            #### [MCP Server](#tab/mcp-server)
+
+            MCP A content.
 
             ---
 
             ## Tool B
 
-            #### [MCP Server](#tab/mcp-server)
-
-            MCP B content.
-
             #### [Azure MCP CLI](#tab/azure-mcp-cli)
 
             CLI B content.
+
+            #### [MCP Server](#tab/mcp-server)
+
+            MCP B content.
 
             ---
             """;

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
@@ -244,6 +244,94 @@ public class CliTabWrapperTests
         Assert.Equal("", remaining.Trim());
     }
 
+    [Fact]
+    public void StripProseFromMcpContent_RemovesExtraParagraphsBeforeExamplePrompts()
+    {
+        var content = """
+            <!-- @mcpcli foundryextensions knowledge index list -->
+
+            List the knowledge indexes in a Microsoft Foundry project.
+
+            Requires the project endpoint URL and authentication context before you run the tool.
+
+            Notes:
+            - The list shows indexes that are available to your project.
+
+            Example prompts include:
+
+            - "List all knowledge indexes in my project."
+
+            | Parameter | Required or optional | Description |
+            |-----------|----------------------|-------------|
+            | **Project endpoint** | Required | The project endpoint URL. |
+            """;
+
+        var result = Shared.CliTabWrapper.StripProseFromMcpContent(content).ReplaceLineEndings("\n");
+
+        Assert.StartsWith("<!-- @mcpcli foundryextensions knowledge index list -->\n\nExample prompts include:", result);
+        Assert.DoesNotContain("Requires the project endpoint URL", result);
+        Assert.DoesNotContain("Notes:", result);
+        Assert.Contains("| Parameter | Required or optional | Description |", result);
+    }
+
+    [Fact]
+    public void StripProseFromMcpContent_WithoutExamplePrompts_KeepsParameterTable()
+    {
+        var content = """
+            <!-- @mcpcli storage account list -->
+
+            List storage accounts in a subscription.
+
+            Use this to inspect account inventory before you take action.
+
+            | Parameter | Required |
+            |---|---|
+            | Subscription | Yes |
+            """;
+
+        var result = Shared.CliTabWrapper.StripProseFromMcpContent(content).ReplaceLineEndings("\n");
+
+        Assert.StartsWith("<!-- @mcpcli storage account list -->\n\n| Parameter | Required |", result);
+        Assert.DoesNotContain("Use this to inspect account inventory", result);
+    }
+
+    [Fact]
+    public void WrapWithTabsAndExtractDescription_StripsMcpProseButPreservesAnnotationBlock()
+    {
+        var mcpContent = """
+            <!-- @mcpcli storage account list -->
+
+            List storage accounts in a subscription.
+
+            Use this to inspect inventory before you take action.
+
+            Example prompts include:
+
+            - "List storage accounts in subscription 'sub1'."
+
+            | Parameter | Required |
+            |---|---|
+            | Subscription | Yes |
+
+            [Tool annotation hints](index.md#tool-annotations):
+
+            Destructive: ❌ | Idempotent: ✅ | Read-only: ✅
+            """;
+        var cliContent = """
+            ```bash
+            az storage account list
+            ```
+            """;
+
+        var (tabBlock, description) = CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent);
+
+        Assert.Equal("List storage accounts in a subscription.", description);
+        Assert.DoesNotContain("Use this to inspect inventory before you take action.", tabBlock);
+        Assert.Contains("Example prompts include:", tabBlock);
+        Assert.Contains("[Tool annotation hints](index.md#tool-annotations):", tabBlock);
+        Assert.Contains("Destructive: ❌ | Idempotent: ✅ | Read-only: ✅", tabBlock);
+    }
+
     // ── ApplyTabsToFamilyArticle ──────────────────────────────────
 
     private const string FamilyArticle = """

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
@@ -38,16 +38,14 @@ public class CliTabWrapperTests
     }
 
     [Fact]
-    public void WrapWithTabs_EmptyCliContent_RendersTabs()
+    public void WrapWithTabs_EmptyCliContent_ReturnsOriginal()
     {
         var mcpContent = "Some MCP content here.";
+        const string cliContent = "   ";
 
-        var result = CliTabWrapper.WrapWithTabs(mcpContent, string.Empty);
+        var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        Assert.Contains("#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
-        Assert.Contains("#### [MCP Server](#tab/mcp-server)", result);
-        Assert.DoesNotContain(mcpContent, result);
-        AssertCliTabBeforeMcpTab(result);
+        Assert.Equal(mcpContent, result);
     }
 
     [Fact]
@@ -201,6 +199,49 @@ public class CliTabWrapperTests
         var result = CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent).TabBlock;
 
         Assert.DoesNotContain("(MCP)", result);
+    }
+
+    [Fact]
+    public void StripMatchingDescriptionFromCli_DifferentDescription_LeavesCliUnchanged()
+    {
+        var cliContent = "Different CLI description.\n\n```bash\naz storage list\n```";
+
+        var result = Shared.CliTabWrapper.StripMatchingDescriptionFromCli(cliContent, "MCP description text.");
+
+        Assert.Contains("Different CLI description.", result);
+    }
+
+    [Fact]
+    public void ExtractDescription_MultiLineDescription_JoinsAsOneParagraph()
+    {
+        var content = "First line of description\nsecond line continues here.\n\n| Parameter | Required |\n|---|---|";
+
+        var (remaining, description) = Shared.CliTabWrapper.ExtractDescription(content);
+
+        Assert.Equal("First line of description second line continues here.", description);
+        Assert.Contains("| Parameter | Required |", remaining);
+    }
+
+    [Fact]
+    public void ExtractDescription_PipeInDescription_DoesNotTruncate()
+    {
+        // Pipe at start of line IS a boundary; pipe mid-line is NOT
+        var content = "Lists items and their status.\n\n| Parameter | Required |\n|---|---|";
+
+        var (_, description) = Shared.CliTabWrapper.ExtractDescription(content);
+
+        Assert.Equal("Lists items and their status.", description);
+    }
+
+    [Fact]
+    public void ExtractDescription_DescriptionOnly_NoTable_ExtractsCorrectly()
+    {
+        var content = "Creates a new storage account in the specified resource group.";
+
+        var (remaining, description) = Shared.CliTabWrapper.ExtractDescription(content);
+
+        Assert.Equal("Creates a new storage account in the specified resource group.", description);
+        Assert.Equal("", remaining.Trim());
     }
 
     // ── ApplyTabsToFamilyArticle ──────────────────────────────────

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabWrapperTests.cs
@@ -20,9 +20,10 @@ public class CliTabWrapperTests
 
         Assert.Contains("#### [MCP Server](#tab/mcp-server)", result);
         Assert.Contains("#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
-        Assert.Contains(mcpContent.TrimEnd(), result);
+        Assert.Contains("| Parameter | Required |", result);
+        Assert.DoesNotContain("List storage accounts.", result);
         Assert.Contains(cliContent.TrimEnd(), result);
-        // Must end with tab group terminator
+        AssertCliTabBeforeMcpTab(result);
         Assert.Contains("---", result);
     }
 
@@ -37,13 +38,16 @@ public class CliTabWrapperTests
     }
 
     [Fact]
-    public void WrapWithTabs_EmptyCliContent_ReturnsOriginal()
+    public void WrapWithTabs_EmptyCliContent_RendersTabs()
     {
         var mcpContent = "Some MCP content here.";
 
-        var result = CliTabWrapper.WrapWithTabs(mcpContent, "   ");
+        var result = CliTabWrapper.WrapWithTabs(mcpContent, string.Empty);
 
-        Assert.Equal(mcpContent, result);
+        Assert.Contains("#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
+        Assert.Contains("#### [MCP Server](#tab/mcp-server)", result);
+        Assert.DoesNotContain(mcpContent, result);
+        AssertCliTabBeforeMcpTab(result);
     }
 
     [Fact]
@@ -53,6 +57,7 @@ public class CliTabWrapperTests
 
         Assert.Contains("#tab/mcp-server", result);
         Assert.Contains("#tab/azure-mcp-cli", result);
+        AssertCliTabBeforeMcpTab(result);
     }
 
     [Fact]
@@ -65,7 +70,6 @@ public class CliTabWrapperTests
 
         var lines = result.Split('\n');
 
-        // The only standalone "---" should be the tab terminator at the end
         int dashCount = 0;
         foreach (var line in lines)
         {
@@ -73,6 +77,130 @@ public class CliTabWrapperTests
                 dashCount++;
         }
         Assert.Equal(1, dashCount);
+    }
+
+    [Fact]
+    public void WrapWithTabs_DescriptionExtracted_NotInEitherTab()
+    {
+        const string description = "List storage accounts in the current subscription.";
+        var mcpContent = $"{description}\n\n| Parameter | Required |\n|---|---|\n| Subscription | Yes |";
+        var cliContent = $"{description}\n\n```bash\naz storage account list\n```";
+
+        var (tabBlock, extractedDescription) = CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent);
+
+        Assert.Equal(description, extractedDescription);
+        Assert.Equal(0, CountOccurrences(tabBlock, description));
+        AssertCliTabBeforeMcpTab(tabBlock);
+    }
+
+    [Fact]
+    public void WrapWithTabs_DescriptionPlaced_AboveTabBlock()
+    {
+        const string article = """
+            ## List accounts
+            <!-- @mcpcli storage account list -->
+
+            List storage accounts in a subscription.
+
+            | Parameter | Required |
+            |---|---|
+            | Subscription | Yes |
+            """;
+
+        var cliContent = new Dictionary<string, string>
+        {
+            ["storage account list"] = """
+                List storage accounts in a subscription.
+
+                ```bash
+                az storage account list
+                ```
+                """
+        };
+
+        var result = CliTabWrapper.ApplyTabsToFamilyArticle(article, cliContent).ReplaceLineEndings("\n");
+
+        Assert.Contains("## List accounts\n\nList storage accounts in a subscription.\n\n#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
+    }
+
+    [Fact]
+    public void WrapWithTabs_NullDescription_NoEmptyParagraph()
+    {
+        const string article = """
+            ## List accounts
+            <!-- @mcpcli storage account list -->
+
+            | Parameter | Required |
+            |---|---|
+            | Subscription | Yes |
+            """;
+
+        var cliContent = new Dictionary<string, string>
+        {
+            ["storage account list"] = "```bash\naz storage account list\n```"
+        };
+
+        var result = CliTabWrapper.ApplyTabsToFamilyArticle(article, cliContent).ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("## List accounts\n\n\n#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
+        Assert.Contains("## List accounts\n#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
+    }
+
+    [Fact]
+    public void WrapWithTabs_EmptyMcpDescription_TabsStillRender()
+    {
+        var mcpContent = "| Parameter | Required |\n|---|---|\n| Subscription | Yes |";
+        var cliContent = "```bash\naz storage account list\n```";
+
+        var (tabBlock, description) = CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent);
+
+        Assert.Null(description);
+        Assert.Contains("#### [Azure MCP CLI](#tab/azure-mcp-cli)", tabBlock);
+        Assert.Contains("#### [MCP Server](#tab/mcp-server)", tabBlock);
+        AssertCliTabBeforeMcpTab(tabBlock);
+    }
+
+    [Fact]
+    public void WrapWithTabs_LongDescription_PlacedVerbatim()
+    {
+        var description = string.Join(" ", Enumerable.Repeat("This tool lists storage accounts across filtered scopes for reporting and inventory scenarios.", 7));
+        var mcpContent = $"{description}\n\n| Parameter | Required |\n|---|---|\n| Subscription | Yes |";
+        var cliContent = $"{description}\n\n```bash\naz storage account list\n```";
+
+        var article = $"""
+            ## List accounts
+            <!-- @mcpcli storage account list -->
+
+            {description}
+
+            | Parameter | Required |
+            |---|---|
+            | Subscription | Yes |
+            """;
+
+        var cliContentByCommand = new Dictionary<string, string>
+        {
+            ["storage account list"] = cliContent
+        };
+
+        var result = CliTabWrapper.ApplyTabsToFamilyArticle(article, cliContentByCommand);
+        var normalized = result.ReplaceLineEndings("\n");
+
+        Assert.Contains(description, normalized);
+        Assert.Contains($"\n\n{description}\n\n#### [Azure MCP CLI](#tab/azure-mcp-cli)", normalized);
+        Assert.DoesNotContain($"{description}\n\n```bash", CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent).TabBlock);
+    }
+
+    [Fact]
+    public void WrapWithTabs_Output_DoesNotContainMcpBranding()
+    {
+        const string description = "Use Model Context Protocol (MCP) wording here.";
+        var mcpContent = $"{description}\n\n| Parameter | Required |\n|---|---|\n| Subscription | Yes |";
+        var cliContent = $"{description}\n\n```bash\naz storage account list\n```";
+
+        var result = CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent).TabBlock;
+
+        Assert.DoesNotContain("(MCP)", result);
     }
 
     // ── ApplyTabsToFamilyArticle ──────────────────────────────────
@@ -111,7 +239,7 @@ public class CliTabWrapperTests
     {
         var cliContent = new Dictionary<string, string>
         {
-            ["storage account list"] = "```bash\naz storage account list\n```"
+            ["storage account list"] = "List storage accounts in a subscription.\n\n```bash\naz storage account list\n```"
         };
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(FamilyArticle, cliContent);
@@ -119,6 +247,7 @@ public class CliTabWrapperTests
         Assert.Contains("#### [MCP Server](#tab/mcp-server)", result);
         Assert.Contains("#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
         Assert.Contains("az storage account list", result);
+        AssertCliTabBeforeMcpTab(result);
     }
 
     [Fact]
@@ -126,36 +255,33 @@ public class CliTabWrapperTests
     {
         var cliContent = new Dictionary<string, string>
         {
-            ["storage account list"] = "```bash\naz storage account list\n```",
-            ["storage account create"] = "```bash\naz storage account create\n```"
+            ["storage account list"] = "List storage accounts in a subscription.\n\n```bash\naz storage account list\n```",
+            ["storage account create"] = "Create a new storage account.\n\n```bash\naz storage account create\n```"
         };
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(FamilyArticle, cliContent);
 
-        // Count MCP Server tab headers — should have 2 (one per tool)
         var mcpTabCount = CountOccurrences(result, "#### [MCP Server](#tab/mcp-server)");
         Assert.Equal(2, mcpTabCount);
 
         var cliTabCount = CountOccurrences(result, "#### [Azure MCP CLI](#tab/azure-mcp-cli)");
         Assert.Equal(2, cliTabCount);
+        AssertCliTabBeforeMcpTab(result);
     }
 
     [Fact]
     public void ApplyTabsToFamilyArticle_ToolWithoutCliContent_LeftUnchanged()
     {
-        // Only provide CLI content for one of the two tools
         var cliContent = new Dictionary<string, string>
         {
-            ["storage account list"] = "```bash\naz storage account list\n```"
+            ["storage account list"] = "List storage accounts in a subscription.\n\n```bash\naz storage account list\n```"
         };
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(FamilyArticle, cliContent);
 
-        // Should have exactly 1 tab group (only for "list")
         var mcpTabCount = CountOccurrences(result, "#### [MCP Server](#tab/mcp-server)");
         Assert.Equal(1, mcpTabCount);
 
-        // "Create account" section content should still be present
         Assert.Contains("Create a new storage account.", result);
     }
 
@@ -179,19 +305,14 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(FamilyArticle, cliContent);
 
-        // Frontmatter preserved
         Assert.Contains("ms.topic: include", result);
-        // Title preserved
         Assert.Contains("# Azure Storage tools", result);
-        // Quick Navigation preserved
         Assert.Contains("## Quick Navigation", result);
     }
 
     [Fact]
     public void ApplyTabsToFamilyArticle_CommandNormalized_CaseInsensitive()
     {
-        // The marker says "storage account list" but we provide uppercase key
-        // NormalizeCommand lowercases, so matching should work
         var cliContent = new Dictionary<string, string>
         {
             ["storage account list"] = "cli content for list"
@@ -201,12 +322,12 @@ public class CliTabWrapperTests
 
         Assert.Contains("#### [MCP Server](#tab/mcp-server)", result);
         Assert.Contains("cli content for list", result);
+        AssertCliTabBeforeMcpTab(result);
     }
 
     [Fact]
     public void ApplyTabsToFamilyArticle_NoMcpCliMarkers_NoTabsInjected()
     {
-        // Article with NO @mcpcli markers — MCP-only content
         const string mcpOnlyArticle = """
             ---
             ms.topic: include
@@ -241,10 +362,8 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(mcpOnlyArticle, cliContent);
 
-        // Verify no tab markers added (content may have normalized line endings)
         Assert.DoesNotContain("#### [MCP Server](#tab/mcp-server)", result);
         Assert.DoesNotContain("#### [Azure MCP CLI](#tab/azure-mcp-cli)", result);
-        // Verify original content is preserved (key sections present)
         Assert.Contains("# Azure Key Vault tools", result);
         Assert.Contains("## Overview", result);
         Assert.Contains("## List secrets", result);
@@ -274,8 +393,7 @@ public class CliTabWrapperTests
             ["some tool"] = "cli content"
         };
 
-        // Should not throw
-        var exception = Record.Exception(() => 
+        var exception = Record.Exception(() =>
             CliTabWrapper.ApplyTabsToFamilyArticle(mcpOnlyArticle, cliContent));
 
         Assert.Null(exception);
@@ -290,23 +408,16 @@ public class CliTabWrapperTests
             "| Parameter | Required |\n|---|---|\n| Sub | Yes |\n\n" +
             "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):\n\n" +
             "Destructive: ❌ | Idempotent: ✅ | Open World: ❌ | Read Only: ✅ | Secret: ❌ | Local Required: ❌";
-        var cliContent = "```bash\naz storage account list\n```\n\n| Parameter | Required |\n|---|---|\n| --sub | Yes |";
+        var cliContent = "List storage accounts.\n\n```bash\naz storage account list\n```\n\n| Parameter | Required |\n|---|---|\n| --sub | Yes |";
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // Annotation block should appear exactly once — after the --- separator
         var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
         Assert.Equal(1, annotationCount);
 
-        // Annotation must be AFTER the --- separator
         var separatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
         var annotationPos = result.IndexOf("[Tool annotation hints]", StringComparison.Ordinal);
         Assert.True(annotationPos > separatorPos, "Annotation should be after --- separator");
-
-        // Annotation must NOT be inside either tab
-        var mcpTabStart = result.IndexOf("#### [MCP Server](#tab/mcp-server)", StringComparison.Ordinal);
-        var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
-        Assert.True(annotationPos > separatorPos, "Annotation must be outside tabs");
     }
 
     [Fact]
@@ -317,7 +428,6 @@ public class CliTabWrapperTests
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // No annotation anywhere
         Assert.DoesNotContain("[Tool annotation hints]", result);
         Assert.Contains("az storage account list", result);
     }
@@ -328,20 +438,21 @@ public class CliTabWrapperTests
         var mcpContent = "Description.\n\n" +
             "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):\n\n" +
             "Destructive: ✅ | Idempotent: ❌ | Open World: ✅ | Read Only: ❌ | Secret: ❌ | Local Required: ❌";
-        var cliContent = "```bash\naz tool run\n```";
+        var cliContent = "Description.\n\n```bash\naz tool run\n```";
 
         var result = CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
-        // Annotation should be AFTER the --- terminator
         var terminatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
         var annotationPos = result.IndexOf("Destructive: ✅", StringComparison.Ordinal);
 
         Assert.True(annotationPos > terminatorPos, "Annotation should be after --- terminator");
 
-        // The MCP tab content should NOT contain annotation
-        var mcpTabStart = result.IndexOf("#### [MCP Server](#tab/mcp-server)", StringComparison.Ordinal);
         var cliTabStart = result.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
-        var mcpTabContent = result.Substring(mcpTabStart, cliTabStart - mcpTabStart);
+        var mcpTabStart = result.IndexOf("#### [MCP Server](#tab/mcp-server)", StringComparison.Ordinal);
+        var cliTabContent = result.Substring(cliTabStart, mcpTabStart - cliTabStart);
+        var mcpTabContent = result.Substring(mcpTabStart, terminatorPos - mcpTabStart);
+
+        Assert.DoesNotContain("[Tool annotation hints]", cliTabContent);
         Assert.DoesNotContain("[Tool annotation hints]", mcpTabContent);
     }
 
@@ -369,19 +480,24 @@ public class CliTabWrapperTests
 
         var cliContent = new Dictionary<string, string>
         {
-            ["storage account list"] = "```bash\naz storage account list\n```"
+            ["storage account list"] = "List storage accounts in a subscription.\n\n```bash\naz storage account list\n```"
         };
 
         var result = CliTabWrapper.ApplyTabsToFamilyArticle(familyWithAnnotations, cliContent);
 
-        // Annotation should appear exactly once — after the --- separator, outside tabs
         var annotationCount = CountOccurrences(result, "[Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):");
         Assert.Equal(1, annotationCount);
 
-        // Verify annotation is after --- separator
         var separatorPos = result.IndexOf("\n---", StringComparison.Ordinal);
         var annotationPos = result.IndexOf("[Tool annotation hints]", StringComparison.Ordinal);
         Assert.True(annotationPos > separatorPos, "Annotation should be after --- separator");
+    }
+
+    private static void AssertCliTabBeforeMcpTab(string text)
+    {
+        Assert.True(
+            text.IndexOf("#tab/azure-mcp-cli", StringComparison.Ordinal) <
+            text.IndexOf("#tab/mcp-server", StringComparison.Ordinal));
     }
 
     private static int CountOccurrences(string text, string pattern)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Fixtures/ToolWithNoAnnotations.md
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Fixtures/ToolWithNoAnnotations.md
@@ -17,20 +17,10 @@ The Azure MCP Server lets you manage Azure Storage resources.
 
 
 ## Account list
-#### [MCP Server](#tab/mcp-server)
-
-
-<!-- @mcpcli storage account list -->
 
 Lists all storage accounts in the subscription.
-
-| Parameter |  Required or optional | Description |
-|-----------------------|----------------------|-------------|
-| **Subscription** |  Required | The Azure subscription ID. |
 
 #### [Azure MCP CLI](#tab/azure-mcp-cli)
-
-Lists all storage accounts in the subscription.
 
 **Example CLI command**
 
@@ -42,6 +32,14 @@ azmcp storage account list \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `--subscription` | string | Yes | The Azure subscription ID. |
+
+#### [MCP Server](#tab/mcp-server)
+
+<!-- @mcpcli storage account list -->
+
+| Parameter |  Required or optional | Description |
+|-----------------------|----------------------|-------------|
+| **Subscription** |  Required | The Azure subscription ID. |
 
 ---
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Fixtures/ValidToolFamily.md
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Fixtures/ValidToolFamily.md
@@ -21,27 +21,10 @@ The Azure MCP Server lets you manage Azure Backup resources with natural languag
 
 
 ## Create vault
-#### [MCP Server](#tab/mcp-server)
-
-
-<!-- @mcpcli azurebackup vault create -->
 
 Creates a new backup vault.
-
-Example prompts include:
-
-- "Create vault 'rsv-backup-prod' in resource group 'rg-prod' in location 'eastus'."
-
-| Parameter |  Required or optional | Description |
-|-----------------------|----------------------|-------------|
-| **Location** |  Required | The Azure region. |
-| **Resource group** |  Required | The name of the Azure resource group. |
-| **Vault name** |  Required | The name of the backup vault. |
-| **Vault type** |  Optional | The type of backup vault: 'rsv' or 'dpp'. |
 
 #### [Azure MCP CLI](#tab/azure-mcp-cli)
-
-Creates a new backup vault.
 
 **Example CLI command**
 
@@ -60,6 +43,21 @@ azmcp azurebackup vault create \
 | `--location` | string | Yes | The Azure region. |
 | `--vault-type` | string | No | The type of backup vault: 'rsv' or 'dpp'. |
 
+#### [MCP Server](#tab/mcp-server)
+
+<!-- @mcpcli azurebackup vault create -->
+
+Example prompts include:
+
+- "Create vault 'rsv-backup-prod' in resource group 'rg-prod' in location 'eastus'."
+
+| Parameter |  Required or optional | Description |
+|-----------------------|----------------------|-------------|
+| **Location** |  Required | The Azure region. |
+| **Resource group** |  Required | The name of the Azure resource group. |
+| **Vault name** |  Required | The name of the backup vault. |
+| **Vault type** |  Optional | The type of backup vault: 'rsv' or 'dpp'. |
+
 ---
 
 [Tool annotation hints](index.md#tool-annotations-for-azure-mcp-server):
@@ -67,25 +65,10 @@ azmcp azurebackup vault create \
 Destructive: ✅ | Idempotent: ❌ | Open World: ❌ | Read Only: ❌ | Secret: ❌ | Local Required: ❌
 
 ## List policies
-#### [MCP Server](#tab/mcp-server)
-
-
-<!-- @mcpcli azurebackup policy list -->
 
 Lists all protection policies in the specified vault.
-
-Example prompts include:
-
-- "List all backup policies in my vault"
-
-| Parameter |  Required or optional | Description |
-|-----------------------|----------------------|-------------|
-| **Vault name** |  Required | The name of the Recovery Services vault |
-| **Resource group** |  Required | The resource group containing the vault |
 
 #### [Azure MCP CLI](#tab/azure-mcp-cli)
-
-Lists all protection policies in the specified vault.
 
 **Example CLI command**
 
@@ -99,6 +82,19 @@ azmcp azurebackup policy list \
 |-----------|------|----------|-------------|
 | `--vault-name` | string | Yes | The name of the Recovery Services vault |
 | `--resource-group` | string | Yes | The resource group containing the vault |
+
+#### [MCP Server](#tab/mcp-server)
+
+<!-- @mcpcli azurebackup policy list -->
+
+Example prompts include:
+
+- "List all backup policies in my vault"
+
+| Parameter |  Required or optional | Description |
+|-----------------------|----------------------|-------------|
+| **Vault name** |  Required | The name of the Recovery Services vault |
+| **Resource group** |  Required | The resource group containing the vault |
 
 ---
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/NlpParameterNameRegressionTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/NlpParameterNameRegressionTests.cs
@@ -281,7 +281,7 @@ public class NlpParameterNameRegressionTests
             var cliStart = section.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
             if (mcpStart < 0 || cliStart < 0) continue;
 
-            var mcpContent = section[mcpStart..cliStart];
+            var mcpContent = section[mcpStart..];
             var tableMatch = Regex.Match(mcpContent, @"(\| Parameter .+Required or optional.+\r?\n\|[-| ]+\r?\n(?:\|.+\r?\n)+)", RegexOptions.Multiline);
             if (tableMatch.Success)
                 tables.Add(tableMatch.Value.TrimEnd());

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/TabStructureRegressionTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/TabStructureRegressionTests.cs
@@ -15,11 +15,11 @@ public class TabStructureRegressionTests
     private static string FixturesDir => RegressionTestHelpers.FixturesDir;
     private static string RepoRoot => RegressionTestHelpers.RepoRoot;
 
-    // ── R-TS1: MCP tab appears first ─────────────────────────────────────
+    // ── R-TS1: CLI tab appears first ─────────────────────────────────────
 
     [Fact]
     [Trait("Category", "RegressionProtection")]
-    public void R_TS1_McpTabAppearsFirst()
+    public void R_TS1_CliTabAppearsFirst()
     {
         var content = LoadFixture("ValidToolFamily.md");
         var toolSections = GetToolSections(content);
@@ -31,16 +31,16 @@ public class TabStructureRegressionTests
 
             if (mcpIndex >= 0 && cliIndex >= 0)
             {
-                Assert.True(mcpIndex < cliIndex, "MCP tab must appear before CLI tab");
+                Assert.True(cliIndex < mcpIndex, "CLI tab must appear before MCP tab");
             }
         }
     }
 
-    // ── R-TS2: CLI tab appears second ────────────────────────────────────
+    // ── R-TS2: MCP tab appears second ────────────────────────────────────
 
     [Fact]
     [Trait("Category", "RegressionProtection")]
-    public void R_TS2_CliTabAppearsSecond()
+    public void R_TS2_McpTabAppearsSecond()
     {
         var content = LoadFixture("ValidToolFamily.md");
         var toolSections = GetToolSections(content);
@@ -52,7 +52,7 @@ public class TabStructureRegressionTests
 
             Assert.True(mcpIndex >= 0, "MCP tab header missing");
             Assert.True(cliIndex >= 0, "CLI tab header missing");
-            Assert.True(cliIndex > mcpIndex, "CLI tab must appear after MCP tab");
+            Assert.True(mcpIndex > cliIndex, "MCP tab must appear after CLI tab");
         }
     }
 
@@ -92,38 +92,17 @@ public class TabStructureRegressionTests
             var cliStart = section.IndexOf("#### [Azure MCP CLI](#tab/azure-mcp-cli)", StringComparison.Ordinal);
             if (mcpStart < 0 || cliStart < 0) continue;
 
-            // Content between MCP header and CLI header (MCP tab content)
-            var mcpHeaderEnd = section.IndexOf('\n', mcpStart) + 1;
-            var mcpContent = section[mcpHeaderEnd..cliStart];
-            Assert.Equal(0, RegressionTestHelpers.CountSeparatorsOutsideCodeBlocks(mcpContent));
-
-            // CLI tab content: from after CLI header to end of section
+            // CLI content is between the CLI header and MCP header.
             var cliHeaderEnd = section.IndexOf('\n', cliStart) + 1;
-            var cliContent = section[cliHeaderEnd..];
+            var cliContent = section[cliHeaderEnd..mcpStart];
+            Assert.Equal(0, RegressionTestHelpers.CountSeparatorsOutsideCodeBlocks(cliContent));
 
-            // Count separators in CLI tab — should be exactly 1 (the tab terminator)
-            var lines = cliContent.Split('\n');
-            bool inCodeBlock = false;
-            int separatorsBeforeTerminator = 0;
-            bool foundTerminator = false;
-            foreach (var line in lines)
-            {
-                var trimmed = line.TrimEnd('\r');
-                if (trimmed.StartsWith("```")) inCodeBlock = !inCodeBlock;
-                if (!inCodeBlock && trimmed == "---")
-                {
-                    if (!foundTerminator)
-                    {
-                        foundTerminator = true; // First --- is the tab terminator
-                    }
-                    else
-                    {
-                        separatorsBeforeTerminator++;
-                    }
-                }
-            }
-            Assert.True(foundTerminator, "Tab terminator --- not found in CLI tab content");
-            Assert.Equal(0, separatorsBeforeTerminator);
+            // MCP tab content is between the MCP header and the tab terminator.
+            var mcpHeaderEnd = section.IndexOf('\n', mcpStart) + 1;
+            var separatorIndex = RegressionTestHelpers.FindTabSeparatorIndex(section);
+            Assert.True(separatorIndex > mcpHeaderEnd, "Tab terminator --- not found after MCP tab");
+            var mcpContent = section[mcpHeaderEnd..separatorIndex];
+            Assert.Equal(0, RegressionTestHelpers.CountSeparatorsOutsideCodeBlocks(mcpContent));
         }
     }
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliTabValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliTabValidator.cs
@@ -26,6 +26,8 @@ public static class CliTabValidator
         int cliTabCount = 0;
         int tabTerminatorCount = 0;
         bool inTabGroup = false;
+        bool cliTabSeenInCurrentGroup = false;
+        bool mcpTabSeenInCurrentGroup = false;
         int lineNum = 0;
 
         foreach (var rawLine in lines)
@@ -33,23 +35,31 @@ public static class CliTabValidator
             lineNum++;
             var line = rawLine.TrimEnd('\r').Trim();
 
-            if (line == "#### [MCP Server](#tab/mcp-server)")
+            if (line == "#### [Azure MCP CLI](#tab/azure-mcp-cli)")
             {
                 if (inTabGroup)
-                    errors.Add($"Line {lineNum}: Nested tab group detected (MCP Server tab opened inside existing tab group).");
-                mcpTabCount++;
-                inTabGroup = true;
-            }
-            else if (line == "#### [Azure MCP CLI](#tab/azure-mcp-cli)")
-            {
-                if (!inTabGroup)
-                    errors.Add($"Line {lineNum}: CLI tab opened without preceding MCP Server tab.");
+                    errors.Add($"Line {lineNum}: Nested tab group detected (Azure MCP CLI tab opened inside existing tab group).");
                 cliTabCount++;
+                inTabGroup = true;
+                cliTabSeenInCurrentGroup = true;
+                mcpTabSeenInCurrentGroup = false;
+            }
+            else if (line == "#### [MCP Server](#tab/mcp-server)")
+            {
+                if (!inTabGroup || !cliTabSeenInCurrentGroup)
+                    errors.Add($"Line {lineNum}: MCP Server tab opened without preceding Azure MCP CLI tab.");
+                else if (mcpTabSeenInCurrentGroup)
+                    errors.Add($"Line {lineNum}: Nested tab group detected (MCP Server tab opened twice in the same tab group).");
+
+                mcpTabCount++;
+                mcpTabSeenInCurrentGroup = true;
             }
             else if (line == "---" && inTabGroup)
             {
                 tabTerminatorCount++;
                 inTabGroup = false;
+                cliTabSeenInCurrentGroup = false;
+                mcpTabSeenInCurrentGroup = false;
             }
         }
 

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliTabWrapper.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliTabWrapper.cs
@@ -18,6 +18,10 @@ public static class CliTabWrapper
     public static string WrapWithTabs(string mcpContent, string? cliContent)
         => Shared.CliTabWrapper.WrapWithTabs(mcpContent, cliContent);
 
+    /// <inheritdoc cref="Shared.CliTabWrapper.WrapWithTabsAndExtractDescription"/>
+    public static (string TabBlock, string? Description) WrapWithTabsAndExtractDescription(string mcpContent, string? cliContent)
+        => Shared.CliTabWrapper.WrapWithTabsAndExtractDescription(mcpContent, cliContent);
+
     /// <inheritdoc cref="Shared.CliTabWrapper.ApplyTabsToFamilyArticle"/>
     public static string ApplyTabsToFamilyArticle(
         string familyMarkdown,

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
@@ -1,6 +1,10 @@
 You are a technical documentation editor specializing in Microsoft Azure documentation and style guidelines.
 
-Your task is to review and improve tool documentation files for the Azure Model Context Protocol (MCP) server.
+Your task is to review and improve tool documentation files for the Azure MCP server.
+
+## Critical Rule — No MCP References in Tool Descriptions
+
+NEVER mention "Model Context Protocol", "MCP", or any protocol-level phrasing in tool descriptions. Tool descriptions must focus on what the tool DOES for the user, not what protocol it uses. The protocol is an implementation detail that users do not need to know.
 
 ## Microsoft Style Guide Standards
 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/system-prompt.txt
@@ -2,10 +2,6 @@ You are a technical documentation editor specializing in Microsoft Azure documen
 
 Your task is to review and improve tool documentation files for the Azure Model Context Protocol (MCP) server.
 
-## Branding Rule — MCP Tools, Not CLI Commands
-
-**MANDATORY**: Always use "this tool" instead of "this command" when referring to the current tool. These are MCP tools, not CLI commands. Likewise, use "tools" (not "commands") when referring to multiple MCP tools, and "tool name" (not "command name"). This applies to all description text you write or edit.
-
 ## Microsoft Style Guide Standards
 
 1. **Voice and Tone**

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/user-prompt-template.txt
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/user-prompt-template.txt
@@ -1,4 +1,4 @@
-Please review and improve the following Azure MCP tool documentation according to Microsoft style guidelines:
+Please review and improve the following Azure tool documentation according to Microsoft style guidelines:
 
 {0}
 

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/user-prompt-template.txt
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/prompts/user-prompt-template.txt
@@ -18,6 +18,4 @@ Focus on:
 10. **Convert any `--switch-name` references in description text to natural language** (e.g., `--resource-group` → "resource group") unless the switch name is a parameter keyword in the parameter table
 11. **Remove LLM-specific tool-calling guidance** from descriptions — strip "Use this tool when...", "Do not use this tool to...", "equivalent to `az ...`", tool disambiguation hints, and parameter-passing instructions aimed at AI agents. Rewrite to focus on what a human user can accomplish.
 12. **Backtick formatting consistency** — If a term in the tool description also appears in the parameter descriptions table enclosed in single backticks, apply the same backtick formatting to that term in the description text (e.g., if the parameter table uses `resource-group` in backticks, the description must also use `resource-group` with backticks)
-13. **Branding: "tool" not "command"** — Always use "this tool" instead of "this command" when referring to the current MCP tool. These are MCP tools, not CLI commands. Use "tools" (not "commands") for plural references.
-
 Return only the improved markdown content, maintaining the same structure and format.

--- a/shared/DocGeneration.Core.Shared.Tests/CliContentAssemblerTests.cs
+++ b/shared/DocGeneration.Core.Shared.Tests/CliContentAssemblerTests.cs
@@ -49,13 +49,13 @@ public class CliContentAssemblerTests : IDisposable
     // ── AssembleCliContent (single tool) ─────────────────────────────
 
     [Fact]
-    public void AssembleCliContent_IncludesDescription()
+    public void AssembleCliContent_DoesNotIncludeDescription()
     {
         var tool = MakeTool(description: "Lists all storage accounts in the subscription.");
 
         var result = CliContentAssembler.AssembleCliContent(tool);
 
-        Assert.Contains("Lists all storage accounts in the subscription.", result);
+        Assert.DoesNotContain("Lists all storage accounts in the subscription.", result);
     }
 
     [Fact]
@@ -87,8 +87,7 @@ public class CliContentAssemblerTests : IDisposable
 
         var result = CliContentAssembler.AssembleCliContent(tool);
 
-        // Should only have the description, no parameter table
-        Assert.Contains("Lists all storage accounts in the subscription.", result);
+        Assert.Equal(string.Empty, result);
         Assert.DoesNotContain("| Parameter", result);
     }
 
@@ -287,9 +286,7 @@ public class CliContentAssemblerTests : IDisposable
 
         var result = CliContentAssembler.AssembleCliContent(tool);
 
-        // Should produce output (even if description is empty)
-        Assert.NotNull(result);
-        Assert.True(result.Length > 0);
+        Assert.Equal(string.Empty, result);
     }
 
     [Fact]
@@ -299,7 +296,7 @@ public class CliContentAssemblerTests : IDisposable
 
         var result = CliContentAssembler.AssembleCliContent(tool);
 
-        Assert.NotNull(result);
+        Assert.Equal(string.Empty, result);
     }
 
     [Fact]

--- a/shared/DocGeneration.Core.Shared/CliContentAssembler.cs
+++ b/shared/DocGeneration.Core.Shared/CliContentAssembler.cs
@@ -23,10 +23,6 @@ public static class CliContentAssembler
     {
         var sb = new StringBuilder();
 
-        // CLI description (AI-improved)
-        sb.AppendLine(tool.Description);
-        sb.AppendLine();
-
         // Example commands (deterministic, from include file or generated)
         if (!string.IsNullOrWhiteSpace(exampleCommandsContent))
         {

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -14,6 +14,7 @@ public static class CliTabWrapper
 {
     private static readonly Regex McpCliMarkerPattern = new(
         @"<!--\s*@mcpcli\s+(.+?)\s*-->", RegexOptions.Compiled);
+    private static readonly Regex NumberedListPattern = new(@"^\d+\.\s", RegexOptions.Compiled);
 
     // Matches the annotation block: "[Tool annotation hints](...):"\n\n"Destructive: ..."
     // The block starts with the link line and includes the values line that follows.
@@ -35,9 +36,16 @@ public static class CliTabWrapper
         return tabBlock;
     }
 
+    /// <summary>
+    /// Wraps tool content with CLI/MCP tabs and extracts the natural language description.
+    /// The description is the first paragraph before any parameter table, heading, or code block.
+    /// </summary>
+    /// <param name="mcpContent">MCP tool section content (without H2 heading)</param>
+    /// <param name="cliContent">CLI content block, or null/whitespace if unavailable</param>
+    /// <returns>Tuple of tab-wrapped content and the extracted description (null if none found)</returns>
     public static (string TabBlock, string? Description) WrapWithTabsAndExtractDescription(string mcpContent, string? cliContent)
     {
-        if (cliContent is null)
+        if (string.IsNullOrWhiteSpace(cliContent))
             return (mcpContent, null);
 
         var (mcpContentWithoutDescription, description) = ExtractDescription(mcpContent);
@@ -84,34 +92,10 @@ public static class CliTabWrapper
     {
         var normalizedContent = content.ReplaceLineEndings("\n");
         var lines = normalizedContent.Split('\n');
-        var descriptionStart = 0;
-
-        while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
-        {
-            descriptionStart++;
-        }
-
-        if (descriptionStart < lines.Length && IsMcpMarker(lines[descriptionStart]))
-        {
-            descriptionStart++;
-
-            while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
-            {
-                descriptionStart++;
-            }
-        }
-
-        if (descriptionStart >= lines.Length || IsDescriptionBoundary(lines[descriptionStart]))
+        var (descriptionStart, descriptionEnd) = FindDescriptionRange(lines);
+        if (descriptionStart < 0)
         {
             return (content, null);
-        }
-
-        var descriptionEnd = descriptionStart;
-        while (descriptionEnd < lines.Length
-            && !string.IsNullOrWhiteSpace(lines[descriptionEnd])
-            && !IsDescriptionBoundary(lines[descriptionEnd]))
-        {
-            descriptionEnd++;
         }
 
         var description = string.Join(" ", lines[descriptionStart..descriptionEnd].Select(line => line.Trim())).Trim();
@@ -151,24 +135,10 @@ public static class CliTabWrapper
 
         var normalizedContent = cliContent.ReplaceLineEndings("\n");
         var lines = normalizedContent.Split('\n');
-        var descriptionStart = 0;
-
-        while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
-        {
-            descriptionStart++;
-        }
-
-        if (descriptionStart >= lines.Length || IsDescriptionBoundary(lines[descriptionStart]))
+        var (descriptionStart, descriptionEnd) = FindDescriptionRange(lines);
+        if (descriptionStart < 0)
         {
             return cliContent;
-        }
-
-        var descriptionEnd = descriptionStart;
-        while (descriptionEnd < lines.Length
-            && !string.IsNullOrWhiteSpace(lines[descriptionEnd])
-            && !IsDescriptionBoundary(lines[descriptionEnd]))
-        {
-            descriptionEnd++;
         }
 
         var cliDescription = string.Join(" ", lines[descriptionStart..descriptionEnd].Select(line => line.Trim())).Trim();
@@ -189,6 +159,41 @@ public static class CliTabWrapper
     private static bool IsMcpMarker(string line)
         => line.TrimStart().StartsWith("<!-- @mcpcli ", StringComparison.Ordinal);
 
+    private static (int Start, int End) FindDescriptionRange(string[] lines)
+    {
+        var descriptionStart = 0;
+
+        while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
+        {
+            descriptionStart++;
+        }
+
+        if (descriptionStart < lines.Length && IsMcpMarker(lines[descriptionStart]))
+        {
+            descriptionStart++;
+
+            while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
+            {
+                descriptionStart++;
+            }
+        }
+
+        if (descriptionStart >= lines.Length || IsDescriptionBoundary(lines[descriptionStart]))
+        {
+            return (-1, -1);
+        }
+
+        var descriptionEnd = descriptionStart;
+        while (descriptionEnd < lines.Length
+            && !string.IsNullOrWhiteSpace(lines[descriptionEnd])
+            && !IsDescriptionBoundary(lines[descriptionEnd]))
+        {
+            descriptionEnd++;
+        }
+
+        return (descriptionStart, descriptionEnd);
+    }
+
     private static bool IsDescriptionBoundary(string line)
     {
         var trimmed = line.TrimStart();
@@ -200,7 +205,7 @@ public static class CliTabWrapper
             || trimmed.StartsWith("- ", StringComparison.Ordinal)
             || trimmed.StartsWith("* ", StringComparison.Ordinal)
             || trimmed.StartsWith("+ ", StringComparison.Ordinal)
-            || Regex.IsMatch(trimmed, @"^\d+\.\s");
+            || NumberedListPattern.IsMatch(trimmed);
     }
 
     /// <summary>

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -42,16 +42,16 @@ public static class CliTabWrapper
 
         var sb = new StringBuilder();
 
-        // MCP Server tab
-        sb.AppendLine("#### [MCP Server](#tab/mcp-server)");
-        sb.AppendLine();
-        sb.AppendLine(mcpWithoutAnnotation.TrimEnd());
-        sb.AppendLine();
-
-        // CLI tab (no annotations inside)
+        // CLI tab first (ground truth, deterministic from tools JSON)
         sb.AppendLine("#### [Azure MCP CLI](#tab/azure-mcp-cli)");
         sb.AppendLine();
         sb.AppendLine(cliContent.TrimEnd());
+        sb.AppendLine();
+
+        // MCP Server tab second (AI-improved derivative)
+        sb.AppendLine("#### [MCP Server](#tab/mcp-server)");
+        sb.AppendLine();
+        sb.AppendLine(mcpWithoutAnnotation.TrimEnd());
         sb.AppendLine();
 
         // Tab group terminator

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -41,7 +41,8 @@ public static class CliTabWrapper
             return (mcpContent, null);
 
         var (mcpContentWithoutDescription, description) = ExtractDescription(mcpContent);
-        return (BuildTabBlock(mcpContentWithoutDescription, cliContent), description);
+        var cliContentWithoutDescription = StripMatchingDescriptionFromCli(cliContent, description);
+        return (BuildTabBlock(mcpContentWithoutDescription, cliContentWithoutDescription), description);
     }
 
     private static string BuildTabBlock(string mcpContent, string cliContent)
@@ -139,6 +140,50 @@ public static class CliTabWrapper
         remainingLines.AddRange(lines[remainderStart..]);
 
         return (string.Join("\n", remainingLines).TrimEnd(), description);
+    }
+
+    internal static string StripMatchingDescriptionFromCli(string cliContent, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return cliContent;
+        }
+
+        var normalizedContent = cliContent.ReplaceLineEndings("\n");
+        var lines = normalizedContent.Split('\n');
+        var descriptionStart = 0;
+
+        while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
+        {
+            descriptionStart++;
+        }
+
+        if (descriptionStart >= lines.Length || IsDescriptionBoundary(lines[descriptionStart]))
+        {
+            return cliContent;
+        }
+
+        var descriptionEnd = descriptionStart;
+        while (descriptionEnd < lines.Length
+            && !string.IsNullOrWhiteSpace(lines[descriptionEnd])
+            && !IsDescriptionBoundary(lines[descriptionEnd]))
+        {
+            descriptionEnd++;
+        }
+
+        var cliDescription = string.Join(" ", lines[descriptionStart..descriptionEnd].Select(line => line.Trim())).Trim();
+        if (!string.Equals(cliDescription, description, StringComparison.Ordinal))
+        {
+            return cliContent;
+        }
+
+        var remainderStart = descriptionEnd;
+        while (remainderStart < lines.Length && string.IsNullOrWhiteSpace(lines[remainderStart]))
+        {
+            remainderStart++;
+        }
+
+        return string.Join("\n", lines[..descriptionStart].Concat(lines[remainderStart..])).TrimEnd();
     }
 
     private static bool IsMcpMarker(string line)

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -49,8 +49,9 @@ public static class CliTabWrapper
             return (mcpContent, null);
 
         var (mcpContentWithoutDescription, description) = ExtractDescription(mcpContent);
+        var strippedMcpContent = StripProseFromMcpContent(mcpContentWithoutDescription);
         var cliContentWithoutDescription = StripMatchingDescriptionFromCli(cliContent, description);
-        return (BuildTabBlock(mcpContentWithoutDescription, cliContentWithoutDescription), description);
+        return (BuildTabBlock(strippedMcpContent, cliContentWithoutDescription), description);
     }
 
     private static string BuildTabBlock(string mcpContent, string cliContent)
@@ -156,8 +157,64 @@ public static class CliTabWrapper
         return string.Join("\n", lines[..descriptionStart].Concat(lines[remainderStart..])).TrimEnd();
     }
 
+    internal static string StripProseFromMcpContent(string content)
+    {
+        var normalizedContent = content.ReplaceLineEndings("\n");
+        var lines = normalizedContent.Split('\n');
+
+        var markerIndex = Array.FindIndex(lines, IsMcpMarker);
+        var markerEnd = 0;
+        if (markerIndex >= 0)
+        {
+            markerEnd = markerIndex + 1;
+            while (markerEnd < lines.Length && string.IsNullOrWhiteSpace(lines[markerEnd]))
+            {
+                markerEnd++;
+            }
+        }
+
+        var keepStart = -1;
+        for (int i = markerEnd; i < lines.Length; i++)
+        {
+            if (IsMcpTabContentStart(lines[i]))
+            {
+                keepStart = i;
+                break;
+            }
+        }
+
+        if (keepStart < 0)
+        {
+            return content.TrimEnd();
+        }
+
+        var keptLines = new List<string>();
+        if (markerIndex >= 0)
+        {
+            keptLines.Add(lines[markerIndex]);
+            keptLines.Add(string.Empty);
+        }
+
+        keptLines.AddRange(lines[keepStart..]);
+        return string.Join("\n", keptLines).TrimEnd();
+    }
+
     private static bool IsMcpMarker(string line)
         => line.TrimStart().StartsWith("<!-- @mcpcli ", StringComparison.Ordinal);
+
+    private static bool IsMcpTabContentStart(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("Example prompts", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("|", StringComparison.Ordinal)
+            || (IsBulletLine(trimmed) && trimmed.Contains('"'));
+    }
+
+    private static bool IsBulletLine(string line)
+        => line.StartsWith("- ", StringComparison.Ordinal)
+            || line.StartsWith("* ", StringComparison.Ordinal)
+            || line.StartsWith("+ ", StringComparison.Ordinal)
+            || NumberedListPattern.IsMatch(line);
 
     private static (int Start, int End) FindDescriptionRange(string[] lines)
     {

--- a/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
+++ b/shared/DocGeneration.Core.Shared/CliTabWrapper.cs
@@ -31,9 +31,21 @@ public static class CliTabWrapper
     /// <returns>Tab-wrapped content, or original content if no CLI available</returns>
     public static string WrapWithTabs(string mcpContent, string? cliContent)
     {
-        if (string.IsNullOrWhiteSpace(cliContent))
-            return mcpContent;
+        var (tabBlock, _) = WrapWithTabsAndExtractDescription(mcpContent, cliContent);
+        return tabBlock;
+    }
 
+    public static (string TabBlock, string? Description) WrapWithTabsAndExtractDescription(string mcpContent, string? cliContent)
+    {
+        if (cliContent is null)
+            return (mcpContent, null);
+
+        var (mcpContentWithoutDescription, description) = ExtractDescription(mcpContent);
+        return (BuildTabBlock(mcpContentWithoutDescription, cliContent), description);
+    }
+
+    private static string BuildTabBlock(string mcpContent, string cliContent)
+    {
         // Extract and strip annotation block from MCP content
         var annotationBlock = ExtractAnnotationBlock(mcpContent);
         var mcpWithoutAnnotation = annotationBlock != null
@@ -65,6 +77,85 @@ public static class CliTabWrapper
         }
 
         return sb.ToString();
+    }
+
+    internal static (string ContentWithoutDescription, string? Description) ExtractDescription(string content)
+    {
+        var normalizedContent = content.ReplaceLineEndings("\n");
+        var lines = normalizedContent.Split('\n');
+        var descriptionStart = 0;
+
+        while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
+        {
+            descriptionStart++;
+        }
+
+        if (descriptionStart < lines.Length && IsMcpMarker(lines[descriptionStart]))
+        {
+            descriptionStart++;
+
+            while (descriptionStart < lines.Length && string.IsNullOrWhiteSpace(lines[descriptionStart]))
+            {
+                descriptionStart++;
+            }
+        }
+
+        if (descriptionStart >= lines.Length || IsDescriptionBoundary(lines[descriptionStart]))
+        {
+            return (content, null);
+        }
+
+        var descriptionEnd = descriptionStart;
+        while (descriptionEnd < lines.Length
+            && !string.IsNullOrWhiteSpace(lines[descriptionEnd])
+            && !IsDescriptionBoundary(lines[descriptionEnd]))
+        {
+            descriptionEnd++;
+        }
+
+        var description = string.Join(" ", lines[descriptionStart..descriptionEnd].Select(line => line.Trim())).Trim();
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return (content, null);
+        }
+
+        var remainderStart = descriptionEnd;
+        while (remainderStart < lines.Length && string.IsNullOrWhiteSpace(lines[remainderStart]))
+        {
+            remainderStart++;
+        }
+
+        var remainingLines = lines[..descriptionStart].ToList();
+        while (remainingLines.Count > 0 && string.IsNullOrWhiteSpace(remainingLines[^1]))
+        {
+            remainingLines.RemoveAt(remainingLines.Count - 1);
+        }
+
+        if (remainingLines.Count > 0 && remainderStart < lines.Length)
+        {
+            remainingLines.Add(string.Empty);
+        }
+
+        remainingLines.AddRange(lines[remainderStart..]);
+
+        return (string.Join("\n", remainingLines).TrimEnd(), description);
+    }
+
+    private static bool IsMcpMarker(string line)
+        => line.TrimStart().StartsWith("<!-- @mcpcli ", StringComparison.Ordinal);
+
+    private static bool IsDescriptionBoundary(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("|", StringComparison.Ordinal)
+            || trimmed.StartsWith("#", StringComparison.Ordinal)
+            || trimmed.StartsWith("{{", StringComparison.Ordinal)
+            || trimmed.StartsWith("[Tool annotation", StringComparison.Ordinal)
+            || trimmed.StartsWith("```", StringComparison.Ordinal)
+            || trimmed.StartsWith("- ", StringComparison.Ordinal)
+            || trimmed.StartsWith("* ", StringComparison.Ordinal)
+            || trimmed.StartsWith("+ ", StringComparison.Ordinal)
+            || Regex.IsMatch(trimmed, @"^\d+\.\s");
     }
 
     /// <summary>
@@ -170,8 +261,16 @@ public static class CliTabWrapper
             var normalizedCmd = CliJsonMapper.NormalizeCommand(command);
             if (cliContentByCommand.TryGetValue(normalizedCmd, out var cliContent))
             {
+                var (tabBlock, description) = WrapWithTabsAndExtractDescription(content, cliContent);
                 result.AppendLine(heading);
-                result.AppendLine(WrapWithTabs(content, cliContent));
+                if (!string.IsNullOrWhiteSpace(description))
+                {
+                    result.AppendLine();
+                    result.AppendLine(description);
+                    result.AppendLine();
+                }
+
+                result.AppendLine(tabBlock);
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- remove MCP branding-only prompt instructions from tool improvement prompts
- emit Azure MCP CLI before MCP Server and move the shared description above both tabs
- update validators, fixtures, regression tests, and document the new output contract

## Validation
- dotnet build mcp-doc-generation.sln
- dotnet test mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DocGeneration.Steps.ToolFamilyCleanup.Tests.csproj *(fails on pre-existing CliTabConfigGenerationTests.R_CG2_AllNamespacesHaveGeneratedOutput: expected azurebackup generated output)*