### PR TITLE
refactor(p6): extract ToolGenerationReducer — typed context for AI improvement stage

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/DocGeneration.PipelineRunner.Tests.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/DocGeneration.PipelineRunner.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocGeneration.PipelineRunner\DocGeneration.PipelineRunner.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.ToolGeneration.Improvements\DocGeneration.Steps.ToolGeneration.Improvements.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.AnnotationsParametersRaw.Annotations\DocGeneration.Steps.AnnotationsParametersRaw.Annotations.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.ToolFamilyCleanup\DocGeneration.Steps.ToolFamilyCleanup.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.ToolGeneration.Composition\DocGeneration.Steps.ToolGeneration.Composition.csproj" />

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FailurePathTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FailurePathTests.cs
@@ -6,6 +6,7 @@ using PipelineRunner.Services;
 using PipelineRunner.Steps;
 using PipelineRunner.Tests.Fixtures;
 using Shared;
+using ToolGeneration_Improved.Models;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -212,23 +213,15 @@ public class FailurePathTests
     }
 
     [Fact]
-    public async Task Step3_ImprovementSubprocessFailure_ReturnsStepLevelFailureForImprovement()
+    public async Task Step3_ImprovementInitializationFailure_ReturnsStepLevelFailureForImprovement()
     {
         var testRoot = CreateTestRoot();
         try
         {
-            var invocationCount = 0;
-            var runner = new CallbackProcessRunner();
-            runner.OnRun = spec =>
-            {
-                invocationCount++;
-                // Composition succeeds, improvement fails
-                return invocationCount == 1
-                    ? CallbackProcessRunner.Success(spec)
-                    : CallbackProcessRunner.Failure(spec, 1, "AI API timeout");
-            };
+            var runner = new RecordingProcessRunner();
             var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["sql list"]);
             context.Items["Namespace"] = "sql";
+            context.Items[ToolGenerationStep.ToolImproverOverrideKey] = "invalid";
 
             await SeedToolGenerationPrerequisitesAsync(context.OutputPath, ["sql list"]);
             await SeedComposedToolOutputAsync(context.OutputPath, "sql list");
@@ -254,13 +247,16 @@ public class FailurePathTests
         var testRoot = CreateTestRoot();
         try
         {
+            static Task<ImprovedToolData> ThrowingImprover(ToolGenerationContext _, CancellationToken __)
+                => throw new InvalidOperationException("boom");
+
             var runner = new RecordingProcessRunner();
             var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["redis list"]);
             context.Items["Namespace"] = "redis";
+            context.Items[ToolGenerationStep.ToolImproverOverrideKey] = (Func<ToolGenerationContext, CancellationToken, Task<ImprovedToolData>>)ThrowingImprover;
 
             await SeedToolGenerationPrerequisitesAsync(context.OutputPath, ["redis list"]);
             await SeedComposedToolOutputAsync(context.OutputPath, "redis list");
-            // Don't seed improved output
 
             var step = new ToolGenerationStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
@@ -738,7 +734,7 @@ public class FailurePathTests
         Directory.CreateDirectory(mcpToolsRoot);
         Directory.CreateDirectory(outputPath);
 
-        return new PipelineContext
+        var context = new PipelineContext
         {
             Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
             RepoRoot = testRoot,
@@ -756,6 +752,17 @@ public class FailurePathTests
             CliOutput = CreateSnapshot(toolCommands),
             SelectedNamespaces = ["compute"],
         };
+
+        context.Items[ToolGenerationStep.ToolImproverOverrideKey] =
+            static (ToolGenerationContext toolContext, CancellationToken _) => Task.FromResult(new ImprovedToolData
+            {
+                FileName = toolContext.ToolName,
+                OriginalContent = toolContext.ComposedContent,
+                ImprovedContent = toolContext.ComposedContent,
+                WasImproved = false
+            });
+
+        return context;
     }
 
     private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
@@ -6,6 +6,7 @@ using PipelineRunner.Services;
 using PipelineRunner.Steps;
 using PipelineRunner.Tests.Fixtures;
 using Shared;
+using ToolGeneration_Improved.Models;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -360,12 +361,11 @@ public class NamespaceStepTests
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Equal(2, runner.Invocations.Count);
+            Assert.Single(runner.Invocations);
             Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("DocGeneration.Steps.ToolGeneration.Composition.csproj", StringComparison.Ordinal));
             Assert.Contains(runner.Invocations[0].Arguments, argument => argument == Path.Combine(context.OutputPath, "tools-raw"));
             Assert.Contains(runner.Invocations[0].Arguments, argument => argument == Path.Combine(context.OutputPath, "example-prompts"));
