### PR TITLE
refactor(p6): extract ArticleOutlineBuilder — typed context for horizontal articles stage

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FailurePathTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/FailurePathTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HorizontalArticleGenerator.Models;
 using PipelineRunner.Cli;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
@@ -445,25 +446,35 @@ public class FailurePathTests
     }
 
     [Fact]
-    public async Task Step6_SubprocessExitCodeNonZero_ReturnsFailureWithProcessDiagnostics()
+    public async Task Step6_InvalidOverrideType_ReturnsFailureWithActionableMessage()
     {
         var testRoot = CreateTestRoot();
         try
         {
-            var runner = new FailingProcessRunner(exitCode: 1, standardError: "Azure OpenAI returned 429 Too Many Requests");
+            var runner = new RecordingProcessRunner();
             var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["eventgrid list"]);
             context.Items["Namespace"] = "eventgrid";
 
             SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "eventgrid list", name = "eventgrid list", description = "List event subscriptions." }
+                    }
+                }));
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] = "invalid";
 
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.False(result.Success);
             Assert.Contains(result.Warnings, w => w.Contains("Horizontal article generation failed", StringComparison.Ordinal));
-            Assert.Contains(result.Warnings, w => w.Contains("exit code 1", StringComparison.Ordinal));
-            Assert.Contains(result.Warnings, w => w.Contains("429 Too Many Requests", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, w => w.Contains(HorizontalArticlesStep.ArticleOutlineOverrideKey, StringComparison.Ordinal));
             Assert.Single(result.ArtifactFailures);
+            Assert.Empty(runner.Invocations);
         }
         finally
         {
@@ -472,7 +483,7 @@ public class FailurePathTests
     }
 
     [Fact]
-    public async Task Step6_SubprocessSucceeds_ErrorArtifactExists_ReturnsFailure()
+    public async Task Step6_OverrideThrows_ReturnsFailure()
     {
         var testRoot = CreateTestRoot();
         try
@@ -482,15 +493,25 @@ public class FailurePathTests
             context.Items["Namespace"] = "servicebus";
 
             SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
-            // Subprocess exit 0 but leaves an error artifact
-            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "error-servicebus.txt"), "AI returned malformed JSON");
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "servicebus list", name = "servicebus list", description = "List namespaces." }
+                    }
+                }));
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((_, _) => throw new InvalidOperationException("override exploded"));
 
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("error artifact", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Warnings, w => w.Contains("override exploded", StringComparison.Ordinal));
             Assert.Single(result.ArtifactFailures);
+            Assert.Empty(runner.Invocations);
         }
         finally
         {
@@ -499,7 +520,7 @@ public class FailurePathTests
     }
 
     [Fact]
