### PR TITLE
refactor(p6): extract FamilyStructureBuilder — typed context for tool-family cleanup stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Completed npm-to-dotnet migration** — Removed all Node.js scripts from `mcp-cli-metadata/`. CLI metadata extraction now uses `mcp-tools/McpCliMetadata/` exclusively. Updated CI workflows, preflight.ps1, and documentation. Closes #627.
 - **PipelineRunner stage observability contract** — Each step now emits a standard observability bundle under `{output}/observability/{stepId}-{slug}/`: `summary.md`, `step-result.json`, `validation.json`, `prompt-preview.txt` (or `prompt-preview-na.txt` for deterministic steps), and `metrics.json`. Missing files are enforced at warning level so incomplete step instrumentation surfaces immediately without breaking existing runs.
 - **Advisor golden behavioral-equivalence gate** — Added `fingerprint golden capture` / `fingerprint golden verify`, an advisor golden manifest fixture, a local capture helper script, and a `golden-diff` workflow job that enforces SHA-256 parity for deterministic outputs plus structural parity for AI-authored outputs.
+- **Step 4 deterministic family structure builder** — Tool-family cleanup now constructs a typed `FamilyStructureContext` via `FamilyStructureBuilder` before AI cleanup, using precomputed `h2-headings/*.json` data for canonical section headings and order. The legacy subprocess path remains available as a fallback.
 
 ### Fixed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,6 +73,10 @@ Step 3: Tool Composition + AI Improvements ────────────�
   ▼
 Step 4: Tool Family Assembly (AI + Retry + Validation) ────────────
   │  • tools/*.md → tool-family/{namespace}.md (one article per service)
+  │  • `FamilyStructureBuilder` deterministically emits
+  │    `FamilyStructureContext` (family name, section order, headings,
+  │    source content, schema version) before AI metadata generation
+  │  • H2 headings come from bootstrap `h2-headings/*.json`
   │  • AI generates: frontmatter, intro, related content
   │  • Post-processing: MCP acronym expansion, frontmatter enrichment,
   │    duplicate example stripping

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyCleanupStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyCleanupStepTests.cs
@@ -5,12 +5,48 @@ using PipelineRunner.Services;
 using PipelineRunner.Steps;
 using PipelineRunner.Tests.Fixtures;
 using Shared;
+using ToolFamilyCleanup.Models;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
 
 public class ToolFamilyCleanupStepTests
 {
+    [Fact]
+    public async Task Step4_ReducerPath_UsesFamilyCleanupOverride_AndSkipsSubprocess()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var processRunner = new CallbackProcessRunner();
+            var context = CreateContext(testRoot, processRunner);
+            context.Items["Namespace"] = "compute";
+            context.Items[ToolFamilyCleanupStep.FamilyCleanupOverrideKey] =
+                static (FamilyStructureContext structure, CancellationToken _) => Task.FromResult(
+                    new ToolFamilyCleanupStep.FamilyCleanupArtifacts(
+                        $"metadata for {structure.FamilyName}",
+                        "related content",
+                        $"# Final article{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine + Environment.NewLine, structure.Sections.Select(section => section.SourceContent))}"));
+
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-disk-create.md"), "compute disk create");
+            SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+
+            var step = new ToolFamilyCleanupStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+            var outputFileName = await ToolFileNameBuilder.ResolveFamilyFileNameAsync("compute");
+
+            Assert.True(result.Success, string.Join(" | ", result.Warnings));
+            Assert.Empty(processRunner.Invocations);
+            Assert.Equal("metadata for compute", File.ReadAllText(Path.Combine(context.OutputPath, "tool-family-metadata", $"{outputFileName}-metadata.md")));
+            Assert.Equal("related content", File.ReadAllText(Path.Combine(context.OutputPath, "tool-family-related", $"{outputFileName}-related.md")));
+            Assert.Contains("## Create disk", File.ReadAllText(Path.Combine(context.OutputPath, "tool-family", $"{outputFileName}.md")));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
     [Fact]
     public async Task Step4_UsesIsolatedWorkspaceAndCopiesOutputsBackOnSuccess()
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.GenerativeAI\DocGeneration.Core.GenerativeAI.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Tracing\DocGeneration.Core.Tracing.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.ToolFamilyCleanup\DocGeneration.Steps.ToolFamilyCleanup.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.ToolGeneration.Improvements\DocGeneration.Steps.ToolGeneration.Improvements.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -4,13 +4,31 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Services;
 
 namespace PipelineRunner.Steps;
 
 public sealed class ToolFamilyCleanupStep : NamespaceStepBase
 {
+    public const string FamilyCleanupOverrideKey = "ToolFamilyCleanupStep.FamilyCleanupOverride";
+
     private static readonly ReducerRegistry Reducers = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
+
+    static ToolFamilyCleanupStep()
+    {
+        Reducers.Register(4, static async (ctx, ct) =>
+        {
+            if (ctx is not FamilyStructureReducerInput input)
+            {
+                throw new InvalidOperationException($"Reducer input for step 4 must be {nameof(FamilyStructureReducerInput)}.");
+            }
+
+            var builder = new FamilyStructureBuilder();
+            return await builder.BuildAsync(input.ToolsDirectory, input.FamilyName, input.H2HeadingsDirectory, ct);
+        });
+    }
 
     public ToolFamilyCleanupStep()
         : base(
@@ -29,12 +47,8 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
     public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
     {
         var (currentNamespace, _, _, matchingTools) = ResolveTarget(context);
-        // P8: ReducerRegistry scaffold — when a reducer is registered, use it exclusively
-        if (Reducers.HasReducer(Id))
-        {
-            throw new NotImplementedException($"Reducer registered for step {Id} but execution path not yet implemented.");
-        }
-
+        var useReducerPath = Reducers.HasReducer(Id);
+        var hasCleanupOverride = context.Items.ContainsKey(FamilyCleanupOverrideKey);
         var processResults = new List<ProcessExecutionResult>();
         var warnings = new List<string>();
         var artifactFailures = new List<ArtifactFailure>();
@@ -121,6 +135,53 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             warnings.Add($"No tool files found for family '{familyName}' in '{toolsInputDirectory}'.");
             artifactFailures.Add(CreateFamilyFailure(context, familyName, outputFileName, warnings));
             return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+        }
+
+        if (useReducerPath)
+        {
+            try
+            {
+                var artifacts = await GenerateFamilyWithReducerAsync(
+                    context,
+                    toolsInputDirectory,
+                    familyName,
+                    h2HeadingsSource,
+                    cliVersionPath,
+                    brandMappings,
+                    warnings,
+                    cancellationToken);
+
+                WriteFamilyArtifacts(context.OutputPath, outputFileName, artifacts);
+                RemoveStaleFamilyFiles(context.OutputPath, familyName, outputFileName);
+                await ApplyCliTabWrappingAsync(
+                    context,
+                    currentNamespace,
+                    cliTabConfigPath,
+                    cliOutputPath,
+                    parameterCliDir,
+                    exampleCommandsDir,
+                    toolsRawDirectory,
+                    Path.Combine(context.OutputPath, "tool-family", $"{outputFileName}.md"),
+                    warnings,
+                    cancellationToken);
+
+                return BuildResult(context, processResults, true, warnings, artifactFailures: artifactFailures);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (hasCleanupOverride)
+                {
+                    warnings.Add($"Tool-family cleanup failed: {ex.Message}");
+                    artifactFailures.Add(CreateFamilyFailure(context, familyName, outputFileName, warnings));
+                    return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+                }
+
+                Console.WriteLine($"Reducer path failed for family '{familyName}', falling back to subprocess: {ex.Message}");
+            }
         }
 
         var tempRoot = context.Workspaces.CreateTemporaryDirectory("pipeline-runner-step4");
@@ -384,6 +445,10 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
         return await ToolFileNameBuilder.ResolveFamilyFileNameAsync(familyName);
     }
 
+    public sealed record FamilyCleanupArtifacts(string Metadata, string RelatedContent, string FinalContent);
+
+    private sealed record FamilyStructureReducerInput(string ToolsDirectory, string FamilyName, string? H2HeadingsDirectory);
+
     private static string ResolveFamilyName(string currentNamespace, IReadOnlyList<CliTool> matchingTools,
         IReadOnlyDictionary<string, BrandMapping> brandMappings)
     {
@@ -529,5 +594,194 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderByDescending(prefix => prefix.Length)
             .ToArray();
+    }
+
+    private static async Task<FamilyCleanupArtifacts> GenerateFamilyWithReducerAsync(
+        PipelineContext context,
+        string toolsDirectory,
+        string familyName,
+        string? h2HeadingsDirectory,
+        string cliVersionPath,
+        IReadOnlyDictionary<string, BrandMapping> brandMappings,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        var reducer = Reducers.GetReducer(4);
+        if (reducer is null)
+        {
+            throw new InvalidOperationException("Reducer path was selected for step 4, but no reducer is registered.");
+        }
+
+        var structure = (FamilyStructureContext)await reducer(
+            new FamilyStructureReducerInput(toolsDirectory, familyName, h2HeadingsDirectory),
+            cancellationToken);
+
+        var cleanupAsync = await ResolveFamilyCleanupAsync(context, familyName, cliVersionPath, brandMappings, warnings, cancellationToken);
+        return await cleanupAsync(structure, cancellationToken);
+    }
+
+    private static async Task<Func<FamilyStructureContext, CancellationToken, Task<FamilyCleanupArtifacts>>> ResolveFamilyCleanupAsync(
+        PipelineContext context,
+        string familyName,
+        string cliVersionPath,
+        IReadOnlyDictionary<string, BrandMapping> brandMappings,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        if (context.Items.TryGetValue(FamilyCleanupOverrideKey, out var overrideValue))
+        {
+            if (overrideValue is Func<FamilyStructureContext, CancellationToken, Task<FamilyCleanupArtifacts>> cleanupOverride)
+            {
+                return cleanupOverride;
+            }
+
+            throw new InvalidOperationException(
+                $"Context item '{FamilyCleanupOverrideKey}' must be {typeof(Func<FamilyStructureContext, CancellationToken, Task<FamilyCleanupArtifacts>>).FullName}.");
+        }
+
+        var displayName = brandMappings.TryGetValue(familyName, out var mapping) && !string.IsNullOrWhiteSpace(mapping.BrandName)
+            ? mapping.BrandName!
+            : familyName;
+
+        var cliVersion = "unknown";
+        if (File.Exists(cliVersionPath))
+        {
+            var cliRoot = Path.GetDirectoryName(Path.GetDirectoryName(cliVersionPath)!)!;
+            cliVersion = await CliVersionReader.ReadCliVersionAsync(cliRoot);
+        }
+        else
+        {
+            warnings.Add($"CLI version file not found at '{cliVersionPath}'. Tool-family cleanup will use 'unknown'.");
+        }
+
+        var cleanupGenerator = new CleanupGenerator(new GenerativeAIOptions(), new CleanupConfiguration());
+        return async (structure, ct) =>
+        {
+            ct.ThrowIfCancellationRequested();
+            var artifacts = await cleanupGenerator.GenerateFromStructureAsync(structure, displayName, cliVersion, ct);
+            return new FamilyCleanupArtifacts(artifacts.Metadata, artifacts.RelatedContent, artifacts.FinalContent);
+        };
+    }
+
+    private static void WriteFamilyArtifacts(string outputPath, string outputFileName, FamilyCleanupArtifacts artifacts)
+    {
+        var metadataDirectory = Path.Combine(outputPath, "tool-family-metadata");
+        var relatedDirectory = Path.Combine(outputPath, "tool-family-related");
+        var finalDirectory = Path.Combine(outputPath, "tool-family");
+        Directory.CreateDirectory(metadataDirectory);
+        Directory.CreateDirectory(relatedDirectory);
+        Directory.CreateDirectory(finalDirectory);
+
+        File.WriteAllText(Path.Combine(metadataDirectory, $"{outputFileName}-metadata.md"), artifacts.Metadata);
+        File.WriteAllText(Path.Combine(relatedDirectory, $"{outputFileName}-related.md"), artifacts.RelatedContent);
+        File.WriteAllText(Path.Combine(finalDirectory, $"{outputFileName}.md"), artifacts.FinalContent);
+    }
+
+    private static void RemoveStaleFamilyFiles(string outputPath, string familyName, string outputFileName)
+    {
+        if (string.Equals(familyName, outputFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        RemoveStaleFile(Path.Combine(outputPath, "tool-family", $"{familyName}.md"));
+        RemoveStaleFile(Path.Combine(outputPath, "tool-family-metadata", $"{familyName}-metadata.md"));
+        RemoveStaleFile(Path.Combine(outputPath, "tool-family-related", $"{familyName}-related.md"));
+    }
+
+    private static async Task ApplyCliTabWrappingAsync(
+        PipelineContext context,
+        string currentNamespace,
+        string cliTabConfigPath,
+        string cliOutputPath,
+        string parameterCliDir,
+        string exampleCommandsDir,
+        string toolsRawDirectory,
+        string familyArticlePath,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(familyArticlePath))
+        {
+            return;
+        }
+
+        var cliTabConfig = CliTabConfig.LoadFromFile(cliTabConfigPath);
+        if (!cliTabConfig.IsNamespaceAllowed(currentNamespace))
+        {
+            Console.WriteLine($"  ⊘ CLI tab generation disabled for namespace '{currentNamespace}'");
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(cliOutputPath) && Directory.Exists(parameterCliDir) && Directory.Exists(exampleCommandsDir))
+            {
+                var cliJson = await File.ReadAllTextAsync(cliOutputPath, cancellationToken);
+                var allCliTools = CliJsonMapper.MapFromCliOutput(cliJson);
+                var nameContext = await FileNameContext.CreateAsync();
+
+                var cliTools = new Dictionary<string, CliToolInfo>(StringComparer.OrdinalIgnoreCase);
+                foreach (var (key, tool) in allCliTools)
+                {
+                    if (key.StartsWith(currentNamespace + " ", StringComparison.OrdinalIgnoreCase) ||
+                        key.Equals(currentNamespace, StringComparison.OrdinalIgnoreCase))
+                    {
+                        cliTools[key] = tool;
+                    }
+                }
+
+                var nlpDescriptions = await NlpDescriptionExtractor.ExtractNlpDescriptionsAsync(
+                    toolsRawDirectory, nameContext, cliTools.Keys);
+
+                if (nlpDescriptions.Count > 0)
+                {
+                    var improver = new CliProseImprover();
+                    var improved = await improver.ImproveProseAsync(cliTools, nlpDescriptions, cancellationToken: cancellationToken);
+                    cliTools = new Dictionary<string, CliToolInfo>(improved, StringComparer.OrdinalIgnoreCase);
+                    Console.WriteLine($"  ✓ Aligned {cliTools.Count} CLI descriptions with NLP (deterministic)");
+                }
+
+                var assembledContent = await CliContentAssembler.AssembleAllCliContentAsync(
+                    cliTools, parameterCliDir, exampleCommandsDir, nameContext);
+
+                if (nlpDescriptions.Count > 0)
+                {
+                    var cliDescriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var (key, tool) in cliTools)
+                    {
+                        cliDescriptions[key] = tool.Description;
+                    }
+
+                    var alignmentResult = DescriptionAlignmentValidator.Validate(nlpDescriptions, cliDescriptions);
+                    foreach (var warning in alignmentResult.Warnings)
+                    {
+                        Console.WriteLine($"  ⚠ Alignment: {warning}");
+                        warnings.Add($"Description alignment warning: {warning}");
+                    }
+
+                    foreach (var error in alignmentResult.Errors)
+                    {
+                        Console.WriteLine($"  ✗ Alignment: {error}");
+                        warnings.Add($"Description alignment error: {error}");
+                    }
+                }
+
+                if (assembledContent.Count > 0)
+                {
+                    var familyMarkdown = await File.ReadAllTextAsync(familyArticlePath, cancellationToken);
+                    var tabbedMarkdown = CliTabWrapper.ApplyTabsToFamilyArticle(familyMarkdown, assembledContent);
+                    await File.WriteAllTextAsync(familyArticlePath, tabbedMarkdown, cancellationToken);
+                }
+            }
+            else
+            {
+                warnings.Add("CLI tab wrapping skipped: missing cli-output.json, parameter-cli, or example-commands directories.");
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"CLI tab wrapping failed (non-fatal): {ex.Message}");
+        }
     }
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FamilyStructureBuilderTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FamilyStructureBuilderTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using ToolFamilyCleanup.Services;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests;
+
+public sealed class FamilyStructureBuilderTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public FamilyStructureBuilderTests()
+    {
+        _testRoot = Path.Combine(AppContext.BaseDirectory, "family-structure-builder-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExtractsSectionsInCanonicalOrder()
+    {
+        var toolsDirectory = Path.Combine(_testRoot, "tools");
+        Directory.CreateDirectory(toolsDirectory);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(toolsDirectory, "compute-disk-delete.md"),
+            """
+            ---
+            ---
+            # Delete disk
+
+            <!-- @mcpcli compute disk delete -->
+
+            Removes a disk.
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(toolsDirectory, "compute-disk-create.md"),
+            """
+            ---
+            ---
+            # Create disk
+
+            <!-- @mcpcli compute disk create -->
+
+            Creates a disk.
+            """);
+
+        var builder = new FamilyStructureBuilder();
+
+        var result = await builder.BuildAsync(toolsDirectory, "compute", h2HeadingsDirectory: null, CancellationToken.None);
+
+        Assert.Equal("compute", result.FamilyName);
+        Assert.Equal(2, result.Sections.Count);
+        Assert.Equal("Create disk", result.Sections[0].Heading);
+        Assert.Equal(["compute disk create"], result.Sections[0].ToolNames);
+        Assert.StartsWith("## Create disk", result.Sections[0].SourceContent.ReplaceLineEndings());
+        Assert.Equal("Delete disk", result.Sections[1].Heading);
+        Assert.Equal(["compute disk delete"], result.Sections[1].ToolNames);
+    }
+
+    [Fact]
+    public async Task BuildAsync_EmptyDirectory_ReturnsEmptySections()
+    {
+        var toolsDirectory = Path.Combine(_testRoot, "empty-tools");
+        Directory.CreateDirectory(toolsDirectory);
+
+        var builder = new FamilyStructureBuilder();
+
+        var result = await builder.BuildAsync(toolsDirectory, "compute", h2HeadingsDirectory: null, CancellationToken.None);
+
+        Assert.Equal("compute", result.FamilyName);
+        Assert.Empty(result.Sections);
+    }
+
+    [Fact]
+    public async Task BuildAsync_SchemaVersion_IsAlwaysOnePointZero()
+    {
+        var toolsDirectory = Path.Combine(_testRoot, "schema-tools");
+        Directory.CreateDirectory(toolsDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(toolsDirectory, "compute-disk-create.md"),
+            """
+            # Create disk
+            <!-- @mcpcli compute disk create -->
+            Creates a disk.
+            """);
+
+        var builder = new FamilyStructureBuilder();
+
+        var result = await builder.BuildAsync(toolsDirectory, "compute", h2HeadingsDirectory: null, CancellationToken.None);
+
+        Assert.Equal("1.0", result.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task BuildAsync_LoadsHeadingsFromJson_WhenAvailable()
+    {
+        var toolsDirectory = Path.Combine(_testRoot, "json-tools");
+        var h2HeadingsDirectory = Path.Combine(_testRoot, "h2-headings");
+        Directory.CreateDirectory(toolsDirectory);
+        Directory.CreateDirectory(h2HeadingsDirectory);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(toolsDirectory, "compute-disk-create.md"),
+            """
+            ---
+            ---
+            # Create disk
+
+            <!-- @mcpcli compute disk create -->
+
+            Creates a disk.
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(h2HeadingsDirectory, "compute.json"),
+            JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                ["compute disk create"] = "Provision disk"
+            }));
+
+        var builder = new FamilyStructureBuilder();
+
+        var result = await builder.BuildAsync(toolsDirectory, "compute", h2HeadingsDirectory, CancellationToken.None);
+
+        Assert.Single(result.Sections);
+        Assert.Equal("Provision disk", result.Sections[0].Heading);
+        Assert.StartsWith("## Provision disk", result.Sections[0].SourceContent.ReplaceLineEndings());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Models/FamilyStructureContext.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Models/FamilyStructureContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ToolFamilyCleanup.Models;
+
+public sealed record FamilyStructureContext(
+    string FamilyName,
+    IReadOnlyList<FamilySection> Sections,
+    string SchemaVersion = "1.0");
+
+public sealed record FamilySection(
+    string Heading,
+    IReadOnlyList<string> ToolNames,
+    string SourceContent);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/README.md
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/README.md
@@ -10,6 +10,8 @@ This tool takes generated tool family markdown files and applies AI-powered clea
 
 1. **Single-Phase Mode** (Default): Processes complete pre-assembled tool family files in one LLM call per file
 2. **Multi-Phase Mode** (Advanced): Assembles tool families from individual tool files, generating metadata and related content separately to avoid token limits
+   - `FamilyStructureBuilder` now deterministically builds a typed `FamilyStructureContext` before any AI call
+   - H2 headings come from precomputed `generated/h2-headings/{family}.json` files, with deterministic fallback when missing
 
 ### Features
 
@@ -56,9 +58,10 @@ pwsh ./GenerateDocGeneration.Steps.ToolFamilyCleanup-multifile.ps1
 
 **How It Works:**
 1. **Phase 1**: Reads individual tool files from `./generated/tools/` and groups by family
-2. **Phase 2**: Generates metadata (frontmatter + H1 + intro) using AI per family
-3. **Phase 3**: Generates "Related content" section using AI per family
-4. **Phase 4**: Stitches tools together with AI-generated metadata/related content (no AI)
+2. **Phase 1.5**: `FamilyStructureBuilder` loads deterministic H2 headings, establishes canonical section order, and emits `FamilyStructureContext`
+3. **Phase 2**: Generates metadata (frontmatter + H1 + intro) using AI per family
+4. **Phase 3**: Generates deterministic related content per family
+5. **Phase 4**: Stitches sections together with metadata/related content (no AI)
 
 **Advantages:**
 - ✓ No 16K token limit (processes tools individually)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/CleanupGenerator.cs
@@ -50,6 +50,56 @@ public class CleanupGenerator
         _config = config;
     }
 
+    public async Task<(string Metadata, string RelatedContent, string FinalContent)> GenerateFromStructureAsync(
+        FamilyStructureContext structureContext,
+        string displayName,
+        string cliVersion,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(structureContext);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var metadataGenerator = new FamilyMetadataGenerator(_options);
+        await metadataGenerator.LoadPromptsAsync();
+
+        var serviceDocLinks = LoadServiceDocLinks();
+        var familyContent = new FamilyContent
+        {
+            FamilyName = structureContext.FamilyName,
+            DisplayName = displayName,
+            Metadata = string.Empty,
+            RelatedContent = string.Empty,
+            Tools = structureContext.Sections.Select((section, index) => new ToolContent
+            {
+                ToolName = section.Heading,
+                FileName = $"section-{index + 1}.md",
+                FamilyName = structureContext.FamilyName,
+                Content = section.SourceContent,
+                Command = section.ToolNames.FirstOrDefault(),
+                Description = null,
+                ResourceType = ToolReader.GetResourceType(section.ToolNames.FirstOrDefault())
+            }).ToList()
+        };
+
+        var aiMetadata = await metadataGenerator.GenerateAsync(familyContent, cliVersion);
+        var metadata = aiMetadata;
+        if (serviceDocLinks.TryGetValue(structureContext.FamilyName, out var docLink) &&
+            !string.IsNullOrWhiteSpace(docLink.SeoDescription))
+        {
+            var generator = new DeterministicFrontmatterGenerator();
+            var header = generator.Generate(displayName, familyContent.ToolCount, cliVersion, docLink.SeoDescription);
+            var intros = generator.ExtractIntroParagraphs(aiMetadata);
+            metadata = generator.Assemble(header, intros);
+        }
+
+        familyContent.Metadata = metadata;
+        familyContent.RelatedContent = DeterministicRelatedContentGenerator.Generate(structureContext.FamilyName, serviceDocLinks);
+        var stitcher = new FamilyFileStitcher();
+        var finalContent = stitcher.Stitch(familyContent);
+        return (metadata, familyContent.RelatedContent, finalContent);
+    }
+
     /// <summary>
     /// Processes all tool family markdown files in the input directory.
     /// </summary>
@@ -215,6 +265,19 @@ public class CleanupGenerator
 
         Console.WriteLine("✓ Prompts loaded");
         Console.WriteLine();
+    }
+
+    private static Dictionary<string, ServiceDocLink> LoadServiceDocLinks()
+    {
+        var serviceDocLinksPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "data", "service-doc-links.json");
+        if (!File.Exists(serviceDocLinksPath))
+        {
+            serviceDocLinksPath = Path.Combine(AppContext.BaseDirectory, "data", "service-doc-links.json");
+        }
+
+        return File.Exists(serviceDocLinksPath)
+            ? DeterministicRelatedContentGenerator.LoadServiceDocLinks(serviceDocLinksPath)
+            : new Dictionary<string, ServiceDocLink>();
     }
 
     private string GenerateUserPrompt(string fileName, string content)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyStructureBuilder.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyStructureBuilder.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text.Json;
+using ToolFamilyCleanup.Models;
+using Shared;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Deterministically assembles canonical tool-family structure from staged tool files.
+/// </summary>
+public sealed class FamilyStructureBuilder
+{
+    public async Task<FamilyStructureContext> BuildAsync(
+        string toolsDirectory,
+        string familyName,
+        string? h2HeadingsDirectory,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolsDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(familyName);
+        ct.ThrowIfCancellationRequested();
+
+        if (!Directory.Exists(toolsDirectory))
+        {
+            return new FamilyStructureContext(familyName, []);
+        }
+
+        var toolReader = new ToolReader(toolsDirectory);
+        var toolsByFamily = await toolReader.ReadAndGroupToolsAsync();
+        var tools = toolsByFamily
+            .FirstOrDefault(kv => string.Equals(kv.Key, familyName, StringComparison.OrdinalIgnoreCase))
+            .Value;
+
+        if (tools is null || tools.Count == 0)
+        {
+            return new FamilyStructureContext(familyName, []);
+        }
+
+        var headings = await LoadHeadingsAsync(h2HeadingsDirectory, familyName, ct);
+        var compoundWords = await DataFileLoader.LoadCompoundWordsAsync();
+        var sections = BuildSections(tools, headings, compoundWords);
+        return new FamilyStructureContext(familyName, sections);
+    }
+
+    private static IReadOnlyList<FamilySection> BuildSections(
+        IReadOnlyList<ToolContent> tools,
+        IReadOnlyDictionary<string, string> headings,
+        Dictionary<string, string> compoundWords)
+    {
+        var orderedTools = tools
+            .OrderBy(tool => tool.FileName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(tool => tool.FileName, StringComparer.Ordinal)
+            .ToList();
+
+        var isMultiResource = FamilyFileStitcher.IsMultiResourceFamily(orderedTools);
+        return isMultiResource
+            ? BuildMultiResourceSections(orderedTools, headings, compoundWords)
+            : BuildSingleResourceSections(orderedTools, headings, compoundWords);
+    }
+
+    private static IReadOnlyList<FamilySection> BuildSingleResourceSections(
+        IReadOnlyList<ToolContent> tools,
+        IReadOnlyDictionary<string, string> headings,
+        Dictionary<string, string> compoundWords)
+    {
+        foreach (var tool in tools)
+        {
+            tool.ToolName = ResolveBaseHeading(tool, headings, compoundWords);
+        }
+
+        return ToolOrderingPolicy.OrderForSingleResource(tools)
+            .Select(tool => CreateSection(tool, tool.ToolName))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<FamilySection> BuildMultiResourceSections(
+        IReadOnlyList<ToolContent> tools,
+        IReadOnlyDictionary<string, string> headings,
+        Dictionary<string, string> compoundWords)
+    {
+        var sections = new List<FamilySection>();
+        var groupOrder = tools
+            .Select(tool => tool.ResourceType ?? string.Empty)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var resourceType in groupOrder)
+        {
+            var resourceTools = tools
+                .Where(tool => string.Equals(tool.ResourceType, resourceType, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            foreach (var tool in ToolOrderingPolicy.OrderForMultiResource(resourceTools))
+            {
+                var heading = ResolveMultiResourceHeading(tool, headings, compoundWords);
+                sections.Add(CreateSection(tool, heading));
+            }
+        }
+
+        return sections;
+    }
+
+    private static FamilySection CreateSection(ToolContent tool, string heading)
+    {
+        var command = DeriveCommand(tool);
+        var sourceContent = EnsureH2Heading(CleanupGenerator.ReplaceH2Heading(tool.Content, heading), heading);
+        return new FamilySection(
+            heading,
+            string.IsNullOrWhiteSpace(command) ? [] : [command],
+            sourceContent);
+    }
+
+    private static string ResolveMultiResourceHeading(
+        ToolContent tool,
+        IReadOnlyDictionary<string, string> headings,
+        Dictionary<string, string> compoundWords)
+    {
+        var command = DeriveCommand(tool);
+        if (!string.IsNullOrWhiteSpace(command))
+        {
+            var overrideHeading = HeadingOverrideProvider.GetOverride(command);
+            if (!string.IsNullOrWhiteSpace(overrideHeading))
+            {
+                return overrideHeading;
+            }
+
+            var action = ToolOrderingPolicy.ExtractActionVerb(command);
+            if (!string.IsNullOrWhiteSpace(tool.ResourceType) && !string.IsNullOrWhiteSpace(action))
+            {
+                return MultiResourceH2Formatter.FormatToolHeading(tool.ResourceType, action);
+            }
+        }
+
+        return ResolveBaseHeading(tool, headings, compoundWords);
+    }
+
+    private static string ResolveBaseHeading(
+        ToolContent tool,
+        IReadOnlyDictionary<string, string> headings,
+        Dictionary<string, string> compoundWords)
+    {
+        var command = DeriveCommand(tool);
+        if (!string.IsNullOrWhiteSpace(command) && headings.TryGetValue(command, out var configuredHeading))
+        {
+            return configuredHeading;
+        }
+
+        if (!string.IsNullOrWhiteSpace(command))
+        {
+            return DeterministicH2HeadingGenerator.GenerateHeading(command, tool.Description, compoundWords);
+        }
+
+        return DeriveHeadingFromFileName(tool.FileName, tool.FamilyName);
+    }
+
+    private static string DeriveCommand(ToolContent tool)
+    {
+        if (!string.IsNullOrWhiteSpace(tool.Command))
+        {
+            return tool.Command;
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(tool.FileName);
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return string.Empty;
+        }
+
+        var normalized = fileName
+            .Replace("azure-", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace('-', ' ')
+            .Trim();
+
+        return normalized;
+    }
+
+    private static string DeriveHeadingFromFileName(string fileName, string familyName)
+    {
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        if (string.IsNullOrWhiteSpace(stem))
+        {
+            return "Tool";
+        }
+
+        var prefixes = new[]
+        {
+            $"{familyName}-",
+            $"azure-{familyName}-",
+            $"ai-{familyName}-"
+        };
+
+        foreach (var prefix in prefixes)
+        {
+            if (stem.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                stem = stem[prefix.Length..];
+                break;
+            }
+        }
+
+        var words = stem
+            .Split('-', StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(word))
+            .ToArray();
+
+        return words.Length == 0 ? "Tool" : string.Join(' ', words);
+    }
+
+    private static string EnsureH2Heading(string content, string heading)
+    {
+        if (content.StartsWith("## ", StringComparison.Ordinal))
+        {
+            return content;
+        }
+
+        return $"## {heading}{Environment.NewLine}{Environment.NewLine}{content.TrimStart()}";
+    }
+
+    private static async Task<IReadOnlyDictionary<string, string>> LoadHeadingsAsync(
+        string? h2HeadingsDirectory,
+        string familyName,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(h2HeadingsDirectory) || !Directory.Exists(h2HeadingsDirectory))
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var path = Path.Combine(h2HeadingsDirectory, $"{familyName}.json");
+        if (!File.Exists(path))
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        await using var stream = File.OpenRead(path);
+        var headings = await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(stream, cancellationToken: ct);
+        return headings ?? new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
Second of three P6 reducer PRs. Extracts deterministic document-structure assembly logic from ToolFamilyCleanupStep into a dedicated FamilyStructureBuilder that produces a typed FamilyStructureContext.

## Changes
- **FamilyStructureContext.cs** — typed records (FamilyStructureContext, FamilySection)
- **FamilyStructureBuilder.cs** — reads tool files + h2-headings JSON, builds canonical section order
- **CleanupGenerator** — added typed-context processing method
- **ToolFamilyCleanupStep** — activated reducer path for step 4, FamilyCleanupOverrideKey for test injection
- **Tests** — FamilyStructureBuilder unit tests + step 4 override tests

## Validation
- Build: 0 errors
- PipelineRunner tests: 491 pass
- FamilyStructureBuilder tests: pass

## PRD Reference
Point 6, PR 2 of 3 (ToolFamilyCleanup stage)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>