-            Assert.Contains(runner.Invocations[1].Arguments, argument => argument.EndsWith("DocGeneration.Steps.ToolGeneration.Improvements.csproj", StringComparison.Ordinal));
-            Assert.Contains(runner.Invocations[1].Arguments, argument => argument == "8000");
+            Assert.Equal(2, Directory.GetFiles(Path.Combine(context.OutputPath, "tools"), "*.md").Length);
         }
         finally
         {
@@ -374,7 +374,7 @@ public class NamespaceStepTests
     }
 
     [Fact]
-    public async Task Step3_ToolGeneration_MissingImprovedToolCreatesArtifactFailure()
+    public async Task Step3_ToolGeneration_ReducerPathGeneratesMissingImprovedTool()
     {
         var testRoot = CreateTestRoot();
         try
@@ -389,10 +389,9 @@ public class NamespaceStepTests
             var step = new ToolGenerationStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
-            Assert.False(result.Success);
-            Assert.Single(result.ArtifactFailures);
-            Assert.Equal("compute show", result.ArtifactFailures[0].ArtifactName);
-            Assert.Contains("improvement", result.ArtifactFailures[0].Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.True(result.Success);
+            Assert.Empty(result.ArtifactFailures);
+            Assert.Equal(2, Directory.GetFiles(Path.Combine(context.OutputPath, "tools"), "*.md").Length);
         }
         finally
         {
@@ -608,7 +607,7 @@ public class NamespaceStepTests
         Directory.CreateDirectory(mcpToolsRoot);
         Directory.CreateDirectory(outputPath);
 
-        return new PipelineContext
+        var context = new PipelineContext
         {
             Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
             RepoRoot = testRoot,
@@ -626,6 +625,17 @@ public class NamespaceStepTests
             CliOutput = CreateSnapshot(toolCommands),
             SelectedNamespaces = ["compute"],
         };
+
+        context.Items[ToolGenerationStep.ToolImproverOverrideKey] =
+            static (ToolGenerationContext toolContext, CancellationToken _) => Task.FromResult(new ImprovedToolData
+            {
+                FileName = toolContext.ToolName,
+                OriginalContent = toolContext.ComposedContent,
+                ImprovedContent = toolContext.ComposedContent,
+                WasImproved = false
+            });
+
+        return context;
     }
 
     private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
@@ -5,6 +5,7 @@ using PipelineRunner.Services;
 using PipelineRunner.Steps;
 using PipelineRunner.Tests.Fixtures;
 using Shared;
+using ToolGeneration_Improved.Models;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -54,17 +55,11 @@ public sealed class UpstreamArtifactResolutionStepTests
             runner.OnRun = spec =>
             {
                 invocationCount++;
-                if (invocationCount == 1)
-                {
-                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "tools-raw"), spec.Arguments);
-                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "annotations"), spec.Arguments);
-                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "parameters"), spec.Arguments);
-                    Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "example-prompts"), spec.Arguments);
-                    SeedFile(Path.Combine(context.OutputPath, "tools-composed", toolFileName));
-                    return CallbackProcessRunner.Success(spec);
-                }
-
-                SeedFile(Path.Combine(context.OutputPath, "tools", toolFileName));
+                Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "tools-raw"), spec.Arguments);
+                Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "annotations"), spec.Arguments);
+                Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "parameters"), spec.Arguments);
+                Assert.Contains(Path.Combine(context.OutputPath, "custom-upstream", "example-prompts"), spec.Arguments);
+                SeedFile(Path.Combine(context.OutputPath, "tools-composed", toolFileName));
                 return CallbackProcessRunner.Success(spec);
             };
 
@@ -72,7 +67,7 @@ public sealed class UpstreamArtifactResolutionStepTests
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Equal(2, runner.Invocations.Count);
+            Assert.Single(runner.Invocations);
         }
         finally
         {
@@ -183,7 +178,7 @@ public sealed class UpstreamArtifactResolutionStepTests
         Directory.CreateDirectory(outputPath);
         File.WriteAllText(Path.Combine(mcpToolsRoot, "data", "brand-to-server-mapping.json"), "[]");
 
-        return new PipelineContext
+        var context = new PipelineContext
         {
             Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
             RepoRoot = testRoot,
@@ -201,6 +196,17 @@ public sealed class UpstreamArtifactResolutionStepTests
             CliOutput = CreateSnapshot(toolCommands),
             SelectedNamespaces = ["compute"],
         };
+
+        context.Items[ToolGenerationStep.ToolImproverOverrideKey] =
+            static (ToolGenerationContext toolContext, CancellationToken _) => Task.FromResult(new ImprovedToolData
+            {
+                FileName = toolContext.ToolName,
+                OriginalContent = toolContext.ComposedContent,
+                ImprovedContent = toolContext.ComposedContent,
+                WasImproved = false
+            });
+
+        return context;
     }
 
     private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.GenerativeAI\DocGeneration.Core.GenerativeAI.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Tracing\DocGeneration.Core.Tracing.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.ToolGeneration.Improvements\DocGeneration.Steps.ToolGeneration.Improvements.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