-    public async Task Step6_SubprocessSucceeds_NoArticleOutput_ReturnsFailure()
+    public async Task Step6_SuccessfulOverride_RemovesStaleErrorArtifacts()
     {
         var testRoot = CreateTestRoot();
         try
@@ -509,14 +530,28 @@ public class FailurePathTests
             context.Items["Namespace"] = "loadtesting";
 
             SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
-            // Subprocess succeeds but writes no article file
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "loadtesting list", name = "loadtesting list", description = "List load tests." }
+                    }
+                }));
+            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "error-loadtesting.txt"), "old error");
+            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "error-loadtesting-airesponse.txt"), "old ai error");
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((_, _) => Task.FromResult("# Article"));
 
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
-            Assert.False(result.Success);
-            Assert.Contains(result.Warnings, w => w.Contains("Expected horizontal article output", StringComparison.Ordinal));
-            Assert.Single(result.ArtifactFailures);
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("error artifact", StringComparison.OrdinalIgnoreCase));
+            Assert.False(File.Exists(Path.Combine(context.OutputPath, "horizontal-articles", "error-loadtesting.txt")));
+            Assert.False(File.Exists(Path.Combine(context.OutputPath, "horizontal-articles", "error-loadtesting-airesponse.txt")));
+            Assert.Empty(runner.Invocations);
         }
         finally
         {
@@ -534,13 +569,23 @@ public class FailurePathTests
             var context = CreateContext(testRoot, runner, skipValidation: true, toolCommands: ["advisor list"]);
             context.Items["Namespace"] = "advisor";
 
-            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-advisor.md"));
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "advisor list", name = "advisor list", description = "List advisor recommendations." }
+                    }
+                }));
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((_, _) => Task.FromResult("# Advisor article"));
 
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Single(runner.Invocations); // Subprocess was invoked
+            Assert.Empty(runner.Invocations);
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/HorizontalArticlesStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/HorizontalArticlesStepTests.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using HorizontalArticleGenerator.Models;
+using PipelineRunner.Cli;
+using PipelineRunner.Context;
+using PipelineRunner.Services;
+using PipelineRunner.Steps;
+using PipelineRunner.Tests.Fixtures;
+using ToolGeneration_Improved.Models;
+using ToolGeneration_Improved.Services;
+using Xunit;
+
+namespace PipelineRunner.Tests.Unit;
+
+public sealed class HorizontalArticlesStepTests
+{
+    [Fact]
+    public async Task Step6_ReducerPath_UsesArticleOutlineOverride_AndSkipsSubprocess()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var processRunner = new RecordingProcessRunner();
+            var context = CreateContext(testRoot, processRunner, skipValidation: false, toolCommands: ["compute vm create", "compute vm list"]);
+            context.Items["Namespace"] = "compute";
+
+            Directory.CreateDirectory(Path.Combine(context.OutputPath, "cli"));
+            await File.WriteAllTextAsync(
+                Path.Combine(context.OutputPath, "cli", "cli-version.json"),
+                "{\"version\":\"1.2.3\"}");
+            await File.WriteAllTextAsync(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new object[]
+                    {
+                        new
+                        {
+                            command = "compute vm create",
+                            name = "compute vm create",
+                            description = "Create virtual machines.",
+                            option = new object[] { new { name = "name" } }
+                        },
+                        new
+                        {
+                            command = "compute vm list",
+                            name = "compute vm list",
+                            description = "List virtual machines.",
+                            option = Array.Empty<object>()
+                        }
+                    }
+                }));
+
+            ArticleOutlineContext? capturedOutline = null;
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((outline, _) =>
+                {
+                    capturedOutline = outline;
+                    return Task.FromResult("# Override article");
+                });
+
+            var step = new HorizontalArticlesStep();
+
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success, string.Join(" | ", result.Warnings));
+            Assert.Empty(processRunner.Invocations);
+            Assert.NotNull(capturedOutline);
+            Assert.Equal("compute", capturedOutline!.ServiceIdentifier);
+            Assert.NotEmpty(capturedOutline.Sections);
+            Assert.Equal(
+                "# Override article",
+                await File.ReadAllTextAsync(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-compute.md")));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static string CreateTestRoot()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), "horizontal-articles-step-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testRoot);
+        return testRoot;
+    }
+
+    private static void DeleteTestRoot(string testRoot)
+    {
+        if (Directory.Exists(testRoot))
+        {
+            Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    private static PipelineContext CreateContext(string testRoot, IProcessRunner processRunner, bool skipValidation, IReadOnlyList<string> toolCommands)
+    {
+        var mcpToolsRoot = Path.Combine(testRoot, "mcp-tools");
+        var outputPath = Path.Combine(testRoot, "generated-compute");
+        Directory.CreateDirectory(mcpToolsRoot);
+        Directory.CreateDirectory(outputPath);
+
+        var context = new PipelineContext
+        {
+            Request = new PipelineRequest("compute", [1], outputPath, SkipBuild: true, SkipValidation: skipValidation, DryRun: false),
+            RepoRoot = testRoot,
+            McpToolsRoot = mcpToolsRoot,
+            OutputPath = outputPath,
+            ProcessRunner = processRunner,
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new FilteredCliWriter(new WorkspaceManager()),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            CliOutput = CreateSnapshot(toolCommands),
+            SelectedNamespaces = ["compute"],
+        };
+
+        context.Items[ToolGenerationStep.ToolImproverOverrideKey] =
+            static (ToolGenerationContext toolContext, CancellationToken _) => Task.FromResult(new ImprovedToolData
+            {
+                FileName = toolContext.ToolName,
+                OriginalContent = toolContext.ComposedContent,
+                ImprovedContent = toolContext.ComposedContent,
+                WasImproved = false
+            });
+
+        return context;
+    }
+
+    private static CliMetadataSnapshot CreateSnapshot(IReadOnlyList<string> toolCommands)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            version = "1.2.3",
+            results = toolCommands.Select(command => new
+            {
+                command,
+                name = command,
+                description = $"Description for {command}",
+            }),
+        });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement.Clone();
+        var tools = root.GetProperty("results")
+            .EnumerateArray()
+            .Select(tool => new CliTool(
+                tool.GetProperty("command").GetString() ?? string.Empty,
+                tool.GetProperty("name").GetString() ?? string.Empty,
+                tool.GetProperty("description").GetString(),
+                tool.Clone()))
+            .ToArray();
+
+        return new CliMetadataSnapshot(Path.Combine(Path.GetTempPath(), $"cli-output-{Guid.NewGuid():N}.json"), root, tools);
+    }
+}

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HorizontalArticleGenerator.Models;
 using PipelineRunner.Cli;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
@@ -570,7 +571,7 @@ public class NamespaceStepTests
     }
 
     [Fact]
