### PR TITLE
fix: deterministic CLI marker reconciliation (approach #4)

### DIFF
--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliMarkerReconcilerTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliMarkerReconcilerTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+public class CliMarkerReconcilerTests
+{
+    [Fact]
+    public void Reconcile_FixesCorruptedMarker()
+    {
+        var markdown = "## Activity log: List\n\n<!-- @mcpcli monitor activity log list -->\n\nDescription here.";
+        var commands = new List<string?> { "monitor activitylog list" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli monitor activitylog list -->", result);
+        Assert.DoesNotContain("activity log list", result);
+    }
+
+    [Fact]
+    public void Reconcile_PreservesCorrectMarker()
+    {
+        var markdown = "## Metrics: Query\n\n<!-- @mcpcli monitor metrics query -->\n\nDescription.";
+        var commands = new List<string?> { "monitor metrics query" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli monitor metrics query -->", result);
+    }
+
+    [Fact]
+    public void Reconcile_InjectsMissingMarker()
+    {
+        var markdown = "## Activity log: List\n\nDescription without marker.";
+        var commands = new List<string?> { "monitor activitylog list" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli monitor activitylog list -->", result);
+    }
+
+    [Fact]
+    public void Reconcile_SkipsNullCommands()
+    {
+        var markdown = "## Tool One\n\n<!-- @mcpcli foo bar -->\n\n## Tool Two\n\nNo marker.";
+        var commands = new List<string?> { null, "baz qux" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli foo bar -->", result);
+        Assert.Contains("<!-- @mcpcli baz qux -->", result);
+    }
+
+    [Fact]
+    public void Reconcile_HandlesMultipleMarkers()
+    {
+        var markdown = @"## Tool A
+
+<!-- @mcpcli monitor activity log list -->
+
+Desc A.
+
+## Tool B
+
+<!-- @mcpcli monitor health models entity get -->
+
+Desc B.
+
+## Related content
+
+Links here.";
+        var commands = new List<string?> { "monitor activitylog list", "monitor healthmodels entity get" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli monitor activitylog list -->", result);
+        Assert.Contains("<!-- @mcpcli monitor healthmodels entity get -->", result);
+        Assert.DoesNotContain("activity log list", result);
+        Assert.DoesNotContain("health models entity", result);
+    }
+
+    [Fact]
+    public void Reconcile_SkipsRelatedContentH2()
+    {
+        var markdown = "## Tool A\n\n<!-- @mcpcli foo bar -->\n\nDesc.\n\n## Related content\n\nLinks.";
+        var commands = new List<string?> { "foo bar" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        var relatedIdx = result.IndexOf("## Related content");
+        var afterRelated = result[(relatedIdx + "## Related content".Length)..];
+        Assert.DoesNotContain("@mcpcli", afterRelated);
+    }
+
+    [Fact]
+    public void Reconcile_EmptyMarkdownReturnsUnchanged()
+    {
+        var result = CliMarkerReconciler.ReconcileAndInject("", new List<string?> { "foo" });
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void Reconcile_EmptyCommandsReturnsUnchanged()
+    {
+        var markdown = "## Tool\n\n<!-- @mcpcli foo bar -->\n\nDesc.";
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, new List<string?>());
+        Assert.Equal(markdown, result);
+    }
+
+    [Fact]
+    public void Reconcile_ExtraWhitespaceInMarker()
+    {
+        var markdown = "## Tool\n\n<!--  @mcpcli  monitor  activitylog  list  -->\n\nDesc.";
+        var commands = new List<string?> { "monitor activitylog list" };
+        var result = CliMarkerReconciler.ReconcileAndInject(markdown, commands);
+        Assert.Contains("<!-- @mcpcli monitor activitylog list -->", result);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/StyleGuidePostProcessorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/StyleGuidePostProcessorTests.cs
@@ -101,6 +101,15 @@ public class StyleGuidePostProcessorTests
     }
 
     [Fact]
+    public void Fix_DoesNotSplitCompoundWordsInsideMcpCliMarkers()
+    {
+        var input = "## Activity log: List\n\n<!-- @mcpcli monitor activitylog list -->\n\nThe activitylog shows events.";
+        var result = StyleGuidePostProcessor.Fix(input);
+        Assert.Contains("<!-- @mcpcli monitor activitylog list -->", result);
+        Assert.Contains("activity log", result.Split("-->")[1]);
+    }
+
+    [Fact]
     public void Fix_CompoundWord_SkipsFrontmatter()
     {
         var input = "---\ntitle: activitylog overview\n---\n\nThe activitylog tracks events.";

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliMarkerReconciler.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliMarkerReconciler.cs
@@ -36,7 +36,7 @@ public static class CliMarkerReconciler
     /// Null entries are skipped (tool had no @mcpcli annotation).
     /// </param>
     /// <returns>Markdown with all @mcpcli markers reconciled.</returns>
-    public static string Reconcile(string markdown, IReadOnlyList<string?> authoritativeCommands)
+    internal static string Reconcile(string markdown, IReadOnlyList<string?> authoritativeCommands)
     {
         if (string.IsNullOrEmpty(markdown) || authoritativeCommands.Count == 0)
             return markdown;

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliMarkerReconciler.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CliMarkerReconciler.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Deterministically reconciles @mcpcli markers in stitched markdown against
+/// authoritative command values from tool files.
+///
+/// This is the "schema-constrained" safety net (approach #4): even if AI or
+/// post-processors corrupt the CLI markers, this reconciler rewrites them to
+/// match the canonical commands extracted by ToolReader at parse time.
+///
+/// Run this AFTER all other post-processors in the stitching pipeline.
+/// Fixes: #638 (AI drift — compound word splitting in markers)
+/// </summary>
+public static class CliMarkerReconciler
+{
+    private static readonly Regex McpCliMarkerPattern = new(
+        @"<!--\s*@mcpcli\s+([^>]+?)\s*-->",
+        RegexOptions.Compiled);
+
+    private static readonly Regex H2Pattern = new(
+        @"^##\s+(.+)$",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Reconciles all @mcpcli markers in the markdown to match the authoritative
+    /// command list. Matches markers to commands by position (Nth H2 section → Nth command).
+    /// </summary>
+    /// <param name="markdown">The stitched markdown content.</param>
+    /// <param name="authoritativeCommands">
+    /// Ordered list of canonical CLI commands (from ToolContent.Command).
+    /// Null entries are skipped (tool had no @mcpcli annotation).
+    /// </param>
+    /// <returns>Markdown with all @mcpcli markers reconciled.</returns>
+    public static string Reconcile(string markdown, IReadOnlyList<string?> authoritativeCommands)
+    {
+        if (string.IsNullOrEmpty(markdown) || authoritativeCommands.Count == 0)
+            return markdown;
+
+        // Find all existing @mcpcli markers in document order
+        var markers = McpCliMarkerPattern.Matches(markdown);
+        if (markers.Count == 0)
+            return markdown;
+
+        // Build replacement map: for each marker, determine the correct command
+        // Strategy: positional matching (Nth marker → Nth authoritative command)
+        var result = markdown;
+
+        // Process in reverse order to preserve string indices during replacement
+        for (int i = markers.Count - 1; i >= 0; i--)
+        {
+            var markerMatch = markers[i];
+            var correspondingCommandIdx = i;
+
+            if (correspondingCommandIdx >= authoritativeCommands.Count)
+                continue;
+
+            var correctCommand = authoritativeCommands[correspondingCommandIdx];
+            if (string.IsNullOrEmpty(correctCommand))
+                continue;
+
+            var correctMarker = $"<!-- @mcpcli {correctCommand} -->";
+            var currentMarker = markerMatch.Value;
+
+            if (!string.Equals(currentMarker, correctMarker, StringComparison.Ordinal))
+            {
+                result = result.Remove(markerMatch.Index, markerMatch.Length)
+                               .Insert(markerMatch.Index, correctMarker);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Injects @mcpcli markers where missing and reconciles existing ones.
+    /// For tools that have a Command but no marker in their section, injects one
+    /// after the H2 heading. For existing markers, reconciles against authoritative values.
+    /// </summary>
+    /// <param name="markdown">The stitched markdown content.</param>
+    /// <param name="authoritativeCommands">
+    /// Ordered list of canonical CLI commands matching H2 section order.
+    /// </param>
+    /// <returns>Markdown with all markers present and correct.</returns>
+    public static string ReconcileAndInject(string markdown, IReadOnlyList<string?> authoritativeCommands)
+    {
+        if (string.IsNullOrEmpty(markdown) || authoritativeCommands.Count == 0)
+            return markdown;
+
+        // First pass: reconcile existing markers
+        var reconciled = Reconcile(markdown, authoritativeCommands);
+
+        // Second pass: ensure every tool H2 has a marker
+        var h2Matches = H2Pattern.Matches(reconciled);
+
+        // Skip "## Related content" at the end
+        var toolH2s = h2Matches
+            .Where(m => !m.Groups[1].Value.Trim().Equals("Related content", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        // Process in reverse to preserve indices
+        for (int i = Math.Min(toolH2s.Count, authoritativeCommands.Count) - 1; i >= 0; i--)
+        {
+            var h2Match = toolH2s[i];
+            var command = authoritativeCommands[i];
+            if (string.IsNullOrEmpty(command))
+                continue;
+
+            var expectedMarker = $"<!-- @mcpcli {command} -->";
+
+            // Check if marker already exists after this H2
+            var afterH2Start = h2Match.Index + h2Match.Length;
+            var searchEnd = Math.Min(afterH2Start + 200, reconciled.Length);
+            var searchRegion = reconciled[afterH2Start..searchEnd];
+
+            if (!searchRegion.Contains("@mcpcli", StringComparison.Ordinal))
+            {
+                // No marker found — inject after the H2 line
+                reconciled = reconciled.Insert(afterH2Start, $"\n\n{expectedMarker}");
+            }
+        }
+
+        return reconciled;
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyFileStitcher.cs
@@ -40,17 +40,21 @@ public class FamilyFileStitcher
         sb.AppendLine();
 
         // 2. Tool sections - group by resource type if multi-resource (#412)
+        // Track the ordered tool commands for deterministic marker reconciliation
         var isMultiResource = IsMultiResourceFamily(familyContent.Tools);
+        List<string?> orderedCommands;
 
         if (isMultiResource)
         {
-            StitchMultiResource(sb, familyContent.Tools);
+            orderedCommands = StitchMultiResource(sb, familyContent.Tools);
         }
         else
         {
             // Sort tools for consistent single-resource presentation order (#503).
             // Ordering delegated to ToolOrderingPolicy (alphabetical by ToolName).
-            foreach (var tool in ToolOrderingPolicy.OrderForSingleResource(familyContent.Tools))
+            var orderedTools = ToolOrderingPolicy.OrderForSingleResource(familyContent.Tools).ToList();
+            orderedCommands = orderedTools.Select(t => t.Command).ToList();
+            foreach (var tool in orderedTools)
             {
                 sb.AppendLine(tool.Content);
                 sb.AppendLine();
@@ -109,6 +113,11 @@ public class FamilyFileStitcher
         // 15. Post-processing: escape bare <placeholder> values for MS Learn validation (#416)
         markdown = PlaceholderEscaper.Escape(markdown);
 
+        // 16. Post-processing: deterministic CLI marker reconciliation (#638)
+        // Safety net — ensures @mcpcli markers match authoritative commands from tool files,
+        // regardless of what any previous AI step or post-processor may have done.
+        markdown = CliMarkerReconciler.ReconcileAndInject(markdown, orderedCommands);
+
         return markdown;
     }
 
@@ -136,9 +145,11 @@ public class FamilyFileStitcher
     /// Emits tool sections for multi-resource families. Each tool gets a flat H2 heading
     /// in "Resource type: action" format. No resource group headers or heading demotion —
     /// the published articles use H2 per tool only.
+    /// Returns the ordered list of commands matching output order for reconciliation.
     /// </summary>
-    private static void StitchMultiResource(StringBuilder sb, List<ToolContent> tools)
+    private static List<string?> StitchMultiResource(StringBuilder sb, List<ToolContent> tools)
     {
+        var orderedCommands = new List<string?>();
         // Group tools preserving existing sort order (already sorted by resource type then verb)
         var groups = new List<(string ResourceType, List<ToolContent> Tools)>();
         string currentResourceType = "";
@@ -167,8 +178,11 @@ public class FamilyFileStitcher
                 var reformattedContent = ReformatToolHeadingForMultiResource(tool);
                 sb.AppendLine(reformattedContent);
                 sb.AppendLine();
+                orderedCommands.Add(tool.Command);
             }
         }
+
+        return orderedCommands;
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/StyleGuidePostProcessor.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/StyleGuidePostProcessor.cs
@@ -143,6 +143,7 @@ public static class StyleGuidePostProcessor
             return key;
         });
 
+        // MC = McpCli comment (matches CB=CodeBlock, IC=InlineCode, HD=HeaDing convention)
         body = McpCliCommentPattern.Replace(body, m =>
         {
             var key = $"\x00MC{placeholderIndex++}\x00";

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/StyleGuidePostProcessor.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/StyleGuidePostProcessor.cs
@@ -34,6 +34,11 @@ public static class StyleGuidePostProcessor
         @"^#{1,6}\s.*$",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
+    // Matches @mcpcli HTML comments that must not be modified by prose processors
+    private static readonly Regex McpCliCommentPattern = new(
+        @"<!--\s*@mcpcli\s+[^>]+?-->",
+        RegexOptions.Compiled);
+
     // ── A. Compound word rules (loaded once from JSON) ──────────────
 
     private static readonly List<(Regex Pattern, string Replacement)> CompoundWordRules = LoadCompoundWordRules();
@@ -134,6 +139,13 @@ public static class StyleGuidePostProcessor
         body = HeadingPattern.Replace(body, m =>
         {
             var key = $"\x00HD{placeholderIndex++}\x00";
+            placeholders[key] = m.Value;
+            return key;
+        });
+
+        body = McpCliCommentPattern.Replace(body, m =>
+        {
+            var key = $"\x00MC{placeholderIndex++}\x00";
             placeholders[key] = m.Value;
             return key;
         });

--- a/mcp-tools/data/brand-to-server-mapping.json
+++ b/mcp-tools/data/brand-to-server-mapping.json
@@ -443,5 +443,14 @@
     "mergeGroup": "azure-monitor",
     "mergeOrder": 2,
     "mergeRole": "secondary"
+  },
+  {
+    "brandName": "Azure Sreagent",
+    "mcpServerName": "sreagent",
+    "shortName": "Sreagent",
+    "fileName": "azure-sreagent",
+    "mergeGroup": null,
+    "mergeOrder": null,
+    "mergeRole": null
   }
 ]


### PR DESCRIPTION
## Problem

The StyleGuidePostProcessor applies compound-word splitting rules to article body text but was not protecting @mcpcli HTML comment markers. This caused CLI commands like monitor activitylog list to be word-split into monitor activity log list, breaking the cross-reference validator in Step 4.

**Root cause:** StyleGuidePostProcessor.Fix() protects code blocks, inline code, and headings with placeholders before applying transformations — but HTML comments were not included in the protection set.

## Fix (Approach #4: Schema-Constrained Deterministic Reconciliation)

### 1. Immediate bug fix — StyleGuidePostProcessor
Added @mcpcli HTML comment pattern to the placeholder protection set. Markers are now substituted with placeholders before any prose transformations and restored after.

### 2. Safety net — CliMarkerReconciler (new)
A deterministic post-processor that runs as the **final step** in FamilyFileStitcher.Stitch(). It:
- Takes the ordered list of authoritative commands (from ToolContent.Command, parsed by ToolReader from tool files)
- Positionally matches each @mcpcli marker in the output to its canonical command
- Rewrites any marker that doesn't match the authoritative value
- Injects missing markers where a tool H2 exists without one

This is the belt-and-suspenders approach: even if AI or any future processor corrupts a marker, the reconciler deterministically corrects it.

### 3. Command ordering — FamilyFileStitcher
Modified Stitch() to track ordered tool commands through both single-resource and multi-resource stitching paths, passing them to the reconciler.

## Also included
- rand-to-server-mapping.json: Added new upstream namespace sreagent

## Testing
- 897/898 ToolFamilyCleanup tests pass (1 pre-existing env-dependent failure)
- 9/9 Validation tests pass
- 455/455 PipelineRunner tests pass
- Zero warnings, zero errors