@@ -1,17 +1,24 @@
+using System.Text;
 using System.Text.RegularExpressions;
+using GenerativeAI;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using ToolGeneration_Improved.Models;
+using ToolGeneration_Improved.Services;
 
 namespace PipelineRunner.Steps;
 
 public sealed class ToolGenerationStep : NamespaceStepBase
 {
     private const int DefaultMaxTokens = 8000;
+    internal const string ToolImproverOverrideKey = "ToolGenerationStep.ToolImproverOverride";
+
     private static readonly ReducerRegistry Reducers = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
+    private static readonly TimeSpan ReducerImprovementTimeout = TimeSpan.FromMinutes(5);
 
     private static readonly Regex ComposedFailureRegex = new(
         @"Error processing (?<file>[^:]+\.md):",
@@ -20,6 +27,20 @@ public sealed class ToolGenerationStep : NamespaceStepBase
     private static readonly Regex ImprovedFailureRegex = new(
         @"Processing\s+(?<file>[^\s]+\.md)\.\.\.\s*✗",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    static ToolGenerationStep()
+    {
+        Reducers.Register(3, static async (ctx, ct) =>
+        {
+            if (ctx is not ToolGenerationReducerInput input)
+            {
+                throw new InvalidOperationException($"Reducer input for step 3 must be {nameof(ToolGenerationReducerInput)}.");
+            }
+
+            var reducer = new ToolGenerationReducer();
+            return await reducer.ReduceAsync(input.ComposedToolsDirectory, input.ToolFileName, input.MaxTokens, ct);
+        });
+    }
 
     public ToolGenerationStep()
         : base(
@@ -37,11 +58,7 @@ public sealed class ToolGenerationStep : NamespaceStepBase
     public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
     {
         var (_, cliOutput, _, matchingTools) = ResolveTarget(context);
-        // P8: ReducerRegistry scaffold — when a reducer is registered, use it exclusively
-        if (Reducers.HasReducer(Id))
-        {
-            throw new NotImplementedException($"Reducer registered for step {Id} but execution path not yet implemented.");
-        }
+        var useReducerPath = Reducers.HasReducer(Id);
 
         _ = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step3", cancellationToken);
         var nameContext = await FileNameContext.CreateAsync();
@@ -166,28 +183,25 @@ public sealed class ToolGenerationStep : NamespaceStepBase
             return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
         }
 
-        var improvedResult = await context.ProcessRunner.RunDotNetProjectAsync(
-            GetProjectPath(context, "DocGeneration.Steps.ToolGeneration.Improvements"),
-            [composedToolsDirectory, improvedToolsDirectory, DefaultMaxTokens.ToString()],
-            context.Request.SkipBuild,
-            context.McpToolsRoot,
-            cancellationToken);
-        processResults.Add(improvedResult);
-
-        var improvedIssues = GetImprovedOutputIssues(toolArtifacts);
-        if (!improvedResult.Succeeded || improvedIssues.Count > 0)
+        if (useReducerPath)
         {
-            if (!improvedResult.Succeeded)
+            try
             {
-                AddProcessIssue(improvedResult, warnings, "AI-improved tool generation failed");
+                await ImproveToolsWithReducerAsync(
+                    context,
+                    toolArtifacts,
+                    composedToolsDirectory,
+                    improvedToolsDirectory,
+                    warnings,
+                    cancellationToken);
             }
-
-            warnings.AddRange(improvedIssues.SelectMany(static issue => issue.Value));
-            var failedImprovedFiles = ParseFailingFiles(
-                string.Join(Environment.NewLine, [improvedResult.StandardOutput, improvedResult.StandardError]),
-                ImprovedFailureRegex);
-            if (!improvedResult.Succeeded && failedImprovedFiles.Count == 0)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"AI-improved tool generation failed: {ex.Message}");
                 artifactFailures.Add(CreateStepLevelFailure(
                     "DocGeneration.Steps.ToolGeneration.Improvements",
                     "Tool improvement failed before specific tools could be identified.",
@@ -195,31 +209,80 @@ public sealed class ToolGenerationStep : NamespaceStepBase
                     [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory]));
                 return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
             }
+        }
+        else
+        {
+            var improvedResult = await context.ProcessRunner.RunDotNetProjectAsync(
+                GetProjectPath(context, "DocGeneration.Steps.ToolGeneration.Improvements"),
+                [composedToolsDirectory, improvedToolsDirectory, DefaultMaxTokens.ToString()],
+                context.Request.SkipBuild,
+                context.McpToolsRoot,
+                cancellationToken);
+            processResults.Add(improvedResult);
 
+            var improvedIssues = GetImprovedOutputIssues(toolArtifacts);
+            if (!improvedResult.Succeeded || improvedIssues.Count > 0)
+            {
+                if (!improvedResult.Succeeded)
+                {
+                    AddProcessIssue(improvedResult, warnings, "AI-improved tool generation failed");
+                }
+
+                warnings.AddRange(improvedIssues.SelectMany(static issue => issue.Value));
+                var failedImprovedFiles = ParseFailingFiles(
+                    string.Join(Environment.NewLine, [improvedResult.StandardOutput, improvedResult.StandardError]),
+                    ImprovedFailureRegex);
+                if (!improvedResult.Succeeded && failedImprovedFiles.Count == 0)
+                {
+                    artifactFailures.Add(CreateStepLevelFailure(
+                        "DocGeneration.Steps.ToolGeneration.Improvements",
+                        "Tool improvement failed before specific tools could be identified.",
+                        warnings,
+                        [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory]));
+                    return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+                }
+
+                artifactFailures.AddRange(toolArtifacts
+                    .Where(artifact => failedImprovedFiles.Contains(artifact.ToolFileName) || improvedIssues.ContainsKey(artifact.Command))
+                    .Select(artifact => CreateArtifactFailure(
+                        "tool",
+                        artifact.Command,
+                        "AI tool improvement failed for this tool.",
+                        warnings.Concat(improvedIssues.TryGetValue(artifact.Command, out var issueDetails) ? issueDetails : Array.Empty<string>()),
+                        artifact.GenerationPaths)));
+
+                if (artifactFailures.Count == 0)
+                {
+                    artifactFailures.Add(!improvedResult.Succeeded
+                        ? CreateStepLevelFailure(
+                            "DocGeneration.Steps.ToolGeneration.Improvements",
+                            "Tool improvement failed before specific tools could be identified.",
+                            warnings,
+                            [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory])
+                        : CreateArtifactFailure(
+                            "tool",
+                            GetCurrentNamespace(context),
+                            "Tool improvement failed before all final tool files were written.",
+                            warnings,
+                            [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory]));
+                }
+
+                return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+            }
+        }
+
+        var reducerImprovedIssues = GetImprovedOutputIssues(toolArtifacts);
+        if (reducerImprovedIssues.Count > 0)
+        {
+            warnings.AddRange(reducerImprovedIssues.SelectMany(static issue => issue.Value));
             artifactFailures.AddRange(toolArtifacts
-                .Where(artifact => failedImprovedFiles.Contains(artifact.ToolFileName) || improvedIssues.ContainsKey(artifact.Command))
+                .Where(artifact => reducerImprovedIssues.ContainsKey(artifact.Command))
                 .Select(artifact => CreateArtifactFailure(
                     "tool",
                     artifact.Command,
                     "AI tool improvement failed for this tool.",
-                    warnings.Concat(improvedIssues.TryGetValue(artifact.Command, out var issueDetails) ? issueDetails : Array.Empty<string>()),
+                    warnings.Concat(reducerImprovedIssues.TryGetValue(artifact.Command, out var issueDetails) ? issueDetails : Array.Empty<string>()),
                     artifact.GenerationPaths)));
-
-            if (artifactFailures.Count == 0)
-            {
-                artifactFailures.Add(!improvedResult.Succeeded
-                    ? CreateStepLevelFailure(
-                        "DocGeneration.Steps.ToolGeneration.Improvements",
-                        "Tool improvement failed before specific tools could be identified.",
-                        warnings,
-                        [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory])
-                    : CreateArtifactFailure(
-                        "tool",
-                        GetCurrentNamespace(context),
-                        "Tool improvement failed before all final tool files were written.",
-                        warnings,
-                        [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory]));
-            }
 
             return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
         }
@@ -319,6 +382,98 @@ public sealed class ToolGenerationStep : NamespaceStepBase
             .Where(static fileName => !string.IsNullOrWhiteSpace(fileName))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+    private static async Task ImproveToolsWithReducerAsync(
+        PipelineContext context,
+        IReadOnlyList<ToolArtifacts> toolArtifacts,
+        string composedToolsDirectory,
+        string improvedToolsDirectory,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(improvedToolsDirectory);
+
+        var reducer = Reducers.GetReducer(3);
+        if (reducer is null)
+        {
+            throw new InvalidOperationException("Reducer path was selected for step 3, but no reducer is registered.");
+        }
+
+        var improveToolAsync = await ResolveToolImproverAsync(context, cancellationToken);
+
+        foreach (var artifact in toolArtifacts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var reduction = (ToolGenerationContext)await reducer(
+                new ToolGenerationReducerInput(composedToolsDirectory, artifact.ToolFileName, DefaultMaxTokens),
+                cancellationToken);
+
+            try
+            {
+                using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                toolCts.CancelAfter(ReducerImprovementTimeout);
+
+                var improvedTool = await improveToolAsync(reduction, toolCts.Token);
+                await File.WriteAllTextAsync(artifact.ImprovedToolPath, improvedTool.ImprovedContent, Encoding.UTF8, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                await File.WriteAllTextAsync(artifact.ImprovedToolPath, reduction.ComposedContent, Encoding.UTF8, cancellationToken);
+            }
+            catch (ToolImprovementAiException)
+            {
+                await File.WriteAllTextAsync(artifact.ImprovedToolPath, reduction.ComposedContent, Encoding.UTF8, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"AI-improved tool generation failed for '{artifact.ToolFileName}': {ex.Message}");
+            }
+        }
+    }
+
+    private static async Task<Func<ToolGenerationContext, CancellationToken, Task<ImprovedToolData>>> ResolveToolImproverAsync(
+        PipelineContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context.Items.TryGetValue(ToolImproverOverrideKey, out var overrideValue))
+        {
+            if (overrideValue is Func<ToolGenerationContext, CancellationToken, Task<ImprovedToolData>> improver)
+            {
+                return improver;
+            }
+
+            throw new InvalidOperationException(
+                $"Context item '{ToolImproverOverrideKey}' must be {typeof(Func<ToolGenerationContext, CancellationToken, Task<ImprovedToolData>>).FullName}.");
+        }
+
+        var prompts = await LoadImprovementPromptsAsync(context.McpToolsRoot, cancellationToken);
+        var service = new ImprovedToolGeneratorService(new GenerativeAIClient(), prompts.SystemPrompt, prompts.UserPromptTemplate);
+        return (toolContext, ct) => service.ImproveToolAsync(toolContext, prompts.SystemPrompt, prompts.UserPromptTemplate, ct);
+    }
+
+    private static async Task<ImprovementPrompts> LoadImprovementPromptsAsync(string mcpToolsRoot, CancellationToken cancellationToken)
+    {
+        var projectRoot = Path.Combine(mcpToolsRoot, "DocGeneration.Steps.ToolGeneration.Improvements");
+        var promptsDirectory = Path.Combine(projectRoot, "prompts");
+        var dataDirectory = Path.Combine(mcpToolsRoot, "data");
+
+        var systemPromptPath = Path.Combine(promptsDirectory, "system-prompt.txt");
+        var userPromptTemplatePath = Path.Combine(promptsDirectory, "user-prompt-template.txt");
+
+        var systemPrompt = PromptTokenResolver.Resolve(
+            await File.ReadAllTextAsync(systemPromptPath, cancellationToken),
+            dataDirectory);
+        var userPromptTemplate = PromptTokenResolver.Resolve(
+            await File.ReadAllTextAsync(userPromptTemplatePath, cancellationToken),
+            dataDirectory);
+
+        return new ImprovementPrompts(systemPrompt, userPromptTemplate);
+    }
+
     private static ArtifactFailure CreateStepLevelFailure(
         string artifactName,
         string summary,
@@ -379,4 +534,8 @@ public sealed class ToolGenerationStep : NamespaceStepBase
                 Path.Combine(improvedToolsDirectory, toolFileName));
         }
     }
