### PR TITLE
feat: Phase 2 contract enforcement (Points 4, 5, 7, 9, 15, 17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Completed npm-to-dotnet migration** — Removed all Node.js scripts from `mcp-cli-metadata/`. CLI metadata extraction now uses `mcp-tools/McpCliMetadata/` exclusively. Updated CI workflows, preflight.ps1, and documentation. Closes #627.
+- **PipelineRunner stage observability contract** — Each step now emits a standard observability bundle under `{output}/observability/{stepId}-{slug}/`: `summary.md`, `step-result.json`, `validation.json`, `prompt-preview.txt` (or `prompt-preview-na.txt` for deterministic steps), and `metrics.json`. Missing files are enforced at warning level so incomplete step instrumentation surfaces immediately without breaking existing runs.
 
 ### Fixed
 
+- **PipelineRunner step-result enforcement** — Every PipelineRunner step wrapper now writes a shared `step-result.json` envelope to `{output}/step-<id>-<slug>/` after `ExecuteAsync` and post-validation complete, including dry-run placeholders. Missing envelopes are now treated as fatal for non-warn steps, while warn-only steps continue with a warning. 
 - **`AzmcpRunner` PATH resolution on Windows** — `Process.Start` with `UseShellExecute=false` does not reliably resolve `.cmd` batch wrappers from `PATH`. `AzmcpRunner` now walks each `PATH` directory to locate `azmcp.cmd` (Windows) or `azmcp` (non-Windows) and passes the full absolute path to `Process.Start`, falling back to the bare name if not found. This fixes `azmcp` invocation failures when the `azure.mcp` dotnet global tool is installed at `~/.dotnet/tools/azmcp.cmd`. Extracted to `internal static ResolveBinaryPath()` for testability.
 - **`BootstrapStep` migrated from npm to dotnet tool** — The bootstrap step previously ran `npm install -g @azure/mcp@latest` to update the MCP CLI. This has been replaced with `dotnet tool update azure.mcp --global`, matching the current installation method. Removed the dead `GetNpmExecutable()` helper and unused `CaptureCommandOutputAsync` method. The `--skip-npm-update` / `SkipNpmUpdate` flag is preserved for backwards compatibility with existing CLI scripts.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,6 +109,7 @@ Final Output ──────────────────────�
   ├── annotations/*.md                   ← Include files
   ├── parameters/*.md                    ← Include files
   ├── example-prompts/*.md               ← Include files
+  ├── observability/{stepId}-{slug}/     ← 5-file step observability contract
   └── reports/                           ← Validation reports
 
 Post-Assembly: Multi-Namespace Merge (AD-011) ────────────────────
@@ -172,6 +173,8 @@ The pipeline migrated from PowerShell scripts to a typed C# orchestrator. This p
 - **Integrated retry logic** for AI-dependent steps
 - **Post-validation framework** (`IPostValidator`) attached to specific steps
 - **Isolated workspaces** via `WorkspaceManager` for parallel execution
+- **Per-step execution envelopes** written to `{output}/step-<id>-<slug>/step-result.json` after each wrapper completes so downstream automation can inspect normalized status, outputs, validation state, and timing without reading step-specific logs
+- **Per-step observability bundles** written to `{output}/observability/{stepId}-{slug}/` with `summary.md`, `step-result.json`, `validation.json`, `prompt-preview.txt` (or `prompt-preview-na.txt`), and `metrics.json`; missing files log warnings so instrumentation gaps are visible without breaking the pipeline
 
 Legacy PowerShell scripts remain in `mcp-tools/scripts/` as fallback.
 
@@ -404,6 +407,10 @@ Both pipelines emit structured trace files after every run to `{output-dir}/trac
 | `summary.md` | Human-readable run summary with step table and AI statistics |
 
 Tracing is always-on (no opt-in flag), uses in-memory collection during execution, and flushes once at the end of each run. The `NullTracer` pattern ensures zero overhead when the tracer is not wired (e.g., in unit tests).
+
+PipelineRunner also writes a shared `step-result.json` envelope for every selected step under `{output-dir}/step-<id>-<slug>/`. Dry runs emit the same envelope with placeholder values, and missing envelopes abort the run for fatal steps while warn-only steps continue.
+
+In addition, every executed step now gets an observability directory at `{output-dir}/observability/{stepId}-{slug}/`. The runner writes `summary.md`, `validation.json`, and `metrics.json`, writes `prompt-preview-na.txt` for deterministic steps, and checks for the full 5-file contract (`prompt-preview.txt` for AI/hybrid steps). Missing contract files are surfaced as warnings so partial instrumentation is visible during rollout.
 
 ### Trace Architecture
 

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/AnnotationsToToolGenerationContractTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/AnnotationsToToolGenerationContractTests.cs
@@ -1,0 +1,102 @@
+using Shared;
+using Xunit;
+
+namespace DocGeneration.PipelineRunner.Tests.Contracts;
+
+[Trait("Category", "Contract")]
+public class AnnotationsToToolGenerationContractTests : IDisposable
+{
+    private readonly string _fixtureDir;
+
+    public AnnotationsToToolGenerationContractTests()
+    {
+        _fixtureDir = Path.Combine(Path.GetTempPath(), $"contract-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_fixtureDir);
+    }
+
+    [Fact]
+    public void ValidUpstreamEnvelope_DeserializesSuccessfully()
+    {
+        var envelope = new StepResultFile
+        {
+            Version = 3,
+            SchemaVersion = "1.0",
+            Status = StepResultStatus.Success,
+            Step = "Generate annotations, parameters, and raw tools",
+            StepName = "step-1-generate-annotations-parameters-and-raw-tools",
+            Namespace = "azure-monitor",
+            OutputFileCount = 3,
+            DurationMs = 1200,
+            Timestamp = "2026-05-29T10:00:00Z",
+            OutputArtifacts =
+            [
+                new ArtifactReference { Path = "annotations/azure-monitor-list-workspaces-annotations.md", Sha256 = "abc123" },
+                new ArtifactReference { Path = "parameters/azure-monitor-list-workspaces-parameters.md", Sha256 = "def456" },
+                new ArtifactReference { Path = "tools-raw/azure-monitor-list-workspaces.md", Sha256 = "ghi789" }
+            ]
+        };
+        StepResultWriter.Write(_fixtureDir, envelope);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Equal("1.0", result!.SchemaVersion);
+        Assert.Equal("step-1-generate-annotations-parameters-and-raw-tools", result.StepName);
+        Assert.Equal(StepResultStatus.Success, result.Status);
+        Assert.NotNull(result.OutputArtifacts);
+        Assert.Equal(3, result.OutputArtifacts!.Count);
+    }
+
+    [Fact]
+    public void MismatchedSchemaVersion_ThrowsStepResultSchemaException()
+    {
+        var json = """
+        {
+            "version": 3,
+            "schemaVersion": "99.0",
+            "status": "success",
+            "step": "Generate annotations, parameters, and raw tools",
+            "stepName": "step-1-generate-annotations-parameters-and-raw-tools",
+            "namespace": "azure-monitor",
+            "outputFileCount": 3
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        Assert.Throws<StepResultSchemaException>(() => StepResultReader.TryRead(_fixtureDir, out _));
+    }
+
+    [Fact]
+    public void LegacyV0Envelope_DeserializesWithoutException()
+    {
+        var json = """
+        {
+            "version": 1,
+            "status": "success",
+            "step": "Generate annotations, parameters, and raw tools",
+            "namespace": "azure-monitor",
+            "outputFileCount": 3,
+            "warnings": [],
+            "errors": [],
+            "duration": "00:01:12.000"
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Null(result!.SchemaVersion);
+        Assert.Null(result.StepName);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_fixtureDir))
+        {
+            Directory.Delete(_fixtureDir, recursive: true);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/FamilyCleanupToHorizontalArticlesContractTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/FamilyCleanupToHorizontalArticlesContractTests.cs
@@ -1,0 +1,101 @@
+using Shared;
+using Xunit;
+
+namespace DocGeneration.PipelineRunner.Tests.Contracts;
+
+[Trait("Category", "Contract")]
+public class FamilyCleanupToHorizontalArticlesContractTests : IDisposable
+{
+    private readonly string _fixtureDir;
+
+    public FamilyCleanupToHorizontalArticlesContractTests()
+    {
+        _fixtureDir = Path.Combine(Path.GetTempPath(), $"contract-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_fixtureDir);
+    }
+
+    [Fact]
+    public void ValidUpstreamEnvelope_DeserializesSuccessfully()
+    {
+        var envelope = new StepResultFile
+        {
+            Version = 3,
+            SchemaVersion = "1.0",
+            Status = StepResultStatus.Success,
+            Step = "Generate tool-family article",
+            StepName = "step-4-generate-tool-family-article",
+            Namespace = "azure-monitor",
+            OutputFileCount = 1,
+            DurationMs = 3100,
+            Timestamp = "2026-05-29T10:10:00Z",
+            OutputArtifacts =
+            [
+                new ArtifactReference { Path = "tool-family/azure-monitor.md", Sha256 = "abc123" }
+            ]
+        };
+        StepResultWriter.Write(_fixtureDir, envelope);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Equal("1.0", result!.SchemaVersion);
+        Assert.Equal("step-4-generate-tool-family-article", result.StepName);
+        Assert.Equal(StepResultStatus.Success, result.Status);
+        Assert.NotNull(result.OutputArtifacts);
+        Assert.Single(result.OutputArtifacts!);
+        Assert.Equal("tool-family/azure-monitor.md", result.OutputArtifacts[0].Path);
+    }
+
+    [Fact]
+    public void MismatchedSchemaVersion_ThrowsStepResultSchemaException()
+    {
+        var json = """
+        {
+            "version": 3,
+            "schemaVersion": "99.0",
+            "status": "success",
+            "step": "Generate tool-family article",
+            "stepName": "step-4-generate-tool-family-article",
+            "namespace": "azure-monitor",
+            "outputFileCount": 1
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        Assert.Throws<StepResultSchemaException>(() => StepResultReader.TryRead(_fixtureDir, out _));
+    }
+
+    [Fact]
+    public void LegacyV0Envelope_DeserializesWithoutException()
+    {
+        var json = """
+        {
+            "version": 1,
+            "status": "success",
+            "step": "Generate tool-family article",
+            "namespace": "azure-monitor",
+            "outputFileCount": 1,
+            "warnings": [],
+            "errors": [],
+            "duration": "00:03:05.000"
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Null(result!.SchemaVersion);
+        Assert.Null(result.StepName);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_fixtureDir))
+        {
+            Directory.Delete(_fixtureDir, recursive: true);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/ToolGenerationToFamilyCleanupContractTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Contracts/ToolGenerationToFamilyCleanupContractTests.cs
@@ -1,0 +1,102 @@
+using Shared;
+using Xunit;
+
+namespace DocGeneration.PipelineRunner.Tests.Contracts;
+
+[Trait("Category", "Contract")]
+public class ToolGenerationToFamilyCleanupContractTests : IDisposable
+{
+    private readonly string _fixtureDir;
+
+    public ToolGenerationToFamilyCleanupContractTests()
+    {
+        _fixtureDir = Path.Combine(Path.GetTempPath(), $"contract-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_fixtureDir);
+    }
+
+    [Fact]
+    public void ValidUpstreamEnvelope_DeserializesSuccessfully()
+    {
+        var envelope = new StepResultFile
+        {
+            Version = 3,
+            SchemaVersion = "1.0",
+            Status = StepResultStatus.Success,
+            Step = "Compose and improve tool files",
+            StepName = "step-3-compose-and-improve-tool-files",
+            Namespace = "azure-monitor",
+            OutputFileCount = 2,
+            DurationMs = 2400,
+            Timestamp = "2026-05-29T10:05:00Z",
+            OutputArtifacts =
+            [
+                new ArtifactReference { Path = "tools/azure-monitor-list-workspaces.md", Sha256 = "abc123" },
+                new ArtifactReference { Path = "tools/azure-monitor-query-logs.md", Sha256 = "def456" }
+            ]
+        };
+        StepResultWriter.Write(_fixtureDir, envelope);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Equal("1.0", result!.SchemaVersion);
+        Assert.Equal("step-3-compose-and-improve-tool-files", result.StepName);
+        Assert.Equal(StepResultStatus.Success, result.Status);
+        Assert.NotNull(result.OutputArtifacts);
+        Assert.Equal(2, result.OutputArtifacts!.Count);
+        Assert.All(result.OutputArtifacts, artifact => Assert.StartsWith("tools/", artifact.Path, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MismatchedSchemaVersion_ThrowsStepResultSchemaException()
+    {
+        var json = """
+        {
+            "version": 3,
+            "schemaVersion": "99.0",
+            "status": "success",
+            "step": "Compose and improve tool files",
+            "stepName": "step-3-compose-and-improve-tool-files",
+            "namespace": "azure-monitor",
+            "outputFileCount": 2
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        Assert.Throws<StepResultSchemaException>(() => StepResultReader.TryRead(_fixtureDir, out _));
+    }
+
+    [Fact]
+    public void LegacyV0Envelope_DeserializesWithoutException()
+    {
+        var json = """
+        {
+            "version": 1,
+            "status": "success",
+            "step": "Compose and improve tool files",
+            "namespace": "azure-monitor",
+            "outputFileCount": 2,
+            "warnings": [],
+            "errors": [],
+            "duration": "00:02:15.000"
+        }
+        """;
+        File.WriteAllText(Path.Combine(_fixtureDir, "step-result.json"), json);
+
+        var success = StepResultReader.TryRead(_fixtureDir, out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Null(result!.SchemaVersion);
+        Assert.Null(result.StepName);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_fixtureDir))
+        {
+            Directory.Delete(_fixtureDir, recursive: true);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/DryRunIntegrationTests.cs
@@ -3,6 +3,7 @@ using PipelineRunner.Context;
 using PipelineRunner.Registry;
 using PipelineRunner.Services;
 using PipelineRunner.Tests.Fixtures;
+using Shared;
 using Xunit;
 
 namespace PipelineRunner.Tests.Integration;
@@ -20,6 +21,7 @@ public class DryRunIntegrationTests
         {
             var processRunner = new RecordingProcessRunner();
             var reportWriter = new BufferedReportWriter();
+            var stepRegistry = StepRegistry.CreateDefault(Path.Combine(repoRoot, "mcp-tools", "scripts"));
             var contextFactory = new PipelineContextFactory(
                 processRunner,
                 new WorkspaceManager(),
@@ -32,7 +34,7 @@ public class DryRunIntegrationTests
                 repoRoot);
 
             var runner = new global::PipelineRunner.PipelineRunner(
-                StepRegistry.CreateDefault(Path.Combine(repoRoot, "mcp-tools", "scripts")),
+                stepRegistry,
                 contextFactory);
 
             var request = new PipelineRequest("compute", new[] { 1, 2, 3, 4, 5, 6 }, ".\\generated-compute", false, false, true, SkipChangelogGate: true);
@@ -48,6 +50,25 @@ public class DryRunIntegrationTests
             Assert.Contains(reportWriter.Messages, message => message.Contains("Step 6: Generate horizontal article [Namespace, Fatal, Typed]", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("Post-validators: ToolFamilyPostAssemblyValidator", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("Dependency check: passed", StringComparison.Ordinal));
+
+            var outputRoot = Path.GetFullPath(Path.Combine(repoRoot, "generated-compute"));
+            var selectedSteps = stepRegistry.GetOrderedSteps(request.Steps).ToDictionary(step => step.Id);
+            var step1Directory = Path.Combine(outputRoot, global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[1]));
+            var step2Directory = Path.Combine(outputRoot, global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[2]));
+            var step3Directory = Path.Combine(outputRoot, global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[3]));
+
+            Assert.True(StepResultReader.TryRead(step1Directory, out var step1Envelope));
+            Assert.NotNull(step1Envelope);
+            Assert.Equal(global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[1]), step1Envelope!.StepName);
+
+            Assert.True(StepResultReader.TryRead(step2Directory, out var step2Envelope));
+            Assert.NotNull(step2Envelope);
+            Assert.Equal(global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[2]), step2Envelope!.StepName);
+
+            Assert.True(StepResultReader.TryRead(step3Directory, out var step3Envelope));
+            Assert.NotNull(step3Envelope);
+            Assert.Equal(global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(selectedSteps[3]), step3Envelope!.StepName);
+            Assert.Equal(StepResultStatus.Success, step3Envelope.Status);
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Services/UpstreamArtifactResolverTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Services/UpstreamArtifactResolverTests.cs
@@ -1,0 +1,90 @@
+using PipelineRunner.Services;
+using Shared;
+using Xunit;
+
+namespace PipelineRunner.Tests.Services;
+
+public sealed class UpstreamArtifactResolverTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly UpstreamArtifactResolver _resolver = new();
+
+    public UpstreamArtifactResolverTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), $"upstream-artifact-resolver-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryReadUpstream_ReturnsEnvelope_WhenStepResultExists()
+    {
+        var upstreamDir = Path.Combine(_testRoot, "step-3-compose-and-improve-tool-files");
+        StepResultWriter.Write(upstreamDir, new StepResultFile
+        {
+            SchemaVersion = "1.0",
+            Status = StepResultStatus.Success,
+            Step = "Compose and improve tool files",
+            StepName = "step-3-compose-and-improve-tool-files",
+            Namespace = "compute",
+            OutputArtifacts =
+            [
+                new ArtifactReference { Path = "tools/compute-list.md", Sha256 = "abc123" }
+            ]
+        });
+
+        var result = _resolver.TryReadUpstream(_testRoot, 3, "compose-and-improve-tool-files");
+
+        Assert.NotNull(result);
+        Assert.Equal("1.0", result!.SchemaVersion);
+        Assert.Single(result.OutputArtifacts!);
+    }
+
+    [Fact]
+    public void TryReadUpstream_ReturnsNull_WhenDirectoryDoesNotExist()
+    {
+        var result = _resolver.TryReadUpstream(_testRoot, 9, "missing-step");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryReadUpstream_ReturnsNull_WhenStepResultIsMissing()
+    {
+        Directory.CreateDirectory(Path.Combine(_testRoot, "step-2-generate-example-prompts"));
+
+        var result = _resolver.TryReadUpstream(_testRoot, 2, "generate-example-prompts");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryReadUpstream_ThrowsStepResultSchemaException_OnVersionMismatch()
+    {
+        var upstreamDir = Path.Combine(_testRoot, "step-1-generate-annotations-parameters-and-raw-tools");
+        Directory.CreateDirectory(upstreamDir);
+        File.WriteAllText(
+            Path.Combine(upstreamDir, StepResultWriter.FileName),
+            """
+            {
+              "version": 3,
+              "schemaVersion": "9.9",
+              "status": "success",
+              "step": "Generate annotations, parameters, and raw tools",
+              "namespace": "compute"
+            }
+            """);
+
+        var ex = Assert.Throws<StepResultSchemaException>(
+            () => _resolver.TryReadUpstream(_testRoot, 1, "generate-annotations-parameters-and-raw-tools"));
+
+        Assert.Equal("9.9", ex.ActualVersion);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ObservabilityContractTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ObservabilityContractTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Contracts;
+using PipelineRunner.Registry;
+using PipelineRunner.Services;
+using PipelineRunner.Tests.Fixtures;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public class ObservabilityContractTests
+{
+    [Fact]
+    public void StageOutputContract_GetExpectedFiles_UsesDeterministicPromptPlaceholder()
+    {
+        var contract = new StageOutputContract(
+            "Generate annotations",
+            Path.Combine("C:", "repo", "generated", "observability", "1-generate-annotations"),
+            IsDeterministic: true);
+
+        var expectedFiles = contract.GetExpectedFiles();
+
+        Assert.Equal(5, expectedFiles.Count);
+        Assert.Contains(expectedFiles, path => path.EndsWith(Path.Combine("1-generate-annotations", "prompt-preview-na.txt"), StringComparison.Ordinal));
+        Assert.DoesNotContain(expectedFiles, path => path.EndsWith("prompt-preview.txt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunAsync_DeterministicStep_WritesObservabilityFilesWithoutWarnings()
+    {
+        var repoRoot = CreateRepoRoot("pipeline-runner-observability-deterministic");
+        var outputRelativePath = Path.Combine(".", "generated-compute");
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var step = new ObservabilityRecordingStep(
+                id: 1,
+                name: "Generate annotations",
+                success: true,
+                outputsFactory: context =>
+                {
+                    var artifactPath = Path.Combine(context.OutputPath, "annotations", "compute-list.md");
+                    Directory.CreateDirectory(Path.GetDirectoryName(artifactPath)!);
+                    File.WriteAllText(artifactPath, "# compute list");
+                    return [artifactPath];
+                });
+
+            var runner = CreateRunner(repoRoot, reportWriter, step);
+            var request = new PipelineRequest("compute", [1], outputRelativePath, SkipBuild: true, SkipValidation: false, DryRun: false);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+
+            var observabilityDirectory = Path.Combine(
+                Path.GetFullPath(Path.Combine(repoRoot, outputRelativePath)),
+                "observability",
+                "1-generate-annotations");
+
+            Assert.True(File.Exists(Path.Combine(observabilityDirectory, StageOutputContract.SummaryFileName)));
+            Assert.True(File.Exists(Path.Combine(observabilityDirectory, StageOutputContract.StepResultFileName)));
+            Assert.True(File.Exists(Path.Combine(observabilityDirectory, StageOutputContract.ValidationFileName)));
+            Assert.True(File.Exists(Path.Combine(observabilityDirectory, StageOutputContract.PromptPreviewNaFileName)));
+            Assert.True(File.Exists(Path.Combine(observabilityDirectory, StageOutputContract.MetricsFileName)));
+            Assert.DoesNotContain(reportWriter.Messages, message => message.Contains("observability contract", StringComparison.OrdinalIgnoreCase));
+
+            using var metricsDocument = JsonDocument.Parse(File.ReadAllText(Path.Combine(observabilityDirectory, StageOutputContract.MetricsFileName)));
+            Assert.Equal("skipped", metricsDocument.RootElement.GetProperty("validationStatus").GetString());
+            Assert.Equal(1, metricsDocument.RootElement.GetProperty("outputArtifactCount").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_AiStep_MissingPromptPreviewLogsWarning()
+    {
+        var repoRoot = CreateRepoRoot("pipeline-runner-observability-ai");
+        var outputRelativePath = Path.Combine(".", "generated-compute");
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var step = new ObservabilityRecordingStep(
+                id: 2,
+                name: "Generate example prompts",
+                success: true);
+
+            var runner = CreateRunner(repoRoot, reportWriter, step);
+            var request = new PipelineRequest("compute", [2], outputRelativePath, SkipBuild: true, SkipValidation: false, DryRun: false);
+
+            var exitCode = await runner.RunAsync(request, CancellationToken.None);
+
+            Assert.Equal(global::PipelineRunner.PipelineRunner.SuccessExitCode, exitCode);
+            Assert.Contains(
+                reportWriter.Messages,
+                message => message.Contains("prompt-preview.txt", StringComparison.Ordinal)
+                    && message.Contains("observability contract", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private static global::PipelineRunner.PipelineRunner CreateRunner(string repoRoot, BufferedReportWriter reportWriter, IPipelineStep step)
+    {
+        var contextFactory = new PipelineContextFactory(
+            new RecordingProcessRunner(),
+            new WorkspaceManager(),
+            new StaticCliMetadataLoader(),
+            new TargetMatcher(),
+            new StubFilteredCliWriter(),
+            new StubBuildCoordinator(),
+            new StubAiCapabilityProbe(),
+            reportWriter,
+            repoRoot);
+
+        return new global::PipelineRunner.PipelineRunner(new StepRegistry([step]), contextFactory);
+    }
+
+    private static string CreateRepoRoot(string prefix)
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+        return repoRoot;
+    }
+
+    private sealed class ObservabilityRecordingStep(
+        int id,
+        string name,
+        bool success,
+        Func<PipelineContext, IReadOnlyList<string>>? outputsFactory = null)
+        : StepDefinition(id, name, StepScope.Namespace, FailurePolicy.Fatal)
+    {
+        public override ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
+        {
+            var outputs = outputsFactory?.Invoke(context) ?? Array.Empty<string>();
+            return ValueTask.FromResult(new StepResult(success, Array.Empty<string>(), TimeSpan.FromSeconds(2), outputs, Array.Empty<string>(), Array.Empty<ValidatorResult>(), Array.Empty<ArtifactFailure>()));
+        }
+    }
+
+    private sealed class StaticCliMetadataLoader : ICliMetadataLoader
+    {
+        private readonly CliMetadataSnapshot _snapshot = CreateSnapshot();
+
+        public bool CliOutputExists(string outputPath) => true;
+
+        public bool CliVersionExists(string outputPath) => true;
+
+        public bool NamespaceMetadataExists(string outputPath) => true;
+
+        public ValueTask<CliMetadataSnapshot> LoadCliOutputAsync(string outputPath, CancellationToken cancellationToken)
+            => ValueTask.FromResult(_snapshot);
+
+        public ValueTask<string> LoadCliVersionAsync(string outputPath, CancellationToken cancellationToken)
+            => ValueTask.FromResult("1.2.3");
+
+        public ValueTask<IReadOnlyList<string>> LoadNamespacesAsync(string outputPath, CancellationToken cancellationToken)
+            => ValueTask.FromResult<IReadOnlyList<string>>(["compute"]);
+
+        private static CliMetadataSnapshot CreateSnapshot()
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                version = "1.2.3",
+                results = new[]
+                {
+                    new
+                    {
+                        command = "compute list",
+                        name = "compute list",
+                        description = "desc",
+                    },
+                },
+            });
+
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement.Clone();
+            var tool = root.GetProperty("results")[0];
+            return new CliMetadataSnapshot(
+                Path.Combine(Path.GetTempPath(), $"cli-output-{Guid.NewGuid():N}.json"),
+                root,
+                [new CliTool(
+                    tool.GetProperty("command").GetString() ?? string.Empty,
+                    tool.GetProperty("name").GetString() ?? string.Empty,
+                    tool.GetProperty("description").GetString(),
+                    tool.Clone())]);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PipelineRunnerPostValidatorTests.cs
@@ -5,6 +5,7 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Registry;
 using PipelineRunner.Services;
 using PipelineRunner.Tests.Fixtures;
+using Shared;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -189,6 +190,99 @@ public class PipelineRunnerPostValidatorTests
             Assert.Equal(1, nextStep.Executions);
             Assert.Contains(reportWriter.Messages, message => message.Contains("skills relevance generation failed", StringComparison.Ordinal));
             Assert.Contains(reportWriter.Messages, message => message.Contains("critical failure record", StringComparison.OrdinalIgnoreCase));
+
+            var outputRoot = Path.GetFullPath(Path.Combine(repoRoot, "generated-compute"));
+            var warnStepDirectory = Path.Combine(outputRoot, global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(warnStep));
+            var nextStepDirectory = Path.Combine(outputRoot, global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(nextStep));
+
+            Assert.True(StepResultReader.TryRead(warnStepDirectory, out var warnEnvelope));
+            Assert.NotNull(warnEnvelope);
+            Assert.Equal(global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(warnStep), warnEnvelope!.StepName);
+            Assert.Equal(StepResultStatus.Failure, warnEnvelope.Status);
+
+            Assert.True(StepResultReader.TryRead(nextStepDirectory, out var nextEnvelope));
+            Assert.NotNull(nextEnvelope);
+            Assert.Equal(global::PipelineRunner.PipelineRunner.GetStepIdentifierSlug(nextStep), nextEnvelope!.StepName);
+            Assert.Equal(StepResultStatus.Success, nextEnvelope.Status);
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BuildStepResultEnvelope_MapsRunnerResultToSharedEnvelope()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"pipeline-runner-envelope-{Guid.NewGuid():N}");
+        var outputRoot = Path.Combine(repoRoot, "generated-compute");
+        Directory.CreateDirectory(Path.Combine(repoRoot, "mcp-tools", "scripts"));
+        Directory.CreateDirectory(Path.Combine(outputRoot, "reports"));
+        File.WriteAllText(Path.Combine(repoRoot, "mcp-doc-generation.sln"), string.Empty);
+
+        try
+        {
+            var reportWriter = new BufferedReportWriter();
+            var context = new PipelineContext
+            {
+                Request = new PipelineRequest("compute", [4], outputRoot, SkipBuild: true, SkipValidation: false, DryRun: false),
+                RepoRoot = repoRoot,
+                McpToolsRoot = Path.Combine(repoRoot, "mcp-tools"),
+                OutputPath = outputRoot,
+                ProcessRunner = new RecordingProcessRunner(),
+                Workspaces = new WorkspaceManager(),
+                CliMetadataLoader = new StaticCliMetadataLoader(),
+                TargetMatcher = new TargetMatcher(),
+                FilteredCliWriter = new StubFilteredCliWriter(),
+                BuildCoordinator = new StubBuildCoordinator(),
+                AiCapabilityProbe = new StubAiCapabilityProbe(),
+                Reports = reportWriter
+            };
+            context.Items["Namespace"] = "compute";
+
+            var outputFile = Path.Combine(outputRoot, "reports", "summary.json");
+            File.WriteAllText(outputFile, """{ "ok": true }""");
+
+            var step = new RecordingStep(
+                id: 4,
+                name: "Generate tool-family article",
+                failurePolicy: FailurePolicy.Fatal,
+                success: false,
+                postValidators: [new FixedValidator(success: false, warnings: ["validator failed"])]);
+            var result = new StepResult(
+                Success: false,
+                Warnings: ["artifact incomplete"],
+                Duration: TimeSpan.FromMilliseconds(1250),
+                Outputs: [outputFile],
+                ProcessInvocations: ["dotnet run --project tool-family"],
+                ValidatorResults: [new ValidatorResult("FixedValidator", false, ["validator failed"])],
+                ArtifactFailures:
+                [
+                    ArtifactFailure.Create(
+                        "tool",
+                        "compute list",
+                        "Article assembly failed.",
+                        ["Missing H2 section."])
+                ]);
+
+            var envelope = global::PipelineRunner.PipelineRunner.BuildStepResultEnvelope(context, step, result);
+
+            Assert.Equal("1.0", envelope.SchemaVersion);
+            Assert.Equal("Generate tool-family article", envelope.Step);
+            Assert.Equal("step-4-generate-tool-family-article", envelope.StepName);
+            Assert.Equal("compute", envelope.Namespace);
+            Assert.Equal(StepResultStatus.Partial, envelope.Status);
+            Assert.Equal(1, envelope.OutputFileCount);
+            Assert.Equal(1250L, envelope.DurationMs);
+            Assert.Equal("00:00:01.2500000", envelope.Duration);
+            Assert.Equal(ValidationStatus.Failed, envelope.ValidationStatus);
+            Assert.NotNull(envelope.OutputArtifacts);
+            Assert.Single(envelope.OutputArtifacts!);
+            Assert.Equal("reports/summary.json", envelope.OutputArtifacts[0].Path);
+            Assert.NotEmpty(envelope.OutputArtifacts[0].Sha256);
+            Assert.Contains("Article assembly failed.", envelope.Errors);
+            Assert.Contains("validator failed", envelope.Warnings);
+            Assert.True(DateTimeOffset.TryParse(envelope.Timestamp, out _));
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
@@ -1,0 +1,299 @@
+using System.Text.Json;
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Services;
+using PipelineRunner.Steps;
+using PipelineRunner.Tests.Fixtures;
+using Shared;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public sealed class UpstreamArtifactResolutionStepTests
+{
+    [Fact]
+    public async Task Step3_UsesEnvelopeResolvedPrerequisites_WhenLegacyDirectoriesAreMissing()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new CallbackProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["keyvault list"]);
+            context.Items["Namespace"] = "keyvault";
+
+            var nameContext = await FileNameContext.CreateAsync();
+            var toolFileName = ToolFileNameBuilder.BuildToolFileName("keyvault list", nameContext);
+            var annotationFileName = ToolFileNameBuilder.BuildAnnotationFileName("keyvault list", nameContext);
+            var parameterFileName = ToolFileNameBuilder.BuildParameterFileName("keyvault list", nameContext);
+            var examplePromptsFileName = ToolFileNameBuilder.BuildExamplePromptsFileName("keyvault list", nameContext);
+
+            SeedFile(Path.Combine(context.OutputPath, "custom-upstream", "tools-raw", toolFileName));
+            SeedFile(Path.Combine(context.OutputPath, "custom-upstream", "annotations", annotationFileName));
+            SeedFile(Path.Combine(context.OutputPath, "custom-upstream", "parameters", parameterFileName));
+            SeedFile(Path.Combine(context.OutputPath, "custom-upstream", "example-prompts", examplePromptsFileName));
+
+            WriteEnvelope(
+                context.OutputPath,
+                1,
+                "generate-annotations-parameters-and-raw-tools",
+                "keyvault",
+                [
+                    "custom-upstream/tools-raw/" + toolFileName,
+                    "custom-upstream/annotations/" + annotationFileName,
+                    "custom-upstream/parameters/" + parameterFileName
+                ]);
+
+            WriteEnvelope(
+                context.OutputPath,
+                2,
+                "generate-example-prompts",
+                "keyvault",
+                ["custom-upstream/example-prompts/" + examplePromptsFileName]);
+
+            var invocationCount = 0;
+            runner.OnRun = spec =>
+            {
+                invocationCount++;
+                if (invocationCount == 1)
+                {
+                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "tools-raw"), spec.Arguments);
+                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "annotations"), spec.Arguments);
+                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "parameters"), spec.Arguments);
+                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "example-prompts"), spec.Arguments);
+                    SeedFile(Path.Combine(context.OutputPath, "tools-composed", toolFileName));
+                    return CallbackProcessRunner.Success(spec);
+                }
+
+                SeedFile(Path.Combine(context.OutputPath, "tools", toolFileName));
+                return CallbackProcessRunner.Success(spec);
+            };
+
+            var step = new ToolGenerationStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(2, runner.Invocations.Count);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step4_UsesEnvelopeResolvedToolDirectory_WhenLegacyDirectoriesAreMissing()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new CallbackProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list"]);
+            context.Items["Namespace"] = "compute";
+
+            var customToolPath = Path.Combine(context.OutputPath, "custom-step3", "tools", "compute-list.md");
+            SeedToolFile(customToolPath, "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+
+            WriteEnvelope(
+                context.OutputPath,
+                3,
+                "compose-and-improve-tool-files",
+                "compute",
+                ["custom-step3/tools/compute-list.md"]);
+
+            var outputFileName = await ToolFileNameBuilder.ResolveFamilyFileNameAsync("compute");
+            runner.OnRun = spec =>
+            {
+                var isolatedGeneratedRoot = Path.GetFullPath(Path.Combine(spec.WorkingDirectory, "..", "generated"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family-metadata"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family-related"));
+                Directory.CreateDirectory(Path.Combine(isolatedGeneratedRoot, "tool-family"));
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family-metadata", $"{outputFileName}-metadata.md"), "metadata");
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family-related", $"{outputFileName}-related.md"), "related");
+                File.WriteAllText(Path.Combine(isolatedGeneratedRoot, "tool-family", $"{outputFileName}.md"), "final article");
+                return CallbackProcessRunner.Success(spec);
+            };
+
+            var step = new ToolFamilyCleanupStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Single(runner.Invocations);
+            Assert.Equal("final article", File.ReadAllText(Path.Combine(context.OutputPath, "tool-family", $"{outputFileName}.md")));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step6_UsesEnvelopeResolvedCliVersion_WhenLegacyPathIsMissing()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new CallbackProcessRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["advisor list"]);
+            context.Items["Namespace"] = "advisor";
+
+            SeedFile(Path.Combine(context.OutputPath, "custom-bootstrap", "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-advisor.md"), "article");
+
+            WriteEnvelope(
+                context.OutputPath,
+                0,
+                "bootstrap-pipeline",
+                "advisor",
+                ["custom-bootstrap/cli/cli-version.json"]);
+
+            var step = new HorizontalArticlesStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Single(runner.Invocations);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static void WriteEnvelope(string outputPath, int stepId, string stepSlug, string currentNamespace, IReadOnlyList<string> artifactPaths)
+    {
+        var stepDir = Path.Combine(outputPath, $"step-{stepId}-{stepSlug}");
+        StepResultWriter.Write(stepDir, new StepResultFile
+        {
+            SchemaVersion = "1.0",
+            Status = StepResultStatus.Success,
+            Step = $"Step {stepId}",
+            StepName = $"step-{stepId}-{stepSlug}",
+            Namespace = currentNamespace,
+            OutputArtifacts = artifactPaths
+                .Select(path => new ArtifactReference { Path = path.Replace('\\', '/'), Sha256 = "abc123" })
+                .ToList()
+        });
+    }
+
+    private static PipelineContext CreateContext(string testRoot, IProcessRunner processRunner, bool skipValidation, IReadOnlyList<string> toolCommands)
+    {
+        var mcpToolsRoot = Path.Combine(testRoot, "mcp-tools");
+        var outputPath = Path.Combine(testRoot, "generated-output");
+        Directory.CreateDirectory(Path.Combine(mcpToolsRoot, "data"));
+        Directory.CreateDirectory(outputPath);
+        File.WriteAllText(Path.Combine(mcpToolsRoot, "data", "brand-to-server-mapping.json"), "[]");
+
+        return new PipelineContext
+        {
+            Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
+            RepoRoot = testRoot,
+            McpToolsRoot = mcpToolsRoot,
+            OutputPath = outputPath,
+            ProcessRunner = processRunner,
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new FilteredCliWriter(new WorkspaceManager()),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            CliOutput = CreateSnapshot(toolCommands),
+            SelectedNamespaces = ["compute"],
+        };
+    }
+
+    private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            version = "1.2.3",
+            results = toolCommands.Select(command => new
+            {
+                command,
+                name = command,
+                description = $"Description for {command}",
+            }),
+        });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+        var tools = root.GetProperty("results")
+            .EnumerateArray()
+            .Select(tool => new CliTool(
+                tool.GetProperty("command").GetString() ?? string.Empty,
+                tool.GetProperty("name").GetString() ?? string.Empty,
+                tool.GetProperty("description").GetString(),
+                tool.Clone()))
+            .ToArray();
+
+        return new CliMetadataSnapshot(Path.Combine(Path.GetTempPath(), $"cli-output-{Guid.NewGuid():N}.json"), root, tools);
+    }
+
+    private static string CreateTestRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"upstream-resolution-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void DeleteTestRoot(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private static void SeedFile(string path, string content = "content")
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static void SeedToolFile(string path, string command)
+        => SeedFile(path, $"---\n---\n# Sample\n\n<!-- @mcpcli {command} -->\nbody\n");
+
+    private sealed class CallbackProcessRunner : IProcessRunner
+    {
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public Func<ProcessSpec, ProcessExecutionResult>? OnRun { get; set; }
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
+        {
+            Invocations.Add(spec);
+            return ValueTask.FromResult(OnRun?.Invoke(spec) ?? Success(spec));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken cancellationToken)
+            => RunAsync(new ProcessSpec("dotnet", ["build", solutionPath], Path.GetDirectoryName(solutionPath) ?? string.Empty), cancellationToken);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken cancellationToken)
+        {
+            var invocation = new List<string>
+            {
+                "run",
+                "--project",
+                projectPath,
+                "--configuration",
+                "Release",
+            };
+
+            if (noBuild)
+            {
+                invocation.Add("--no-build");
+            }
+
+            invocation.Add("--");
+            invocation.AddRange(arguments);
+            return RunAsync(new ProcessSpec("dotnet", invocation, workingDirectory), cancellationToken);
+        }
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);
+
+        public static ProcessExecutionResult Success(ProcessSpec spec)
+            => new(spec.FileName, spec.Arguments, spec.WorkingDirectory, 0, string.Empty, string.Empty, TimeSpan.Zero);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Contracts/StageOutputContract.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Contracts/StageOutputContract.cs
@@ -1,0 +1,34 @@
+namespace PipelineRunner.Contracts;
+
+/// <summary>
+/// Defines the 5-file observability contract for every step workspace.
+/// After step execution, PipelineRunner checks for these files and logs warnings for any missing.
+/// </summary>
+public sealed record StageOutputContract(
+    string StepName,
+    string WorkspaceDirectory,
+    bool IsDeterministic)
+{
+    public const string SummaryFileName = "summary.md";
+    public const string StepResultFileName = "step-result.json";
+    public const string ValidationFileName = "validation.json";
+    public const string PromptPreviewFileName = "prompt-preview.txt";
+    public const string PromptPreviewNaFileName = "prompt-preview-na.txt";
+    public const string MetricsFileName = "metrics.json";
+
+    /// <summary>
+    /// Returns the expected file paths based on whether the step is deterministic.
+    /// </summary>
+    public IReadOnlyList<string> GetExpectedFiles()
+    {
+        var promptFile = IsDeterministic ? PromptPreviewNaFileName : PromptPreviewFileName;
+        return
+        [
+            Path.Combine(WorkspaceDirectory, SummaryFileName),
+            Path.Combine(WorkspaceDirectory, StepResultFileName),
+            Path.Combine(WorkspaceDirectory, ValidationFileName),
+            Path.Combine(WorkspaceDirectory, promptFile),
+            Path.Combine(WorkspaceDirectory, MetricsFileName),
+        ];
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -4,6 +4,8 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Context;
 using PipelineRunner.Registry;
 using PipelineRunner.Services;
+using Shared;
+using System.Security.Cryptography;
 
 namespace PipelineRunner;
 
@@ -100,6 +102,7 @@ public sealed class PipelineRunner
         if (request.DryRun)
         {
             WriteDryRunPlan(context, selectedSteps, dependencyErrors);
+            WriteDryRunStepResults(context, selectedSteps);
             return dependencyErrors.Count == 0 ? SuccessExitCode : InvalidArgumentsExitCode;
         }
 
@@ -378,6 +381,23 @@ public sealed class PipelineRunner
             }
 
             var persistedFailures = CriticalFailureRecorder.Persist(context, step, result);
+            if (!TryWriteStepResultEnvelope(context, step, result, out var stepResultError))
+            {
+                if (step.FailurePolicy == FailurePolicy.Warn)
+                {
+                    warnings.Add(stepResultError);
+                    context.Reports.Warning(stepResultError);
+                }
+                else
+                {
+                    context.Reports.Error($"FATAL: {stepResultError}");
+                    handle.Fail(stepResultError);
+                    return new StepExecutionOutcome(FatalExitCode, result, persistedFailures);
+                }
+            }
+
+            WriteObservabilityOutputs(context, step, result, classification);
+
             var stepExitCode = MapStepFailureExitCode(step.FailurePolicy, result.Success, result.ExitCodeOverride);
             if (stepExitCode != SuccessExitCode)
             {
@@ -396,6 +416,268 @@ public sealed class PipelineRunner
             handle.Fail(ex.Message);
             throw;
         }
+    }
+
+    private static void WriteObservabilityOutputs(
+        PipelineContext context,
+        IPipelineStep step,
+        StepResult result,
+        StepClassification classification)
+    {
+        var directory = GetObservabilityDirectory(context.OutputPath, step);
+        var validationStatus = GetValidationStatus(result.ValidatorResults);
+        Directory.CreateDirectory(directory);
+
+        var stepWorkspaceDirectory = GetStepWorkspaceDirectory(context, step);
+        var stepResultPath = Path.Combine(stepWorkspaceDirectory, StepResultWriter.FileName);
+        if (File.Exists(stepResultPath))
+        {
+            File.Copy(stepResultPath, Path.Combine(directory, StageOutputContract.StepResultFileName), overwrite: true);
+        }
+        else
+        {
+            StepResultWriter.Write(directory, BuildStepResultEnvelope(context, step, result));
+        }
+
+        ObservabilityWriter.WriteMetrics(
+            directory,
+            step.Name,
+            result.Duration,
+            inputCount: 0,
+            outputCount: result.Outputs.Count,
+            validationStatus.ToString().ToLowerInvariant());
+        ObservabilityWriter.WriteValidation(directory, step.Name, result.ValidatorResults);
+        ObservabilityWriter.WriteSummary(directory, step.Name, result.Success, result.Duration, result.Warnings);
+
+        if (classification == StepClassification.Deterministic)
+        {
+            ObservabilityWriter.WritePromptPreviewNa(directory);
+        }
+
+        var contract = new StageOutputContract(
+            step.Name,
+            directory,
+            IsDeterministic: classification == StepClassification.Deterministic);
+        var missingFiles = context.Workspaces.AssertOutputContract(contract);
+        if (missingFiles.Count > 0)
+        {
+            context.Reports.Warning(
+                $"Step {step.Id} observability contract missing file(s): {string.Join(", ", missingFiles)}");
+        }
+    }
+
+    public static StepResultFile BuildStepResultEnvelope(
+        PipelineContext context,
+        IPipelineStep step,
+        StepResult result)
+    {
+        return new StepResultFile
+        {
+            Version = 3,
+            SchemaVersion = "1.0",
+            Status = GetStepResultStatus(result),
+            Step = step.Name,
+            StepName = GetStepIdentifierSlug(step),
+            Namespace = ResolveNamespace(context),
+            OutputFileCount = result.Outputs.Count,
+            Warnings = GetWarnings(result),
+            Errors = GetErrors(result),
+            Duration = result.Duration.ToString("c"),
+            DurationMs = (long)result.Duration.TotalMilliseconds,
+            ValidationStatus = GetStepResultValidationStatus(step, result.ValidatorResults),
+            Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+            OutputArtifacts = BuildArtifactReferences(context.OutputPath, result.Outputs),
+        };
+    }
+
+    private static bool TryWriteStepResultEnvelope(
+        PipelineContext context,
+        IPipelineStep step,
+        StepResult result,
+        out string error)
+    {
+        var stepWorkspaceDirectory = GetStepWorkspaceDirectory(context, step);
+        Directory.CreateDirectory(stepWorkspaceDirectory);
+
+        try
+        {
+            StepResultWriter.Write(stepWorkspaceDirectory, BuildStepResultEnvelope(context, step, result));
+        }
+        catch (Exception ex)
+        {
+            error = $"Step {step.Id} failed to write {StepResultWriter.FileName}: {ex.Message}";
+            return false;
+        }
+
+        if (StepResultReader.TryRead(stepWorkspaceDirectory, out _))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"Step {step.Id} did not produce {StepResultWriter.FileName} in '{stepWorkspaceDirectory}'.";
+        return false;
+    }
+
+    private static void WriteDryRunStepResults(PipelineContext context, IReadOnlyList<IPipelineStep> selectedSteps)
+    {
+        foreach (var step in selectedSteps)
+        {
+            var stepWorkspaceDirectory = GetStepWorkspaceDirectory(context, step);
+            Directory.CreateDirectory(stepWorkspaceDirectory);
+
+            var dryRunOutputs = (step as StepDefinition)?.ExpectedOutputs
+                ?? Array.Empty<string>();
+
+            var resolvedOutputs = dryRunOutputs
+                .Select(output => Path.Combine(context.OutputPath, output))
+                .ToArray();
+
+            StepResultWriter.Write(
+                stepWorkspaceDirectory,
+                BuildStepResultEnvelope(context, step, StepResult.DryRun(resolvedOutputs)));
+        }
+    }
+
+    private static List<ArtifactReference>? BuildArtifactReferences(string outputRoot, IReadOnlyList<string> outputs)
+    {
+        var artifacts = new List<ArtifactReference>();
+        foreach (var output in outputs)
+        {
+            if (!File.Exists(output))
+            {
+                continue;
+            }
+
+            artifacts.Add(new ArtifactReference
+            {
+                Path = GetRelativePath(outputRoot, output),
+                Sha256 = ComputeFileHash(output),
+            });
+        }
+
+        return artifacts.Count == 0 ? null : artifacts;
+    }
+
+    private static string ComputeFileHash(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexStringLower(SHA256.HashData(stream));
+    }
+
+    private static List<string> GetWarnings(StepResult result)
+    {
+        return result.Warnings
+            .Concat(result.ValidatorResults.SelectMany(validator => validator.Warnings))
+            .Where(warning => !string.IsNullOrWhiteSpace(warning))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static List<string> GetErrors(StepResult result)
+    {
+        if (result.Success)
+        {
+            return [];
+        }
+
+        var errors = result.ArtifactFailures
+            .Select(failure => failure.Summary)
+            .Where(summary => !string.IsNullOrWhiteSpace(summary))
+            .ToList();
+
+        if (errors.Count == 0)
+        {
+            errors.Add("Step execution reported failure.");
+        }
+
+        return errors;
+    }
+
+    private static ValidationStatus GetValidationStatus(IReadOnlyList<ValidatorResult> validatorResults)
+    {
+        if (validatorResults.Count == 0)
+        {
+            return ValidationStatus.Skipped;
+        }
+
+        return validatorResults.All(result => result.Success)
+            ? ValidationStatus.Passed
+            : ValidationStatus.Failed;
+    }
+
+    private static ValidationStatus? GetStepResultValidationStatus(
+        IPipelineStep step,
+        IReadOnlyList<ValidatorResult> validatorResults)
+    {
+        if (step.PostValidators.Count == 0)
+        {
+            return null;
+        }
+
+        return GetValidationStatus(validatorResults);
+    }
+
+    private static StepResultStatus GetStepResultStatus(StepResult result)
+    {
+        if (result.Success)
+        {
+            return StepResultStatus.Success;
+        }
+
+        return result.Outputs.Count > 0
+            ? StepResultStatus.Partial
+            : StepResultStatus.Failure;
+    }
+
+    private static string ResolveNamespace(PipelineContext context)
+        => context.Items.TryGetValue("Namespace", out var namespaceName)
+            ? namespaceName as string ?? string.Empty
+            : context.Request.Namespace ?? string.Empty;
+
+    private static string GetObservabilityDirectory(string outputPath, IPipelineStep step)
+        => Path.Combine(outputPath, "observability", $"{step.Id}-{Slugify(step.Name)}");
+
+    internal static string GetStepIdentifierSlug(IPipelineStep step)
+        => Slugify($"Step {step.Id} - {step.Name}");
+
+    private static string GetStepWorkspaceDirectory(PipelineContext context, IPipelineStep step)
+        => Path.Combine(context.OutputPath, GetStepIdentifierSlug(step));
+
+    private static string GetRelativePath(string rootPath, string path)
+    {
+        var relativePath = Path.GetRelativePath(rootPath, path);
+        var normalizedPath = relativePath.StartsWith("..", StringComparison.Ordinal)
+            ? path
+            : relativePath;
+
+        return normalizedPath.Replace('\\', '/');
+    }
+
+    private static string Slugify(string value)
+    {
+        var buffer = new char[value.Length];
+        var length = 0;
+        var previousDash = false;
+
+        foreach (var character in value.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                buffer[length++] = character;
+                previousDash = false;
+                continue;
+            }
+
+            if (!previousDash)
+            {
+                buffer[length++] = '-';
+                previousDash = true;
+            }
+        }
+
+        var sanitized = new string(buffer, 0, length).Trim('-');
+        return string.IsNullOrWhiteSpace(sanitized) ? $"step-{Guid.NewGuid():N}" : sanitized;
     }
 
     // Flush is deliberately non-cancellable to ensure traces are written even when pipeline execution is cancelled.

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/ObservabilityWriter.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/ObservabilityWriter.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using System.Text.Json;
+using PipelineRunner.Contracts;
+
+namespace PipelineRunner.Services;
+
+/// <summary>
+/// Writes observability files (metrics.json, validation.json, summary.md) to step workspaces.
+/// </summary>
+public static class ObservabilityWriter
+{
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
+
+    public static void WriteMetrics(
+        string directory,
+        string stepName,
+        TimeSpan duration,
+        int inputCount,
+        int outputCount,
+        string? validationStatus)
+    {
+        var metrics = new
+        {
+            stepName,
+            durationMs = (long)duration.TotalMilliseconds,
+            inputArtifactCount = inputCount,
+            outputArtifactCount = outputCount,
+            validationStatus = validationStatus ?? "skipped",
+        };
+
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, StageOutputContract.MetricsFileName),
+            JsonSerializer.Serialize(metrics, Options));
+    }
+
+    public static void WriteValidation(string directory, string stepName, IReadOnlyList<ValidatorResult> results)
+    {
+        var overallStatus = results.Count == 0
+            ? "skipped"
+            : results.All(r => r.Success) ? "passed" : "failed";
+
+        var validation = new
+        {
+            stepName,
+            validatorResults = results.Select(r => new { r.Name, r.Success, r.Warnings }),
+            overallStatus,
+        };
+
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, StageOutputContract.ValidationFileName),
+            JsonSerializer.Serialize(validation, Options));
+    }
+
+    public static void WriteSummary(
+        string directory,
+        string stepName,
+        bool success,
+        TimeSpan duration,
+        IReadOnlyList<string> warnings)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"# {stepName}");
+        builder.AppendLine();
+        builder.AppendLine($"**Status:** {(success ? "✅ Success" : "❌ Failed")}");
+        builder.AppendLine($"**Duration:** {duration.TotalSeconds:F1}s");
+
+        if (warnings.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("## Warnings");
+            foreach (var warning in warnings)
+            {
+                builder.AppendLine($"- {warning}");
+            }
+        }
+
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, StageOutputContract.SummaryFileName),
+            builder.ToString());
+    }
+
+    public static void WritePromptPreviewNa(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, StageOutputContract.PromptPreviewNaFileName),
+            "N/A — deterministic step (no AI prompt)");
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/UpstreamArtifactResolver.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/UpstreamArtifactResolver.cs
@@ -1,0 +1,126 @@
+namespace PipelineRunner.Services;
+
+using Shared;
+
+/// <summary>
+/// Resolves upstream step outputs by reading their step-result.json envelopes.
+/// Falls back to legacy path resolution when no envelope exists.
+/// </summary>
+public sealed class UpstreamArtifactResolver
+{
+    /// <summary>
+    /// Attempts to resolve an upstream step's output directory from its envelope.
+    /// Returns the envelope if found, null otherwise.
+    /// </summary>
+    /// <exception cref="StepResultSchemaException">
+    /// Propagated from <see cref="StepResultReader.TryRead(string, out StepResultFile?)"/>
+    /// when the upstream envelope declares an unsupported schema version.
+    /// </exception>
+    public StepResultFile? TryReadUpstream(string outputPath, int stepId, string stepSlug)
+    {
+        var envelopeDir = Path.Combine(outputPath, $"step-{stepId}-{stepSlug}");
+        if (StepResultReader.TryRead(envelopeDir, out var result))
+            return result;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the workspace directory for an upstream step.
+    /// </summary>
+    public string GetUpstreamWorkspaceDir(string outputPath, int stepId, string stepSlug)
+        => Path.Combine(outputPath, $"step-{stepId}-{stepSlug}");
+
+    /// <summary>
+    /// Attempts to resolve a logical output directory from the upstream envelope's output artifacts.
+    /// The requested directory can appear anywhere within the artifact path to support gradual migration.
+    /// </summary>
+    public bool TryResolveOutputDirectory(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeDirectory,
+        out string resolvedDirectory)
+    {
+        resolvedDirectory = string.Empty;
+        var relativePath = TryResolveRelativePath(envelope, relativeDirectory);
+        if (relativePath is null)
+            return false;
+
+        resolvedDirectory = Path.GetFullPath(Path.Combine(outputPath, relativePath));
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to resolve a logical output file from the upstream envelope's output artifacts.
+    /// The requested file path can appear anywhere within the artifact path to support gradual migration.
+    /// </summary>
+    public bool TryResolveOutputFile(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeFilePath,
+        out string resolvedFile)
+    {
+        resolvedFile = string.Empty;
+        var relativePath = TryResolveRelativePath(envelope, relativeFilePath);
+        if (relativePath is null)
+            return false;
+
+        resolvedFile = Path.GetFullPath(Path.Combine(outputPath, relativePath));
+        return true;
+    }
+
+    private static string? TryResolveRelativePath(StepResultFile? envelope, string requestedPath)
+    {
+        if (envelope?.OutputArtifacts is not { Count: > 0 })
+            return null;
+
+        var requestedSegments = SplitPathSegments(requestedPath);
+        if (requestedSegments.Length == 0)
+            return null;
+
+        foreach (var artifact in envelope.OutputArtifacts)
+        {
+            if (string.IsNullOrWhiteSpace(artifact.Path))
+                continue;
+
+            var artifactSegments = SplitPathSegments(artifact.Path);
+            var matchIndex = FindSegmentSequence(artifactSegments, requestedSegments);
+            if (matchIndex < 0)
+                continue;
+
+            return string.Join(
+                Path.DirectorySeparatorChar,
+                artifactSegments.Take(matchIndex + requestedSegments.Length));
+        }
+
+        return null;
+    }
+
+    private static string[] SplitPathSegments(string path)
+        => path.Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static int FindSegmentSequence(IReadOnlyList<string> haystack, IReadOnlyList<string> needle)
+    {
+        if (needle.Count == 0 || haystack.Count < needle.Count)
+            return -1;
+
+        for (var start = 0; start <= haystack.Count - needle.Count; start++)
+        {
+            var matched = true;
+            for (var offset = 0; offset < needle.Count; offset++)
+            {
+                if (!string.Equals(haystack[start + offset], needle[offset], StringComparison.OrdinalIgnoreCase))
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched)
+                return start;
+        }
+
+        return -1;
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner/Services/WorkspaceManager.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Services/WorkspaceManager.cs
@@ -1,3 +1,5 @@
+using PipelineRunner.Contracts;
+
 namespace PipelineRunner.Services;
 
 public sealed class WorkspaceManager
@@ -33,5 +35,24 @@ public sealed class WorkspaceManager
         {
             Delete(directory);
         }
+    }
+
+    /// <summary>
+    /// Checks the step workspace for the 5-file observability contract.
+    /// Returns list of missing file names (empty if all present).
+    /// Does NOT throw — enforcement is at WARNING level.
+    /// </summary>
+    public IReadOnlyList<string> AssertOutputContract(StageOutputContract contract)
+    {
+        var missing = new List<string>();
+        foreach (var expectedPath in contract.GetExpectedFiles())
+        {
+            if (!File.Exists(expectedPath))
+            {
+                missing.Add(Path.GetFileName(expectedPath));
+            }
+        }
+
+        return missing;
     }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
@@ -2,11 +2,14 @@ using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
+using Shared;
 
 namespace PipelineRunner.Steps;
 
 public sealed class HorizontalArticlesStep : NamespaceStepBase
 {
+    private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
+
     public HorizontalArticlesStep()
         : base(
             6,
@@ -28,7 +31,12 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
         var processResults = new List<ProcessExecutionResult>();
         var warnings = new List<string>();
         var artifactFailures = new List<ArtifactFailure>();
-        var cliVersionPath = Path.Combine(context.OutputPath, "cli", "cli-version.json");
+        var bootstrapEnvelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 0, "bootstrap-pipeline");
+        var cliVersionPath = ResolveUpstreamFile(
+            context.OutputPath,
+            bootstrapEnvelope,
+            Path.Combine("cli", "cli-version.json"),
+            Path.Combine(context.OutputPath, "cli", "cli-version.json"));
         if (!context.Request.SkipValidation && !File.Exists(cliVersionPath))
         {
             warnings.Add($"CLI version file not found at '{cliVersionPath}'.");
@@ -89,5 +97,21 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
                 Path.Combine(articleDirectory, $"error-{currentNamespace}.txt"),
                 Path.Combine(articleDirectory, $"error-{currentNamespace}-airesponse.txt"),
             ]);
+    }
+
+    private static string ResolveUpstreamFile(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeFilePath,
+        string fallbackPath)
+    {
+        if (UpstreamArtifacts.TryResolveOutputFile(outputPath, envelope, relativeFilePath, out var resolvedPath))
+        {
+            Console.WriteLine(
+                $"INFO: Using bootstrap envelope-based resolution for '{relativeFilePath}' at '{resolvedPath}'.");
+            return resolvedPath;
+        }
+
+        return fallbackPath;
     }
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -9,6 +9,8 @@ namespace PipelineRunner.Steps;
 
 public sealed class ToolFamilyCleanupStep : NamespaceStepBase
 {
+    private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
+
     public ToolFamilyCleanupStep()
         : base(
             4,
@@ -35,8 +37,58 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
         context.Items[ToolFamilyPostAssemblyValidator.FamilyNameContextKey] = familyName;
         context.Items[ToolFamilyPostAssemblyValidator.OutputFileNameContextKey] = outputFileName;
 
-        var toolsInputDirectory = Path.Combine(context.OutputPath, "tools");
-        var toolsRawDirectory = Path.Combine(context.OutputPath, "tools-raw");
+        var bootstrapEnvelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 0, "bootstrap-pipeline");
+        var step1Envelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 1, "generate-annotations-parameters-and-raw-tools");
+        var step3Envelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 3, "compose-and-improve-tool-files");
+
+        var toolsInputDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step3Envelope,
+            "tools",
+            Path.Combine(context.OutputPath, "tools"),
+            "step 3");
+        var toolsRawDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step3Envelope,
+            "tools-raw",
+            Path.Combine(context.OutputPath, "tools-raw"),
+            "step 3");
+        var cliVersionPath = ResolveUpstreamFile(
+            context.OutputPath,
+            bootstrapEnvelope,
+            Path.Combine("cli", "cli-version.json"),
+            Path.Combine(context.OutputPath, "cli", "cli-version.json"),
+            "bootstrap");
+        var h2HeadingsSource = ResolveUpstreamDirectory(
+            context.OutputPath,
+            bootstrapEnvelope,
+            "h2-headings",
+            Path.Combine(context.OutputPath, "h2-headings"),
+            "bootstrap");
+        var cliTabConfigPath = ResolveUpstreamFile(
+            context.OutputPath,
+            bootstrapEnvelope,
+            "cli-tab-config.json",
+            Path.Combine(context.OutputPath, "cli-tab-config.json"),
+            "bootstrap");
+        var cliOutputPath = ResolveUpstreamFile(
+            context.OutputPath,
+            bootstrapEnvelope,
+            Path.Combine("cli", "cli-output.json"),
+            Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+            "bootstrap");
+        var parameterCliDir = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step1Envelope,
+            "parameter-cli",
+            Path.Combine(context.OutputPath, "parameter-cli"),
+            "step 1");
+        var exampleCommandsDir = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step1Envelope,
+            "example-commands",
+            Path.Combine(context.OutputPath, "example-commands"),
+            "step 1");
 
         // Fallback: if tools/ is empty or doesn't exist, try tools-raw/ (#602)
         if (!Directory.Exists(toolsInputDirectory)
@@ -78,7 +130,6 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             Directory.CreateDirectory(tempCliDirectory);
             Directory.CreateDirectory(tempDataDirectory);
 
-            var cliVersionPath = Path.Combine(context.OutputPath, "cli", "cli-version.json");
             if (File.Exists(cliVersionPath))
             {
                 File.Copy(cliVersionPath, Path.Combine(tempCliDirectory, "cli-version.json"), overwrite: true);
@@ -102,7 +153,6 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             }
 
             // Copy h2-headings JSON for deterministic heading lookup in Phase 1.5
-            var h2HeadingsSource = Path.Combine(context.OutputPath, "h2-headings");
             if (Directory.Exists(h2HeadingsSource))
             {
                 var tempH2Directory = Path.Combine(tempGeneratedDirectory, "h2-headings");
@@ -203,7 +253,7 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             if (File.Exists(familyArticlePath))
             {
                 // Check if CLI tab generation is allowed for this namespace
-                var cliTabConfig = CliTabConfig.LoadFromFile(Path.Combine(context.OutputPath, "cli-tab-config.json"));
+                var cliTabConfig = CliTabConfig.LoadFromFile(cliTabConfigPath);
                 if (!cliTabConfig.IsNamespaceAllowed(currentNamespace))
                 {
                     Console.WriteLine($"  ⊘ CLI tab generation disabled for namespace '{currentNamespace}'");
@@ -212,10 +262,6 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
 
                 try
                 {
-                    var cliOutputPath = Path.Combine(context.OutputPath, "cli", "cli-output.json");
-                    var parameterCliDir = Path.Combine(context.OutputPath, "parameter-cli");
-                    var exampleCommandsDir = Path.Combine(context.OutputPath, "example-commands");
-
                     if (File.Exists(cliOutputPath) && Directory.Exists(parameterCliDir) && Directory.Exists(exampleCommandsDir))
                     {
                         var cliJson = await File.ReadAllTextAsync(cliOutputPath, cancellationToken);
@@ -232,9 +278,8 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
                         }
 
                         // Extract NLP descriptions from tools-raw files (source of truth)
-                        var toolsRawDir = Path.Combine(context.OutputPath, "tools-raw");
                         var nlpDescriptions = await NlpDescriptionExtractor.ExtractNlpDescriptionsAsync(
-                            toolsRawDir, nameContext, cliTools.Keys);
+                            toolsRawDirectory, nameContext, cliTools.Keys);
 
                         // Align CLI descriptions with NLP descriptions (deterministic, no AI)
                         if (nlpDescriptions.Count > 0)
@@ -358,6 +403,40 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
         }
 
         return tokens[0].ToLowerInvariant();
+    }
+
+    private static string ResolveUpstreamDirectory(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeDirectory,
+        string fallbackPath,
+        string upstreamStep)
+    {
+        if (UpstreamArtifacts.TryResolveOutputDirectory(outputPath, envelope, relativeDirectory, out var resolvedPath))
+        {
+            Console.WriteLine(
+                $"INFO: Using {upstreamStep} envelope-based resolution for '{relativeDirectory}' at '{resolvedPath}'.");
+            return resolvedPath;
+        }
+
+        return fallbackPath;
+    }
+
+    private static string ResolveUpstreamFile(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeFilePath,
+        string fallbackPath,
+        string upstreamStep)
+    {
+        if (UpstreamArtifacts.TryResolveOutputFile(outputPath, envelope, relativeFilePath, out var resolvedPath))
+        {
+            Console.WriteLine(
+                $"INFO: Using {upstreamStep} envelope-based resolution for '{relativeFilePath}' at '{resolvedPath}'.");
+            return resolvedPath;
+        }
+
+        return fallbackPath;
     }
 
     private static async Task<IReadOnlyList<string>> ResolveFamilyToolFilesAsync(string toolsInputDirectory, string familyName, CancellationToken cancellationToken)

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
@@ -10,6 +10,7 @@ namespace PipelineRunner.Steps;
 public sealed class ToolGenerationStep : NamespaceStepBase
 {
     private const int DefaultMaxTokens = 8000;
+    private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
 
     private static readonly Regex ComposedFailureRegex = new(
         @"Error processing (?<file>[^:]+\.md):",
@@ -37,19 +38,48 @@ public sealed class ToolGenerationStep : NamespaceStepBase
         var (_, cliOutput, _, matchingTools) = ResolveTarget(context);
         _ = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step3", cancellationToken);
         var nameContext = await FileNameContext.CreateAsync();
-        var toolArtifacts = matchingTools
-            .Select(tool => ToolArtifacts.Create(tool.Command, context.OutputPath, nameContext))
-            .ToArray();
-
         var processResults = new List<ProcessExecutionResult>();
         var warnings = new List<string>();
         var artifactFailures = new List<ArtifactFailure>();
-        var rawToolsDirectory = Path.Combine(context.OutputPath, "tools-raw");
+        var step1Envelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 1, "generate-annotations-parameters-and-raw-tools");
+        var step2Envelope = UpstreamArtifacts.TryReadUpstream(context.OutputPath, 2, "generate-example-prompts");
+        var rawToolsDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step1Envelope,
+            "tools-raw",
+            Path.Combine(context.OutputPath, "tools-raw"),
+            "step 1");
         var composedToolsDirectory = Path.Combine(context.OutputPath, "tools-composed");
         var improvedToolsDirectory = Path.Combine(context.OutputPath, "tools");
-        var annotationsDirectory = Path.Combine(context.OutputPath, "annotations");
-        var parametersDirectory = Path.Combine(context.OutputPath, "parameters");
-        var examplePromptsDirectory = Path.Combine(context.OutputPath, "example-prompts");
+        var annotationsDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step1Envelope,
+            "annotations",
+            Path.Combine(context.OutputPath, "annotations"),
+            "step 1");
+        var parametersDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step1Envelope,
+            "parameters",
+            Path.Combine(context.OutputPath, "parameters"),
+            "step 1");
+        var examplePromptsDirectory = ResolveUpstreamDirectory(
+            context.OutputPath,
+            step2Envelope,
+            "example-prompts",
+            Path.Combine(context.OutputPath, "example-prompts"),
+            "step 2");
+        var toolArtifacts = matchingTools
+            .Select(tool => ToolArtifacts.Create(
+                tool.Command,
+                rawToolsDirectory,
+                annotationsDirectory,
+                parametersDirectory,
+                examplePromptsDirectory,
+                composedToolsDirectory,
+                improvedToolsDirectory,
+                nameContext))
+            .ToArray();
 
         var prerequisiteIssues = GetPrerequisiteIssues(toolArtifacts);
         if (prerequisiteIssues.Count > 0)
@@ -289,6 +319,23 @@ public sealed class ToolGenerationStep : NamespaceStepBase
         IEnumerable<string> relatedPaths)
         => ArtifactFailure.Create("pipeline step", artifactName, summary, details, relatedPaths);
 
+    private static string ResolveUpstreamDirectory(
+        string outputPath,
+        StepResultFile? envelope,
+        string relativeDirectory,
+        string fallbackPath,
+        string upstreamStep)
+    {
+        if (UpstreamArtifacts.TryResolveOutputDirectory(outputPath, envelope, relativeDirectory, out var resolvedPath))
+        {
+            Console.WriteLine(
+                $"INFO: Using {upstreamStep} envelope-based resolution for '{relativeDirectory}' at '{resolvedPath}'.");
+            return resolvedPath;
+        }
+
+        return fallbackPath;
+    }
+
     private sealed record ToolArtifacts(
         string Command,
         string ToolFileName,
@@ -303,18 +350,26 @@ public sealed class ToolGenerationStep : NamespaceStepBase
 
         public string[] GenerationPaths => [RawToolPath, ComposedToolPath, ImprovedToolPath, AnnotationPath, ParameterPath, ExamplePromptsPath];
 
-        public static ToolArtifacts Create(string command, string outputPath, FileNameContext nameContext)
+        public static ToolArtifacts Create(
+            string command,
+            string rawToolsDirectory,
+            string annotationsDirectory,
+            string parametersDirectory,
+            string examplePromptsDirectory,
+            string composedToolsDirectory,
+            string improvedToolsDirectory,
+            FileNameContext nameContext)
         {
             var toolFileName = ToolFileNameBuilder.BuildToolFileName(command, nameContext);
             return new ToolArtifacts(
                 command,
                 toolFileName,
-                Path.Combine(outputPath, "tools-raw", toolFileName),
-                Path.Combine(outputPath, "annotations", ToolFileNameBuilder.BuildAnnotationFileName(command, nameContext)),
-                Path.Combine(outputPath, "parameters", ToolFileNameBuilder.BuildParameterFileName(command, nameContext)),
-                Path.Combine(outputPath, "example-prompts", ToolFileNameBuilder.BuildExamplePromptsFileName(command, nameContext)),
-                Path.Combine(outputPath, "tools-composed", toolFileName),
-                Path.Combine(outputPath, "tools", toolFileName));
+                Path.Combine(rawToolsDirectory, toolFileName),
+                Path.Combine(annotationsDirectory, ToolFileNameBuilder.BuildAnnotationFileName(command, nameContext)),
+                Path.Combine(parametersDirectory, ToolFileNameBuilder.BuildParameterFileName(command, nameContext)),
+                Path.Combine(examplePromptsDirectory, ToolFileNameBuilder.BuildExamplePromptsFileName(command, nameContext)),
+                Path.Combine(composedToolsDirectory, toolFileName),
+                Path.Combine(improvedToolsDirectory, toolFileName));
         }
     }
 }

--- a/shared/DocGeneration.Core.Shared.Tests/StepResultWriterTests.cs
+++ b/shared/DocGeneration.Core.Shared.Tests/StepResultWriterTests.cs
@@ -204,4 +204,75 @@ public class StepResultWriterTests : IDisposable
         Assert.Equal("input/monitor.json", readBack.InputArtifacts![0].Path);
         Assert.Single(readBack.OutputArtifacts!);
     }
+
+    [Fact]
+    public void Write_UniqueOutputArtifactPaths_Succeeds()
+    {
+        var result = new StepResultFile
+        {
+            Status = StepResultStatus.Success,
+            Namespace = "storage",
+            OutputArtifacts = new List<ArtifactReference>
+            {
+                new() { Path = "output/storage-list.md", Sha256 = "aa11" },
+                new() { Path = "output/storage-show.md", Sha256 = "bb22" }
+            }
+        };
+
+        StepResultWriter.Write(_testDir, result);
+
+        var filePath = Path.Combine(_testDir, StepResultWriter.FileName);
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void Write_DuplicateOutputArtifactPaths_ThrowsArtifactPathCollisionException()
+    {
+        var result = new StepResultFile
+        {
+            Status = StepResultStatus.Success,
+            Namespace = "monitor",
+            OutputArtifacts = new List<ArtifactReference>
+            {
+                new() { Path = "output/health.md", Sha256 = "aa11" },
+                new() { Path = "output/health.md", Sha256 = "bb22" }
+            }
+        };
+
+        var ex = Assert.Throws<ArtifactPathCollisionException>(() => StepResultWriter.Write(_testDir, result));
+
+        Assert.Equal("output/health.md", ex.DuplicatePath);
+    }
+
+    [Fact]
+    public void Write_NullOutputArtifacts_Succeeds()
+    {
+        var result = new StepResultFile
+        {
+            Status = StepResultStatus.Success,
+            Namespace = "aks",
+            OutputArtifacts = null
+        };
+
+        StepResultWriter.Write(_testDir, result);
+
+        var filePath = Path.Combine(_testDir, StepResultWriter.FileName);
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void Write_EmptyOutputArtifacts_Succeeds()
+    {
+        var result = new StepResultFile
+        {
+            Status = StepResultStatus.Success,
+            Namespace = "sql",
+            OutputArtifacts = new List<ArtifactReference>()
+        };
+
+        StepResultWriter.Write(_testDir, result);
+
+        var filePath = Path.Combine(_testDir, StepResultWriter.FileName);
+        Assert.True(File.Exists(filePath));
+    }
 }

--- a/shared/DocGeneration.Core.Shared.Tests/Validation/PreAiValidatorRegistryTests.cs
+++ b/shared/DocGeneration.Core.Shared.Tests/Validation/PreAiValidatorRegistryTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Shared.Validation;
+using Xunit;
+
+namespace Shared.Tests.Validation;
+
+public class PreAiValidatorRegistryTests
+{
+    [Fact]
+    public async Task ValidateAsync_ValidContext_Passes()
+    {
+        var registry = new PreAiValidatorRegistry();
+        registry.DeclareStage<TestContext>("tool-generation");
+        registry.Register("tool-generation", new PassingValidator());
+
+        var result = await registry.ValidateAsync("tool-generation", new TestContext("storage"), CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.True(result.WithinBudget);
+        Assert.Equal(120, result.EstimatedPromptTokens);
+        Assert.Equal(400, result.TokenBudget);
+    }
+
+    [Fact]
+    public void Register_ContextMismatch_Throws()
+    {
+        var registry = new PreAiValidatorRegistry();
+        registry.DeclareStage<TestContext>("example-prompts");
+
+        var exception = Assert.Throws<ValidatorContextMismatchException>(
+            () => registry.Register("example-prompts", new DifferentContextValidator()));
+
+        Assert.Equal("example-prompts", exception.StageName);
+        Assert.Equal(typeof(TestContext), exception.DeclaredType);
+        Assert.Equal(typeof(DifferentContext), exception.AttemptedType);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MultipleValidators_AggregatesErrors()
+    {
+        var registry = new PreAiValidatorRegistry();
+        registry.DeclareStage<TestContext>("horizontal-articles");
+        registry.Register("horizontal-articles", new WarningValidator());
+        registry.Register("horizontal-articles", new ErrorValidator());
+
+        var result = await registry.ValidateAsync("horizontal-articles", new TestContext("monitor"), CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Contains(result.Errors, error => error.Field == "name" && error.Severity == ValidationSeverity.Warning);
+        Assert.Contains(result.Errors, error => error.Field == "description" && error.Severity == ValidationSeverity.Error);
+    }
+
+    [Fact]
+    public void Pass_CreatesValidResult()
+    {
+        var result = PreAiValidationResult.Pass(estimatedTokens: 55, budget: 100);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.Equal(55, result.EstimatedPromptTokens);
+        Assert.Equal(100, result.TokenBudget);
+        Assert.True(result.WithinBudget);
+    }
+
+    [Fact]
+    public void Fail_CreatesInvalidResult()
+    {
+        var result = PreAiValidationResult.Fail(
+            new ValidationError("title", "Title is required.", ValidationSeverity.Error),
+            new ValidationError("summary", "Summary is long.", ValidationSeverity.Warning));
+
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Null(result.EstimatedPromptTokens);
+        Assert.Null(result.TokenBudget);
+    }
+
+    [Fact]
+    public void HasValidators_UnregisteredStage_ReturnsFalse()
+    {
+        var registry = new PreAiValidatorRegistry();
+
+        Assert.False(registry.HasValidators("missing-stage"));
+    }
+
+    private sealed record TestContext(string Name);
+
+    private sealed record DifferentContext(string Name);
+
+    private sealed class PassingValidator : IPreAiValidator<TestContext>
+    {
+        public Task<PreAiValidationResult> ValidateAsync(TestContext context, CancellationToken cancellationToken)
+            => Task.FromResult(PreAiValidationResult.Pass(estimatedTokens: 120, budget: 400));
+    }
+
+    private sealed class DifferentContextValidator : IPreAiValidator<DifferentContext>
+    {
+        public Task<PreAiValidationResult> ValidateAsync(DifferentContext context, CancellationToken cancellationToken)
+            => Task.FromResult(PreAiValidationResult.Pass());
+    }
+
+    private sealed class WarningValidator : IPreAiValidator<TestContext>
+    {
+        public Task<PreAiValidationResult> ValidateAsync(TestContext context, CancellationToken cancellationToken)
+            => Task.FromResult(new PreAiValidationResult(
+                true,
+                new[]
+                {
+                    new ValidationError("name", "Name should be clearer.", ValidationSeverity.Warning)
+                }));
+    }
+
+    private sealed class ErrorValidator : IPreAiValidator<TestContext>
+    {
+        public Task<PreAiValidationResult> ValidateAsync(TestContext context, CancellationToken cancellationToken)
+            => Task.FromResult(new PreAiValidationResult(
+                false,
+                new[]
+                {
+                    new ValidationError("description", "Description is required.", ValidationSeverity.Error)
+                }));
+    }
+}

--- a/shared/DocGeneration.Core.Shared/ArtifactPathCollisionException.cs
+++ b/shared/DocGeneration.Core.Shared/ArtifactPathCollisionException.cs
@@ -1,0 +1,15 @@
+namespace Shared;
+
+/// <summary>
+/// Thrown by StepResultWriter when two output artifacts in the same envelope share a path.
+/// </summary>
+public sealed class ArtifactPathCollisionException : InvalidOperationException
+{
+    public string DuplicatePath { get; }
+
+    public ArtifactPathCollisionException(string duplicatePath)
+        : base($"Duplicate output artifact path detected: '{duplicatePath}'. Each artifact must have a unique path within a step envelope.")
+    {
+        DuplicatePath = duplicatePath;
+    }
+}

--- a/shared/DocGeneration.Core.Shared/NlpDescriptionExtractor.cs
+++ b/shared/DocGeneration.Core.Shared/NlpDescriptionExtractor.cs
@@ -74,7 +74,7 @@ public static class NlpDescriptionExtractor
     internal static string? ExtractNlpDescription(string toolMarkdown)
     {
         // Strip frontmatter first
-        var contentWithoutFrontmatter = FrontmatterUtility.StripFrontmatter(toolMarkdown);
+        var contentWithoutFrontmatter = FrontmatterUtility.StripFrontmatter(toolMarkdown) ?? string.Empty;
 
         // Match the paragraph after the @mcpcli comment
         var match = NlpDescriptionRegex.Match(contentWithoutFrontmatter);

--- a/shared/DocGeneration.Core.Shared/StepResultWriter.cs
+++ b/shared/DocGeneration.Core.Shared/StepResultWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,6 +29,16 @@ public static class StepResultWriter
     /// </summary>
     public static void Write(string directory, StepResultFile result)
     {
+        if (result.OutputArtifacts is { Count: > 0 })
+        {
+            var duplicatePath = result.OutputArtifacts
+                .GroupBy(a => a.Path, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(g => g.Count() > 1)?.Key;
+
+            if (duplicatePath is not null)
+                throw new ArtifactPathCollisionException(duplicatePath);
+        }
+
         Directory.CreateDirectory(directory);
         var filePath = Path.Combine(directory, FileName);
         var json = JsonSerializer.Serialize(result, SerializerOptions);

--- a/shared/DocGeneration.Core.Shared/Validation/IPreAiValidator.cs
+++ b/shared/DocGeneration.Core.Shared/Validation/IPreAiValidator.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shared.Validation;
+
+/// <summary>
+/// Non-generic base interface for DI and registry use.
+/// </summary>
+public interface IPreAiValidator
+{
+    /// <summary>
+    /// Gets the context type this validator expects.
+    /// </summary>
+    Type ContextType { get; }
+
+    /// <summary>
+    /// Validates a context object.
+    /// </summary>
+    Task<PreAiValidationResult> ValidateAsync(object context, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Generic typed validator for compile-time safety.
+/// </summary>
+public interface IPreAiValidator<in TContext> : IPreAiValidator
+{
+    /// <summary>
+    /// Validates a typed context object.
+    /// </summary>
+    Task<PreAiValidationResult> ValidateAsync(TContext context, CancellationToken cancellationToken);
+
+    Type IPreAiValidator.ContextType => typeof(TContext);
+
+    Task<PreAiValidationResult> IPreAiValidator.ValidateAsync(object context, CancellationToken cancellationToken)
+        => ValidateAsync((TContext)context, cancellationToken);
+}

--- a/shared/DocGeneration.Core.Shared/Validation/PreAiValidationResult.cs
+++ b/shared/DocGeneration.Core.Shared/Validation/PreAiValidationResult.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Shared.Validation;
+
+public sealed record PreAiValidationResult(
+    bool IsValid,
+    IReadOnlyList<ValidationError> Errors,
+    int? EstimatedPromptTokens = null,
+    int? TokenBudget = null)
+{
+    public bool WithinBudget => TokenBudget is null || EstimatedPromptTokens <= TokenBudget;
+
+    public static PreAiValidationResult Pass(int? estimatedTokens = null, int? budget = null)
+        => new(true, Array.Empty<ValidationError>(), estimatedTokens, budget);
+
+    public static PreAiValidationResult Fail(params ValidationError[] errors)
+        => new(false, errors);
+}
+
+public sealed record ValidationError(string Field, string Message, ValidationSeverity Severity);
+
+public enum ValidationSeverity
+{
+    Error,
+    Warning
+}

--- a/shared/DocGeneration.Core.Shared/Validation/PreAiValidatorRegistry.cs
+++ b/shared/DocGeneration.Core.Shared/Validation/PreAiValidatorRegistry.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shared.Validation;
+
+/// <summary>
+/// Registry that maps step names to their pre-AI validators.
+/// </summary>
+public sealed class PreAiValidatorRegistry
+{
+    private readonly Dictionary<string, List<IPreAiValidator>> _validators = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Type> _stageContextTypes = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Declares the expected context type for a stage.
+    /// </summary>
+    public void DeclareStage<TContext>(string stageName)
+    {
+        _stageContextTypes[stageName] = typeof(TContext);
+    }
+
+    /// <summary>
+    /// Registers a validator for a stage.
+    /// </summary>
+    public void Register<TContext>(string stageName, IPreAiValidator<TContext> validator)
+    {
+        if (_stageContextTypes.TryGetValue(stageName, out var declaredType) && declaredType != typeof(TContext))
+        {
+            throw new ValidatorContextMismatchException(stageName, declaredType, typeof(TContext));
+        }
+
+        if (!_validators.ContainsKey(stageName))
+        {
+            _validators[stageName] = new List<IPreAiValidator>();
+        }
+
+        _validators[stageName].Add(validator);
+    }
+
+    /// <summary>
+    /// Runs all validators for a stage and returns an aggregated result.
+    /// </summary>
+    public async Task<PreAiValidationResult> ValidateAsync(string stageName, object context, CancellationToken cancellationToken)
+    {
+        if (!_validators.TryGetValue(stageName, out var validators) || validators.Count == 0)
+        {
+            return PreAiValidationResult.Pass();
+        }
+
+        var allErrors = new List<ValidationError>();
+        int? estimatedTokens = null;
+        int? tokenBudget = null;
+
+        foreach (var validator in validators)
+        {
+            var result = await validator.ValidateAsync(context, cancellationToken);
+            allErrors.AddRange(result.Errors);
+
+            if (result.EstimatedPromptTokens.HasValue)
+            {
+                estimatedTokens = result.EstimatedPromptTokens;
+            }
+
+            if (result.TokenBudget.HasValue)
+            {
+                tokenBudget = result.TokenBudget;
+            }
+        }
+
+        var isValid = allErrors.All(error => error.Severity != ValidationSeverity.Error);
+        return new PreAiValidationResult(isValid, allErrors, estimatedTokens, tokenBudget);
+    }
+
+    /// <summary>
+    /// Checks if any validators are registered for a stage.
+    /// </summary>
+    public bool HasValidators(string stageName)
+        => _validators.ContainsKey(stageName) && _validators[stageName].Count > 0;
+}

--- a/shared/DocGeneration.Core.Shared/Validation/ValidatorContextMismatchException.cs
+++ b/shared/DocGeneration.Core.Shared/Validation/ValidatorContextMismatchException.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Shared.Validation;
+
+public sealed class ValidatorContextMismatchException : InvalidOperationException
+{
+    public string StageName { get; }
+
+    public Type DeclaredType { get; }
+
+    public Type AttemptedType { get; }
+
+    public ValidatorContextMismatchException(string stageName, Type declaredType, Type attemptedType)
+        : base($"Stage '{stageName}' declares context type '{declaredType.Name}' but validator provides '{attemptedType.Name}'.")
+    {
+        StageName = stageName;
+        DeclaredType = declaredType;
+        AttemptedType = attemptedType;
+    }
+}


### PR DESCRIPTION
## Phase 2 — Contract Enforcement

Implements all 6 Phase 2 points from the [Pipeline Manageability PRD](../projects/azure-ai-tools/prds/pipeline-manageability-prd-2026-05-29.md):

| Point | Title | Status |
|-------|-------|--------|
| P4 | Enforce StepResultWriter in PipelineRunner | ✅ FATAL on missing envelope |
| P5 | Migrate StepResultReader to downstream steps | ✅ Envelope-first + legacy fallback |
| P7 | Artifact naming collision-proofing | ✅ ArtifactPathCollisionException |
| P9 | Pre-AI seam validator interface | ✅ IPreAiValidator\<T\> + registry |
| P15 | 5-file observability output contract | ✅ WARNING on missing files |
| P17 | Schema contract tests | ✅ 9 tests across 3 seams |

### Test Results
- Shared tests: 425 passed
- PipelineRunner tests: 475 passed
- Build: 0 warnings, 0 errors

### Key Design Decisions
- **Envelope enforcement** is FATAL for non-warn steps, allowing warn-only steps (SkillsRelevance) to continue
- **UpstreamArtifactResolver** uses envelope-first resolution with legacy path fallback for backward compatibility
- **PreAiValidatorRegistry** throws at registration time (not runtime) on type mismatch
- **ObservabilityWriter** writes to \observability/{stepId}-{slug}/\ subdirectory, separate from step artifacts
- **StageOutputContract** enforcement is WARNING-level only (does not abort pipeline)

Closes phase 2 of the pipeline manageability roadmap.