-    public async Task Step6_HorizontalArticles_UsesExpectedGeneratorArguments()
+    public async Task Step6_HorizontalArticles_UsesReducerOverride_AndWritesOutput()
     {
         var testRoot = CreateTestRoot();
         try
@@ -580,19 +581,35 @@ public class NamespaceStepTests
             context.Items["Namespace"] = "compute";
 
             SeedFile(Path.Combine(context.OutputPath, "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
-            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-compute.md"));
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "compute list", name = "compute list", description = "List compute resources." },
+                        new { command = "compute show", name = "compute show", description = "Show compute resources." }
+                    }
+                }));
+
+            ArticleOutlineContext? capturedOutline = null;
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((outline, _) =>
+                {
+                    capturedOutline = outline;
+                    return Task.FromResult("# Horizontal article");
+                });
 
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Single(runner.Invocations);
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument.EndsWith("DocGeneration.Steps.HorizontalArticles.csproj", StringComparison.Ordinal));
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--single-service");
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "compute");
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--output-path");
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == context.OutputPath);
-            Assert.Contains(runner.Invocations[0].Arguments, argument => argument == "--transform");
+            Assert.Empty(runner.Invocations);
+            Assert.NotNull(capturedOutline);
+            Assert.Equal("compute", capturedOutline!.ServiceIdentifier);
+            Assert.Equal(
+                "# Horizontal article",
+                File.ReadAllText(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-compute.md")));
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/UpstreamArtifactResolutionStepTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HorizontalArticleGenerator.Models;
 using PipelineRunner.Cli;
 using PipelineRunner.Context;
 using PipelineRunner.Services;
@@ -133,7 +134,15 @@ public sealed class UpstreamArtifactResolutionStepTests
             context.Items["Namespace"] = "advisor";
 
             SeedFile(Path.Combine(context.OutputPath, "custom-bootstrap", "cli", "cli-version.json"), "{\"version\":\"1.2.3\"}");
-            SeedFile(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-advisor.md"), "article");
+            SeedFile(
+                Path.Combine(context.OutputPath, "cli", "cli-output.json"),
+                JsonSerializer.Serialize(new
+                {
+                    results = new[]
+                    {
+                        new { command = "advisor list", name = "advisor list", description = "List advisor recommendations." }
+                    }
+                }));
 
             WriteEnvelope(
                 context.OutputPath,
@@ -142,11 +151,15 @@ public sealed class UpstreamArtifactResolutionStepTests
                 "advisor",
                 ["custom-bootstrap/cli/cli-version.json"]);
 
+            context.Items[HorizontalArticlesStep.ArticleOutlineOverrideKey] =
+                (Func<ArticleOutlineContext, CancellationToken, Task<string>>)((_, _) => Task.FromResult("article"));
+
             var step = new HorizontalArticlesStep();
             var result = await step.ExecuteAsync(context, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Single(runner.Invocations);
+            Assert.Empty(runner.Invocations);
+            Assert.Equal("article", File.ReadAllText(Path.Combine(context.OutputPath, "horizontal-articles", "horizontal-article-advisor.md")));
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.GenerativeAI\DocGeneration.Core.GenerativeAI.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Tracing\DocGeneration.Core.Tracing.csproj" />
+    <ProjectReference Include="..\DocGeneration.Steps.HorizontalArticles\DocGeneration.Steps.HorizontalArticles.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.ToolFamilyCleanup\DocGeneration.Steps.ToolFamilyCleanup.csproj" />
     <ProjectReference Include="..\DocGeneration.Steps.ToolGeneration.Improvements\DocGeneration.Steps.ToolGeneration.Improvements.csproj" />
   </ItemGroup>

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
@@ -1,15 +1,37 @@
+using Azure.Mcp.TextTransformation.Services;
+using Azure.Mcp.TextTransformation.Models;
+using GenerativeAI;
+using HorizontalArticleGenerator.Builders;
+using HorizontalArticleGenerator.Models;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using HorizontalArticleGeneratorClass = HorizontalArticleGenerator.Generators.HorizontalArticleGenerator;
 
 namespace PipelineRunner.Steps;
 
 public sealed class HorizontalArticlesStep : NamespaceStepBase
 {
+    public const string ArticleOutlineOverrideKey = "HorizontalArticlesStep.ArticleOutlineOverride";
+
     private static readonly ReducerRegistry Reducers = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
+
+    static HorizontalArticlesStep()
+    {
+        Reducers.Register(6, static async (ctx, ct) =>
+        {
+            if (ctx is not ArticleOutlineReducerInput input)
+            {
+                throw new InvalidOperationException($"Reducer input for step 6 must be {nameof(ArticleOutlineReducerInput)}.");
+            }
+
+            var builder = new ArticleOutlineBuilder();
+            return await builder.BuildAsync(input.OutputPath, input.ServiceNamespace, ct);
+        });
+    }
 
     public HorizontalArticlesStep()
         : base(
@@ -27,11 +49,8 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
     public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
     {
         var (currentNamespace, cliOutput, _, matchingTools) = ResolveTarget(context);
-        // P8: ReducerRegistry scaffold — when a reducer is registered, use it exclusively
-        if (Reducers.HasReducer(Id))
-        {
-            throw new NotImplementedException($"Reducer registered for step {Id} but execution path not yet implemented.");
-        }
+        var useReducerPath = Reducers.HasReducer(Id);
+        var hasOverride = context.Items.ContainsKey(ArticleOutlineOverrideKey);
 
         _ = await CreateFilteredCliFileAsync(context, cliOutput, matchingTools, "pipeline-runner-step6", cancellationToken);
 
@@ -49,6 +68,48 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
             warnings.Add($"CLI version file not found at '{cliVersionPath}'.");
             artifactFailures.Add(CreateHorizontalFailure(context, currentNamespace, warnings));
             return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+        }
+
+        if (useReducerPath)
+        {
+            try
+            {
+                var reducer = Reducers.GetReducer(6);
+                if (reducer is null)
+                {
+                    throw new InvalidOperationException("Reducer path was selected for step 6, but no reducer is registered.");
+                }
+
+                var outline = (ArticleOutlineContext)await reducer(
+                    new ArticleOutlineReducerInput(context.OutputPath, currentNamespace),
+                    cancellationToken);
+                var renderArticleAsync = await ResolveArticleRendererAsync(context, cancellationToken);
+                var articleContent = await renderArticleAsync(outline, cancellationToken);
+                var reducerArticleDirectory = Path.Combine(context.OutputPath, "horizontal-articles");
+                Directory.CreateDirectory(reducerArticleDirectory);
+                File.WriteAllText(
+                    Path.Combine(reducerArticleDirectory, $"horizontal-article-{currentNamespace}.md"),
+                    articleContent);
+                RemoveStaleFile(Path.Combine(reducerArticleDirectory, $"error-{currentNamespace}.txt"));
+                RemoveStaleFile(Path.Combine(reducerArticleDirectory, $"error-{currentNamespace}-airesponse.txt"));
+
+                return BuildResult(context, processResults, true, warnings, artifactFailures: artifactFailures);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (hasOverride)
+                {
+                    warnings.Add($"Horizontal article generation failed: {ex.Message}");
+                    artifactFailures.Add(CreateHorizontalFailure(context, currentNamespace, warnings));
+                    return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+                }
+
+                Console.WriteLine($"Reducer path failed for namespace '{currentNamespace}', falling back to subprocess: {ex.Message}");
+            }
         }
 
         var processResult = await context.ProcessRunner.RunDotNetProjectAsync(
@@ -91,6 +152,39 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
         return BuildResult(context, processResults, success, warnings, artifactFailures: artifactFailures);
     }
 
+    private static async Task<Func<ArticleOutlineContext, CancellationToken, Task<string>>> ResolveArticleRendererAsync(
+        PipelineContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (context.Items.TryGetValue(ArticleOutlineOverrideKey, out var overrideValue))
+        {
+            if (overrideValue is Func<ArticleOutlineContext, CancellationToken, Task<string>> articleOverride)
+            {
+                return articleOverride;
+            }
+
+            throw new InvalidOperationException(
+                $"Context item '{ArticleOutlineOverrideKey}' must be {typeof(Func<ArticleOutlineContext, CancellationToken, Task<string>>).FullName}.");
+        }
+
+        var transformConfigPath = Path.Combine(context.McpToolsRoot, "data", "transformation-config.json");
+        TransformationEngine? transformationEngine = null;
+        if (File.Exists(transformConfigPath))
+        {
+            var loader = new ConfigLoader(transformConfigPath);
+            transformationEngine = new TransformationEngine(await loader.LoadAsync());
+        }
+
+        var generator = new HorizontalArticleGeneratorClass(
+            GenerativeAIOptions.LoadFromEnvironmentOrDotEnv(),
+            useTextTransformation: transformationEngine is not null,
+            generateAllArticles: false,
+            transformationEngine,
+            outputBasePath: context.OutputPath);
+        return generator.GenerateArticleMarkdownAsync;
+    }
+
     private static ArtifactFailure CreateHorizontalFailure(PipelineContext context, string currentNamespace, IEnumerable<string> details)
     {
         var articleDirectory = Path.Combine(context.OutputPath, "horizontal-articles");
@@ -121,4 +215,14 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
 
         return fallbackPath;
     }
+
+    private static void RemoveStaleFile(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    private sealed record ArticleOutlineReducerInput(string OutputPath, string ServiceNamespace);
 }

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/ArticleOutlineBuilderTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/ArticleOutlineBuilderTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using CSharpGenerator.Models;
+using HorizontalArticleGenerator.Builders;
+using HorizontalArticleGenerator.Models;
+using Xunit;
+
+namespace DocGeneration.Steps.HorizontalArticles.Tests;
+
+public sealed class ArticleOutlineBuilderTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public ArticleOutlineBuilderTests()
+    {
+        _testRoot = Path.Combine(AppContext.BaseDirectory, "article-outline-builder-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExtractsStandardSectionsForTargetNamespace()
+    {
+        await WriteCliOutputAsync(new CliOutput
+        {
+            Results =
+            [
+                new Tool
+                {
+                    Command = "compute vm create",
+                    Name = "compute vm create",
+                    Description = "Create virtual machines.",
+                    Option =
+                    [
+                        new Option { Name = "name" },
+                        new Option { Name = "subscription-id" }
+                    ],
+                    Metadata = new ToolMetadata
+                    {
+                        Destructive = new MetadataValue { Value = true },
+                        ReadOnly = new MetadataValue { Value = false },
+                        Secret = new MetadataValue { Value = false }
+                    }
+                },
+                new Tool
+                {
+                    Command = "compute vm list",
+                    Name = "compute vm list",
+                    Description = "List virtual machines.",
+                    Option =
+                    [
+                        new Option { Name = "resource-group" }
+                    ],
+                    Metadata = new ToolMetadata
+                    {
+                        Destructive = new MetadataValue { Value = false },
+                        ReadOnly = new MetadataValue { Value = true },
+                        Secret = new MetadataValue { Value = false }
+                    }
+                },
+                new Tool
+                {
+                    Command = "storage account list",
+                    Name = "storage account list",
+                    Description = "List storage accounts."
+                }
+            ]
+        });
+
+        var builder = new ArticleOutlineBuilder();
+
+        var result = await builder.BuildAsync(_testRoot, "compute", CancellationToken.None);
+
+        Assert.Equal("compute", result.ServiceIdentifier);
+        Assert.Equal(
+            ["Introduction", "Prerequisites", "Tool overview", "Common scenarios", "Best practices"],
+            result.Sections.Select(section => section.Heading).ToArray());
+        Assert.Equal(
+            ["overview", "checklist", "reference", "scenario-list", "guidance"],
+            result.Sections.Select(section => section.ContentType).ToArray());
+    }
+
+    [Fact]
+    public async Task BuildAsync_MissingCliOutput_ReturnsStandardOutlineWithoutThrowing()
+    {
+        var builder = new ArticleOutlineBuilder();
+
+        var result = await builder.BuildAsync(_testRoot, "storage", CancellationToken.None);
+
+        Assert.Equal("storage", result.ServiceIdentifier);
+        Assert.Equal(5, result.Sections.Count);
+        Assert.Empty(result.Sections.Single(section => section.Heading == "Tool overview").EvidenceItems);
+    }
+
+    [Fact]
+    public async Task BuildAsync_SchemaVersion_IsAlwaysOnePointZero()
+    {
+        await WriteCliOutputAsync(new CliOutput
+        {
+            Results =
+            [
+                new Tool
+                {
+                    Command = "search index list",
+                    Name = "search index list",
+                    Description = "List indexes."
+                }
+            ]
+        });
+
+        var builder = new ArticleOutlineBuilder();
+
+        var result = await builder.BuildAsync(_testRoot, "search", CancellationToken.None);
+
+        Assert.Equal("1.0", result.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task BuildAsync_PopulatesExpectedEvidenceItemsPerSection()
+    {
+        await WriteCliOutputAsync(new CliOutput
+        {
+            Results =
+            [
+                new Tool
+                {
+                    Command = "compute vm create",
+                    Name = "compute vm create",
+                    Description = "Create virtual machines.",
+                    Option =
+                    [
+                        new Option { Name = "name" },
+                        new Option { Name = "auth-method" }
+                    ],
+                    Metadata = new ToolMetadata
+                    {
+                        Destructive = new MetadataValue { Value = true },
+                        ReadOnly = new MetadataValue { Value = false },
+                        Secret = new MetadataValue { Value = true }
+                    }
+                },
+                new Tool
+                {
+                    Command = "compute vm list",
+                    Name = "compute vm list",
+                    Description = "List virtual machines.",
+                    Metadata = new ToolMetadata
+                    {
+                        Destructive = new MetadataValue { Value = false },
+                        ReadOnly = new MetadataValue { Value = true },
+                        Secret = new MetadataValue { Value = false }
+                    }
+                }
+            ]
+        });
+
+        var builder = new ArticleOutlineBuilder();
+
+        var result = await builder.BuildAsync(_testRoot, "compute", CancellationToken.None);
+        var introduction = result.Sections.Single(section => section.Heading == "Introduction");
+        var prerequisites = result.Sections.Single(section => section.Heading == "Prerequisites");
+        var toolOverview = result.Sections.Single(section => section.Heading == "Tool overview");
+        var scenarios = result.Sections.Single(section => section.Heading == "Common scenarios");
+        var bestPractices = result.Sections.Single(section => section.Heading == "Best practices");
+
+        Assert.Contains("xref:../tool-family/azure-compute.md", introduction.EvidenceItems);
+        Assert.Contains("capability:management", introduction.EvidenceItems);
+        Assert.Contains("capability:data", introduction.EvidenceItems);
+
+        Assert.Contains("capability:secret", prerequisites.EvidenceItems);
+        Assert.Contains("xref:../parameters/compute-vm-create-parameters.md", prerequisites.EvidenceItems);
+
+        Assert.Equal(2, toolOverview.EvidenceItems.Count);
+        using var createTool = JsonDocument.Parse(toolOverview.EvidenceItems[0]);
+        Assert.Equal("tool", createTool.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("compute vm create", createTool.RootElement.GetProperty("command").GetString());
+        Assert.Equal(1, createTool.RootElement.GetProperty("parameterCount").GetInt32());
+        Assert.Equal("management", createTool.RootElement.GetProperty("plane").GetString());
+
+        Assert.Contains("scenario-tool:compute vm create", scenarios.EvidenceItems);
+        Assert.Contains("scenario-tool:compute vm list", scenarios.EvidenceItems);
+
+        Assert.Contains("capability:destructive", bestPractices.EvidenceItems);
+        Assert.Contains("capability:secret", bestPractices.EvidenceItems);
+    }
+
+    private async Task WriteCliOutputAsync(CliOutput cliOutput)
+    {
+        var cliDirectory = Path.Combine(_testRoot, "cli");
+        Directory.CreateDirectory(cliDirectory);
+        await File.WriteAllTextAsync(Path.Combine(cliDirectory, "cli-output.json"), JsonSerializer.Serialize(cliOutput));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Builders/ArticleOutlineBuilder.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Builders/ArticleOutlineBuilder.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text.Json;
+using CSharpGenerator.Models;
+using HorizontalArticleGenerator.Generators;
+using HorizontalArticleGenerator.Models;
+using Shared;
+
+namespace HorizontalArticleGenerator.Builders;
+
+/// <summary>
+/// Deterministically assembles the minimal evidence pack used to prompt horizontal article generation.
+/// </summary>
+public sealed class ArticleOutlineBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly HashSet<string> CommonParameters = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "subscription-id",
+        "resource-group",
+        "output",
+        "verbose",
+        "help",
+        "debug",
+        "only-show-errors",
+        "tenant",
+        "auth-method",
+        "retry-delay",
+        "retry-max-delay",
+        "retry-max-retries",
+        "retry-mode",
+        "retry-network-timeout"
+    };
+
+    public async Task<ArticleOutlineContext> BuildAsync(string outputPath, string serviceNamespace, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceNamespace);
+        ct.ThrowIfCancellationRequested();
+
+        var normalizedNamespace = NormalizeNamespace(serviceNamespace);
+        var brandMappings = await DataFileLoader.LoadBrandMappingsAsync();
+        var brandMapping = ResolveBrandMapping(brandMappings, normalizedNamespace);
+        var toolFamilyFileName = ResolveToolFamilyFileName(brandMapping, normalizedNamespace);
+        var tools = await LoadToolsAsync(outputPath, normalizedNamespace, ct);
+        var sections = BuildSections(toolFamilyFileName, tools);
+
+        return new ArticleOutlineContext(
+            ResolveArticleTitle(brandMapping, normalizedNamespace),
+            sections,
+            normalizedNamespace);
+    }
+
+    private static async Task<IReadOnlyList<OutlineTool>> LoadToolsAsync(string outputPath, string serviceNamespace, CancellationToken ct)
+    {
+        var cliOutputPath = Path.Combine(outputPath, "cli", "cli-output.json");
+        if (!File.Exists(cliOutputPath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(cliOutputPath);
+        var cliOutput = await JsonSerializer.DeserializeAsync<CliOutput>(stream, JsonOptions, ct);
+        if (cliOutput?.Results is null)
+        {
+            return [];
+        }
+
+        var tools = cliOutput.Results
+            .Where(tool => IsMatchingNamespace(tool, serviceNamespace))
+            .Select(CreateOutlineTool)
+            .ToList();
+
+        if (tools.Count == 0)
+        {
+            return [];
+        }
+
+        var orderedToolSummaries = DeterministicHorizontalHelpers.OrderToolsByPlane(
+            tools.Select(tool => tool.ToSummary()).ToList());
+        var orderLookup = orderedToolSummaries
+            .Select((tool, index) => new { tool.Command, index })
+            .ToDictionary(item => item.Command, item => item.index, StringComparer.OrdinalIgnoreCase);
+
+        return tools
+            .OrderBy(tool => orderLookup.GetValueOrDefault(tool.Command, int.MaxValue))
+            .ThenBy(tool => tool.Command, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ArticleOutlineSection> BuildSections(string toolFamilyFileName, IReadOnlyList<OutlineTool> tools)
+    {
+        var toolFamilyReference = $"xref:../tool-family/{toolFamilyFileName}.md";
+        var introductionEvidence = new List<string> { toolFamilyReference };
+        foreach (var plane in tools.Select(tool => tool.Plane).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            introductionEvidence.Add($"capability:{plane}");
+        }
+
+        var prerequisitesEvidence = new List<string> { toolFamilyReference };
+        foreach (var parameterLink in tools
+                     .Where(tool => tool.Secret || tool.ParameterCount > 0)
+                     .Select(tool => $"xref:{tool.MoreInfoLink}")
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            prerequisitesEvidence.Add(parameterLink);
+        }
+
+        if (tools.Any(tool => tool.Secret))
+        {
+            prerequisitesEvidence.Add("capability:secret");
+        }
+
+        if (tools.Any(tool => tool.LocalRequired))
+        {
+            prerequisitesEvidence.Add("capability:local-required");
+        }
+
+        var toolOverviewEvidence = tools
+            .Select(tool => JsonSerializer.Serialize(new
+            {
+                kind = "tool",
+                command = tool.Command,
+                description = tool.Description,
+                parameterCount = tool.ParameterCount,
+                moreInfoLink = tool.MoreInfoLink,
+                destructive = tool.Destructive,
+                readOnly = tool.ReadOnly,
+                secret = tool.Secret,
+                plane = tool.Plane
+            }))
+            .ToArray();
+
+        var scenarioEvidence = tools
+            .Take(4)
+            .SelectMany(tool => new[]
+            {
+                $"scenario-tool:{tool.Command}",
+                $"capability:{tool.Plane}"
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var bestPracticesEvidence = new List<string> { toolFamilyReference };
+        if (tools.Any(tool => tool.Destructive))
+        {
+            bestPracticesEvidence.Add("capability:destructive");
+        }
+
+        if (tools.Any(tool => tool.Secret))
+        {
+            bestPracticesEvidence.Add("capability:secret");
+        }
+
+        if (tools.Any(tool => tool.ReadOnly))
+        {
+            bestPracticesEvidence.Add("capability:read-only");
+        }
+
+        return
+        [
+            new ArticleOutlineSection("Introduction", "overview", introductionEvidence),
+            new ArticleOutlineSection("Prerequisites", "checklist", prerequisitesEvidence),
+            new ArticleOutlineSection("Tool overview", "reference", toolOverviewEvidence),
+            new ArticleOutlineSection("Common scenarios", "scenario-list", scenarioEvidence),
+            new ArticleOutlineSection("Best practices", "guidance", bestPracticesEvidence)
+        ];
+    }
+
+    private static OutlineTool CreateOutlineTool(Tool tool)
+    {
+        var command = (tool.Command ?? tool.Name ?? string.Empty).Trim();
+        var description = (tool.Description ?? string.Empty).Trim();
+        var parameterCount = tool.Option?.Count(option => !CommonParameters.Contains(option.Name ?? string.Empty)) ?? 0;
+
+        return new OutlineTool(
+            command,
+            description,
+            parameterCount,
+            $"../parameters/{command.Replace(' ', '-')}-parameters.md",
+            tool.Metadata?.Destructive?.Value ?? false,
+            tool.Metadata?.ReadOnly?.Value ?? false,
+            tool.Metadata?.Secret?.Value ?? false,
+            tool.Metadata?.LocalRequired?.Value ?? false,
+            ClassifyPlane(command, description, tool.Metadata));
+    }
+
+    private static string ClassifyPlane(string command, string description, ToolMetadata? metadata)
+    {
+        var summary = new HorizontalToolSummary
+        {
+            Command = command,
+            Description = description,
+            Metadata = new Dictionary<string, MetadataValue>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["destructive"] = new MetadataValue { Value = metadata?.Destructive?.Value ?? false },
+                ["readOnly"] = new MetadataValue { Value = metadata?.ReadOnly?.Value ?? false },
+                ["secret"] = new MetadataValue { Value = metadata?.Secret?.Value ?? false }
+            }
+        };
+
+        return DeterministicHorizontalHelpers.ClassifyToolPlane(summary);
+    }
+
+    private static bool IsMatchingNamespace(Tool tool, string serviceNamespace)
+    {
+        var command = NormalizeNamespace(tool.Command ?? tool.Name ?? string.Empty);
+        return string.Equals(command, serviceNamespace, StringComparison.OrdinalIgnoreCase)
+            || command.StartsWith($"{serviceNamespace} ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static BrandMapping? ResolveBrandMapping(IReadOnlyDictionary<string, BrandMapping> brandMappings, string serviceNamespace)
+    {
+        if (brandMappings.TryGetValue(serviceNamespace, out var exact))
+        {
+            return exact;
+        }
+
+        var underscoredNamespace = serviceNamespace.Replace(' ', '_');
+        return brandMappings.TryGetValue(underscoredNamespace, out var underscored) ? underscored : null;
+    }
+
+    private static string ResolveArticleTitle(BrandMapping? brandMapping, string serviceNamespace)
+    {
+        if (!string.IsNullOrWhiteSpace(brandMapping?.BrandName))
+        {
+            return brandMapping.BrandName!;
+        }
+
+        var words = serviceNamespace
+            .Replace('_', ' ')
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static word => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(word));
+        return string.Join(' ', words);
+    }
+
+    private static string ResolveToolFamilyFileName(BrandMapping? brandMapping, string serviceNamespace)
+    {
+        if (!string.IsNullOrWhiteSpace(brandMapping?.FileName))
+        {
+            return brandMapping.FileName!;
+        }
+
+        return serviceNamespace.Replace(' ', '-').ToLowerInvariant();
+    }
+
+    private static string NormalizeNamespace(string value)
+        => value.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .Replace('_', ' ')
+            .ToLowerInvariant();
+
+    private sealed record OutlineTool(
+        string Command,
+        string Description,
+        int ParameterCount,
+        string MoreInfoLink,
+        bool Destructive,
+        bool ReadOnly,
+        bool Secret,
+        bool LocalRequired,
+        string Plane)
+    {
+        public HorizontalToolSummary ToSummary() =>
+            new()
+            {
+                Command = Command,
+                Description = Description,
+                ParameterCount = ParameterCount,
+                MoreInfoLink = MoreInfoLink,
+                Metadata = new Dictionary<string, MetadataValue>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["destructive"] = new MetadataValue { Value = Destructive },
+                    ["readOnly"] = new MetadataValue { Value = ReadOnly },
+                    ["secret"] = new MetadataValue { Value = Secret }
+                }
+            };
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using GenerativeAI;
 using CSharpGenerator.Models;
+using HorizontalArticleGenerator.Builders;
 using HorizontalArticleGenerator.Models;
 using TemplateEngine;
 using Shared;
@@ -191,30 +192,43 @@ public class HorizontalArticleGenerator
     /// </summary>
     public async Task GenerateSingleServiceArticle(string serviceArea)
     {
-        // Phase 1: Extract static data
-        var staticDataList = await ExtractStaticData();
-        
-        // Find the requested service
-        var targetService = staticDataList.FirstOrDefault(s => 
-            s.ServiceIdentifier.Equals(serviceArea, StringComparison.OrdinalIgnoreCase));
-        
-        if (targetService == null)
+        var outlineBuilder = new ArticleOutlineBuilder();
+        var outline = await outlineBuilder.BuildAsync(_outputBasePath, serviceArea, CancellationToken.None);
+        var hasToolEvidence = outline.Sections
+            .FirstOrDefault(section => section.Heading == "Tool overview")?
+            .EvidenceItems
+            .Any() ?? false;
+        if (!hasToolEvidence)
         {
             Console.Error.WriteLine($"✗ Service not found: {serviceArea}");
-            Console.Error.WriteLine($"Available services: {string.Join(", ", staticDataList.Select(s => s.ServiceIdentifier))}");
             return;
         }
-        
-        // Create output directory
+
         Directory.CreateDirectory(_outputDir);
-        
-        // Generate the article
-        bool result = await GenerateSingleArticleAsync(targetService, _outputDir, "[1/1]");
-        
+        bool result = await GenerateSingleArticleAsync(outline, _outputDir, "[1/1]", CancellationToken.None);
+
         if (!result)
         {
             Console.Error.WriteLine($"✗ Single service article generation failed for {serviceArea}");
         }
+    }
+
+    public async Task<string> GenerateArticleMarkdownAsync(ArticleOutlineContext outlineContext, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var staticData = await BuildStaticArticleDataAsync(outlineContext, cancellationToken);
+        var aiResponse = await GenerateAIContent(staticData);
+        var aiData = ParseAIResponse(aiResponse);
+        var processor = new ArticleContentProcessor(_transformationEngine);
+        var validationResult = processor.Process(aiData, staticData.ServiceBrandName, staticData.ServiceIdentifier);
+        if (validationResult.HasCriticalErrors)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, validationResult.CriticalErrors));
+        }
+
+        var templateData = MergeData(staticData, aiData);
+        templateData.Skills = SkillsRelevanceReader.LoadRelevantSkills(_outputBasePath, staticData.ServiceIdentifier);
+        return await RenderArticleAsync(templateData);
     }
 
     /// <summary>
@@ -589,6 +603,14 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
     /// </summary>
     private async Task RenderAndSaveArticle(HorizontalArticleTemplateData templateData)
     {
+        var filename = $"horizontal-article-{templateData.ServiceIdentifier}.md";
+        var outputPath = Path.Combine(_outputDir, filename);
+        var renderedContent = await RenderArticleAsync(templateData);
+        await File.WriteAllTextAsync(outputPath, renderedContent, Encoding.UTF8);
+    }
+
+    private async Task<string> RenderArticleAsync(HorizontalArticleTemplateData templateData)
+    {
         var templatePath = Path.GetFullPath(TEMPLATE_PATH);
         
         // Manually build dictionary with correct field names (including genai- prefix)
@@ -635,14 +657,93 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
             }).ToList();
         }
         
-        var renderedContent = await HandlebarsTemplateEngine.ProcessTemplateAsync(templatePath, data);
-        
-        // Save to file
-        var filename = $"horizontal-article-{templateData.ServiceIdentifier}.md";
-        var outputPath = Path.Combine(_outputDir, filename);
-        
-        await File.WriteAllTextAsync(outputPath, renderedContent, Encoding.UTF8);
+        return await HandlebarsTemplateEngine.ProcessTemplateAsync(templatePath, data);
+    }
+
+    private async Task<bool> GenerateSingleArticleAsync(
+        ArticleOutlineContext outlineContext,
+        string outputDir,
+        string progress,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Console.WriteLine($"{progress} Processing {outlineContext.ArticleTitle}...");
+            var renderedContent = await GenerateArticleMarkdownAsync(outlineContext, cancellationToken);
+            Directory.CreateDirectory(outputDir);
+            await File.WriteAllTextAsync(
+                Path.Combine(outputDir, $"horizontal-article-{outlineContext.ServiceIdentifier}.md"),
+                renderedContent,
+                Encoding.UTF8,
+                cancellationToken);
+            Console.WriteLine($"{progress} ✓ Generated: horizontal-article-{outlineContext.ServiceIdentifier}.md");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"{progress} ✗ Failed for {outlineContext.ArticleTitle}: {ex.Message}");
+            var errorLog = Path.Combine(outputDir, $"error-{outlineContext.ServiceIdentifier}.txt");
+            await File.WriteAllTextAsync(errorLog, $"{ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}", Encoding.UTF8, cancellationToken);
+            Console.WriteLine();
+            return false;
+        }
+    }
+
+    private async Task<StaticArticleData> BuildStaticArticleDataAsync(ArticleOutlineContext outlineContext, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var cliVersion = await CliVersionReader.ReadCliVersionAsync(_outputBasePath);
+        var tools = ExtractToolsFromOutline(outlineContext);
+
+        return new StaticArticleData
+        {
+            ServiceBrandName = outlineContext.ArticleTitle,
+            ServiceIdentifier = outlineContext.ServiceIdentifier,
+            GeneratedAt = DateTime.UtcNow.ToString("o"),
+            Version = cliVersion,
+            ToolsReferenceLink = outlineContext.Sections
+                .SelectMany(section => section.EvidenceItems)
+                .FirstOrDefault(item => item.StartsWith("xref:../tool-family/", StringComparison.OrdinalIgnoreCase))?
+                .Replace("xref:", string.Empty, StringComparison.OrdinalIgnoreCase)
+                ?? $"../tool-family/{outlineContext.ServiceIdentifier}.md",
+            Tools = tools
+        };
+    }
+
+    private static List<HorizontalToolSummary> ExtractToolsFromOutline(ArticleOutlineContext outlineContext)
+    {
+        var toolOverviewSection = outlineContext.Sections.FirstOrDefault(section => section.Heading == "Tool overview");
+        if (toolOverviewSection is null)
+        {
+            return [];
+        }
+
+        var tools = new List<HorizontalToolSummary>();
+        foreach (var evidenceItem in toolOverviewSection.EvidenceItems)
+        {
+            using var document = JsonDocument.Parse(evidenceItem);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("kind", out var kind) || !string.Equals(kind.GetString(), "tool", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            tools.Add(new HorizontalToolSummary
+            {
+                Command = root.GetProperty("command").GetString() ?? string.Empty,
+                Description = root.GetProperty("description").GetString() ?? string.Empty,
+                ParameterCount = root.TryGetProperty("parameterCount", out var parameterCount) ? parameterCount.GetInt32() : 0,
+                MoreInfoLink = root.TryGetProperty("moreInfoLink", out var moreInfoLink) ? moreInfoLink.GetString() ?? string.Empty : string.Empty,
+                Metadata = new Dictionary<string, MetadataValue>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["destructive"] = new MetadataValue { Value = root.TryGetProperty("destructive", out var destructive) && destructive.GetBoolean() },
+                    ["readOnly"] = new MetadataValue { Value = root.TryGetProperty("readOnly", out var readOnly) && readOnly.GetBoolean() },
+                    ["secret"] = new MetadataValue { Value = root.TryGetProperty("secret", out var secret) && secret.GetBoolean() }
+                }
+            });
+        }
+
+        return tools;
     }
 
 }
-

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/ArticleOutlineContext.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/ArticleOutlineContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HorizontalArticleGenerator.Models;
+
+public sealed record ArticleOutlineContext(
+    string ArticleTitle,
+    IReadOnlyList<ArticleOutlineSection> Sections,
+    string ServiceIdentifier,
+    string SchemaVersion = "1.0");
+
+public sealed record ArticleOutlineSection(
+    string Heading,
+    string ContentType,
+    IReadOnlyList<string> EvidenceItems);


### PR DESCRIPTION
## Summary
Extracts the deterministic evidence-pack assembly logic from HorizontalArticlesStep (Step 6) into a typed ArticleOutlineBuilder + ArticleOutlineContext.

## Changes
- **ArticleOutlineContext.cs** — immutable record (ArticleTitle, Sections[], ServiceIdentifier, SchemaVersion)
- **ArticleOutlineBuilder.cs** — deterministic builder: reads CLI output, filters to namespace, produces standard outline sections with evidence items
- **HorizontalArticlesStep.cs** — ReducerRegistry activation (step ID 6), dual-path execution, ArticleOutlineOverrideKey
- **HorizontalArticleGenerator.cs** — new GenerateFromOutlineAsync consuming typed context
- **Tests** — builder unit tests + step integration test

## Part of
Pipeline Manageability PRD — Point 6, PR 3 of 3 (final reducer)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>