+
+    private sealed record ToolGenerationReducerInput(string ComposedToolsDirectory, string ToolFileName, int MaxTokens);
+
+    private sealed record ImprovementPrompts(string SystemPrompt, string UserPromptTemplate);
 }

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/ToolGenerationReducerTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/ToolGenerationReducerTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolGeneration_Improved.Services;
+
+namespace DocGeneration.Steps.ToolGeneration.Improvements.Tests;
+
+public sealed class ToolGenerationReducerTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public ToolGenerationReducerTests()
+    {
+        _testRoot = Path.Combine(AppContext.BaseDirectory, "tool-generation-reducer-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, true);
+        }
+    }
+
+    [Fact]
+    public async Task ReduceAsync_ReadsComposedFile_AndBuildsContext()
+    {
+        var composedDir = Path.Combine(_testRoot, "composed");
+        Directory.CreateDirectory(composedDir);
+
+        const string fileName = "fileshare-create.md";
+        const string content = """
+            # create
+
+            <!-- @mcpcli fileshares fileshare create -->
+
+            Tool content.
+            """;
+        await File.WriteAllTextAsync(Path.Combine(composedDir, fileName), content);
+
+        var reducer = new ToolGenerationReducer();
+
+        var result = await reducer.ReduceAsync(composedDir, fileName, 4096, CancellationToken.None);
+
+        Assert.Equal("fileshares fileshare create", result.ToolName);
+        Assert.Equal(content.ReplaceLineEndings(), result.ComposedContent.ReplaceLineEndings());
+        Assert.Equal(4096, result.MaxTokens);
+        Assert.Equal("1.0", result.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task ReduceAsync_MissingFile_ThrowsFileNotFoundException()
+    {
+        var composedDir = Path.Combine(_testRoot, "missing");
+        Directory.CreateDirectory(composedDir);
+
+        var reducer = new ToolGenerationReducer();
+
+        var ex = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            reducer.ReduceAsync(composedDir, "missing-tool.md", 1024, CancellationToken.None));
+
+        Assert.EndsWith("missing-tool.md", ex.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReduceAsync_SchemaVersion_IsAlwaysOnePointZero()
+    {
+        var composedDir = Path.Combine(_testRoot, "schema");
+        Directory.CreateDirectory(composedDir);
+
+        const string fileName = "tool.md";
+        await File.WriteAllTextAsync(Path.Combine(composedDir, fileName), "# tool");
+
+        var reducer = new ToolGenerationReducer();
+
+        var result = await reducer.ReduceAsync(composedDir, fileName, 123, CancellationToken.None);
+
+        Assert.Equal("1.0", result.SchemaVersion);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Models/ToolGenerationContext.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Models/ToolGenerationContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ToolGeneration_Improved.Models;
+
+/// <summary>
+/// Typed context for improving a single composed tool document.
+/// </summary>
+/// <param name="ToolName">The MCP tool command name.</param>
+/// <param name="ComposedContent">The full composed markdown content for the tool.</param>
+/// <param name="MaxTokens">The maximum token budget for the AI response.</param>
+/// <param name="SchemaVersion">The reducer schema version.</param>
+public sealed record ToolGenerationContext(
+    string ToolName,
+    string ComposedContent,
+    int MaxTokens,
+    string SchemaVersion = "1.0");

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ImprovedToolGeneratorService.cs
@@ -9,6 +9,23 @@ using System.Text;
 
 namespace ToolGeneration_Improved.Services;
 
+public enum ToolImprovementFailureKind
+{
+    AiFailure,
+    Truncated
+}
+
+public sealed class ToolImprovementAiException : Exception
+{
+    public ToolImprovementAiException(ToolImprovementFailureKind kind, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Kind = kind;
+    }
+
+    public ToolImprovementFailureKind Kind { get; }
+}
+
 /// <summary>
 /// Service that improves tool documentation using AI based on Microsoft content guidelines
 /// </summary>
@@ -119,11 +136,11 @@ public class ImprovedToolGeneratorService
         int skippedCount = 0;
         int errorCount = 0;
         int timedOutCount = 0;
+        var reducer = new ToolGenerationReducer();
 
         for (int i = 0; i < composedFiles.Length; i++)
         {
-            var composedFilePath = composedFiles[i];
-            var fileName = Path.GetFileName(composedFilePath);
+            var fileName = Path.GetFileName(composedFiles[i]);
             var progress = $"[{i + 1}/{composedFiles.Length}]";
 
             // Check if pipeline cancellation was requested before starting this tool
@@ -131,31 +148,16 @@ public class ImprovedToolGeneratorService
 
             Console.Write($"  {progress} Processing {fileName}...");
 
-            // Load composed file content (outside try — file read failures are hard errors)
-            var originalContent = await File.ReadAllTextAsync(composedFilePath, pipelineCancellationToken);
+            var toolContext = await reducer.ReduceAsync(composedToolsDir, fileName, maxTokens, pipelineCancellationToken);
 
-            // Pre-processing (deterministic, should not fail — errors here are real bugs)
-            var requiredParameters = ExtractRequiredParameters(originalContent);
-            var frozenContent = ProtectExamplePromptSections(originalContent, out var sectionMap);
-            frozenContent = ProtectParameterTable(frozenContent, out var paramTableMap);
-            var mcpCliComment = ExtractMcpCliComment(originalContent);
-            var protectedContent = ProtectTemplateLabels(frozenContent, out var labelMap);
-            var userPrompt = string.Format(_userPromptTemplate, protectedContent);
-            userPrompt = AppendRequiredParameterPreservationInstruction(userPrompt, requiredParameters);
-
-            // AI call — this is the section that may hang/fail/timeout
-            string improvedContent;
             try
             {
                 using var toolCts = CancellationTokenSource.CreateLinkedTokenSource(pipelineCancellationToken);
                 toolCts.CancelAfter(timeout);
-                var toolCt = toolCts.Token;
 
-                improvedContent = await _aiClient.GetChatCompletionAsync(
-                    _systemPrompt,
-                    userPrompt,
-                    maxTokens,
-                    toolCt);
+                var improvedTool = await ImproveToolAsync(toolContext, _systemPrompt, _userPromptTemplate, toolCts.Token);
+                var outputPath = Path.Combine(outputDir, fileName);
+                await File.WriteAllTextAsync(outputPath, improvedTool.ImprovedContent, Encoding.UTF8, pipelineCancellationToken);
             }
             catch (OperationCanceledException) when (pipelineCancellationToken.IsCancellationRequested)
             {
@@ -168,62 +170,26 @@ public class ImprovedToolGeneratorService
                 // Per-tool timeout — save original composed content as fallback
                 Console.WriteLine($" ⏱ Timed out after {timeout.TotalMinutes:F0}m — saving original");
                 timedOutCount++;
-                await SaveFallbackContent(originalContent, outputDir, fileName);
+                await SaveFallbackContent(toolContext.ComposedContent, outputDir, fileName);
                 continue;
             }
-            catch (InvalidOperationException ex) when (ex.Message.Contains("truncated"))
+            catch (ToolImprovementAiException ex) when (ex.Kind == ToolImprovementFailureKind.Truncated)
             {
                 Console.WriteLine($" ⚠ Truncated - saving original");
                 Console.WriteLine($"      {ex.Message}");
                 skippedCount++;
-                await SaveFallbackContent(originalContent, outputDir, fileName);
+                await SaveFallbackContent(toolContext.ComposedContent, outputDir, fileName);
                 continue;
             }
-            catch (Exception ex)
+            catch (ToolImprovementAiException ex)
             {
                 // AI-specific failure (network, server error, etc.) — save original as fallback
                 Console.WriteLine($" ⚠ AI error — saving original");
-                Console.WriteLine($"      {ex.GetType().Name}: {ex.Message}");
+                Console.WriteLine($"      {ex.InnerException?.GetType().Name ?? ex.GetType().Name}: {ex.Message}");
                 skippedCount++;
-                await SaveFallbackContent(originalContent, outputDir, fileName);
+                await SaveFallbackContent(toolContext.ComposedContent, outputDir, fileName);
                 continue;
             }
-
-            // Post-processing (deterministic — errors here are real bugs, not swallowed)
-            var restoredContent = RestoreTemplateLabels(improvedContent, labelMap);
-            restoredContent = NormalizeTemplateLabels(restoredContent);
-            restoredContent = RestoreExamplePromptSections(restoredContent, sectionMap);
-            restoredContent = RestoreParameterTable(restoredContent, paramTableMap);
-            restoredContent = RestoreMcpCliComment(restoredContent, mcpCliComment);
-
-            // Validate no leaked placeholder tokens remain
-            var leakedTokens = ValidateRestoredContent(restoredContent);
-            if (leakedTokens.Count > 0)
-            {
-                Console.WriteLine($" ⚠ Leaked tokens detected: {string.Join(", ", leakedTokens)}");
-                Console.WriteLine($"      Falling back to original content");
-                restoredContent = originalContent;
-            }
-            else if (requiredParameters.Count > 0)
-            {
-                var missingRequiredParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
-                if (missingRequiredParameters.Count > 0)
-                {
-                    Console.WriteLine($" ⚠ Missing required parameters after AI: {string.Join(", ", missingRequiredParameters.Select(parameter => parameter.DisplayName))}");
-                    restoredContent = ReinjectMissingRequiredParameters(restoredContent, originalContent, missingRequiredParameters);
-
-                    var remainingMissingParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
-                    if (remainingMissingParameters.Count > 0)
-                    {
-                        Console.WriteLine($"      Reinjection incomplete; falling back to original content");
-                        restoredContent = originalContent;
-                    }
-                }
-            }
-
-            // Save improved content
-            var outputPath = Path.Combine(outputDir, fileName);
-            await File.WriteAllTextAsync(outputPath, restoredContent, Encoding.UTF8);
 
             successCount++;
             Console.WriteLine(" ✓");
@@ -254,6 +220,81 @@ public class ImprovedToolGeneratorService
         }
 
         return errorCount > 0 ? 1 : 0;
+    }
+
+    public async Task<ImprovedToolData> ImproveToolAsync(
+        ToolGenerationContext context,
+        string systemPrompt,
+        string userPromptTemplate,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userPromptTemplate);
+
+        var requiredParameters = ExtractRequiredParameters(context.ComposedContent);
+        var frozenContent = ProtectExamplePromptSections(context.ComposedContent, out var sectionMap);
+        frozenContent = ProtectParameterTable(frozenContent, out var paramTableMap);
+        var mcpCliComment = ExtractMcpCliComment(context.ComposedContent);
+        var protectedContent = ProtectTemplateLabels(frozenContent, out var labelMap);
+        var userPrompt = string.Format(userPromptTemplate, protectedContent);
+        userPrompt = AppendRequiredParameterPreservationInstruction(userPrompt, requiredParameters);
+
+        string improvedContent;
+        try
+        {
+            improvedContent = await _aiClient.GetChatCompletionAsync(
+                systemPrompt,
+                userPrompt,
+                context.MaxTokens,
+                ct);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("truncated", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ToolImprovementAiException(ToolImprovementFailureKind.Truncated, ex.Message, ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new ToolImprovementAiException(ToolImprovementFailureKind.AiFailure, ex.Message, ex);
+        }
+
+        var restoredContent = RestoreTemplateLabels(improvedContent, labelMap);
+        restoredContent = NormalizeTemplateLabels(restoredContent);
+        restoredContent = RestoreExamplePromptSections(restoredContent, sectionMap);
+        restoredContent = RestoreParameterTable(restoredContent, paramTableMap);
+        restoredContent = RestoreMcpCliComment(restoredContent, mcpCliComment);
+
+        string? errorMessage = null;
+        var leakedTokens = ValidateRestoredContent(restoredContent);
+        if (leakedTokens.Count > 0)
+        {
+            errorMessage = $"Leaked tokens detected: {string.Join(", ", leakedTokens)}";
+            restoredContent = context.ComposedContent;
+        }
+        else if (requiredParameters.Count > 0)
+        {
+            var missingRequiredParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
+            if (missingRequiredParameters.Count > 0)
+            {
+                restoredContent = ReinjectMissingRequiredParameters(restoredContent, context.ComposedContent, missingRequiredParameters);
+
+                var remainingMissingParameters = FindMissingRequiredParameters(restoredContent, requiredParameters);
+                if (remainingMissingParameters.Count > 0)
+                {
+                    errorMessage = $"Missing required parameters after reinjection: {string.Join(", ", remainingMissingParameters.Select(parameter => parameter.DisplayName))}";
+                    restoredContent = context.ComposedContent;
+                }
+            }
+        }
+
+        return new ImprovedToolData
+        {
+            FileName = context.ToolName,
+            OriginalContent = context.ComposedContent,
+            ImprovedContent = restoredContent,
+            WasImproved = !string.Equals(restoredContent, context.ComposedContent, StringComparison.Ordinal),
+            ErrorMessage = errorMessage
+        };
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ToolGenerationReducer.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Services/ToolGenerationReducer.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using ToolGeneration_Improved.Models;
+
+namespace ToolGeneration_Improved.Services;
+
+/// <summary>
+/// Deterministically reduces a composed tool file into typed improvement context.
+/// </summary>
+public sealed class ToolGenerationReducer
+{
+    private const string CurrentSchemaVersion = "1.0";
+
+    private static readonly Regex McpCliCommandRegex = new(
+        @"<!--\s*@mcpcli\s+(?<command>.*?)\s*-->",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public async Task<ToolGenerationContext> ReduceAsync(
+        string composedToolsDir,
+        string toolFileName,
+        int maxTokens,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(composedToolsDir);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolFileName);
+
+        var composedFilePath = Path.Combine(composedToolsDir, toolFileName);
+        if (!File.Exists(composedFilePath))
+        {
+            throw new FileNotFoundException($"Composed tool file not found: {composedFilePath}", composedFilePath);
+        }
+
+        var composedContent = await File.ReadAllTextAsync(composedFilePath, ct);
+        var toolName = ExtractToolName(composedContent, toolFileName);
+
+        return new ToolGenerationContext(
+            toolName,
+            composedContent,
+            maxTokens,
+            CurrentSchemaVersion);
+    }
+
+    private static string ExtractToolName(string composedContent, string toolFileName)
+    {
+        var match = McpCliCommandRegex.Match(composedContent);
+        if (match.Success)
+        {
+            return match.Groups["command"].Value.Trim();
+        }
+
+        return Path.GetFileNameWithoutExtension(toolFileName);
+    }
+}


### PR DESCRIPTION
## Summary
First of three P6 reducer PRs. Extracts deterministic prompt-assembly logic from ToolGenerationStep into a dedicated ToolGenerationReducer that produces a typed ToolGenerationContext.

## Changes
- **ToolGenerationContext.cs** — typed record (ToolName, ComposedContent, MaxTokens, SchemaVersion)
- **ToolGenerationReducer.cs** — reads composed tool file, returns context
- **ImprovedToolGeneratorService** — added ImproveToolAsync for single-tool processing from context
- **ToolGenerationStep** — implemented reducer execution path (P8 scaffold activated for step 3)
- **Tests** — 86 passing (includes new reducer unit tests)

## Validation
- Build: 0 errors
- PipelineRunner tests: 490 pass
- Improvement tests: 86 pass
- Fingerprint tests: 67 pass

## PRD Reference
Point 6, PR 1 of 3 (ToolGeneration stage)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>