### PR TITLE
feat(p10): register pre-AI seam validators for steps 3, 4, and 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **P10: Pre-AI seam validators** — Registered `IPreAiValidator` implementations for pipeline steps 3, 4, and 6 using the `PreAiValidatorRegistry` from P9. Five validators added:
+  - `ToolGenerationContextValidator` — validates `ToolName`, `ComposedContent` non-empty, `SchemaVersion == "1.0"` before step 3 AI calls.
+  - `ToolGenerationBudgetValidator` — enforces 100,000-token input budget (via `ComposedContent.Length / 4`) before step 3 AI calls.
+  - `FamilyStructureContextValidator` — validates `FamilyName`, `Sections.Count >= 1`, all section headings non-empty, `SchemaVersion == "1.0"` before step 4 AI calls.
+  - `ArticleOutlineContextValidator` — validates `ArticleTitle`, `Sections.Count >= 2`, each section has `EvidenceItems.Count >= 1`, `SchemaVersion == "1.0"` before step 6 AI calls.
+  - `ArticleOutlineBudgetValidator` — enforces 100,000-token input budget (via total evidence item length / 4) before step 6 AI calls.
+  - 27 new unit tests covering valid and invalid inputs for all five validators. All 492 `DocGeneration.PipelineRunner.Tests` pass.
+
 ### Changed
 
 - **Completed npm-to-dotnet migration** — Removed all Node.js scripts from `mcp-cli-metadata/`. CLI metadata extraction now uses `mcp-tools/McpCliMetadata/` exclusively. Updated CI workflows, preflight.ps1, and documentation. Closes #627.

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/HorizontalArticlesStep.cs
@@ -3,11 +3,13 @@ using Azure.Mcp.TextTransformation.Models;
 using GenerativeAI;
 using HorizontalArticleGenerator.Builders;
 using HorizontalArticleGenerator.Models;
+using HorizontalArticleGenerator.Validation;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using Shared.Validation;
 using HorizontalArticleGeneratorClass = HorizontalArticleGenerator.Generators.HorizontalArticleGenerator;
 
 namespace PipelineRunner.Steps;
@@ -15,8 +17,10 @@ namespace PipelineRunner.Steps;
 public sealed class HorizontalArticlesStep : NamespaceStepBase
 {
     public const string ArticleOutlineOverrideKey = "HorizontalArticlesStep.ArticleOutlineOverride";
+    private const string HorizontalArticlesStageName = "horizontal-articles";
 
     private static readonly ReducerRegistry Reducers = new();
+    private static readonly PreAiValidatorRegistry ValidatorRegistry = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
 
     static HorizontalArticlesStep()
@@ -31,6 +35,9 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
             var builder = new ArticleOutlineBuilder();
             return await builder.BuildAsync(input.OutputPath, input.ServiceNamespace, ct);
         });
+
+        ValidatorRegistry.Register(HorizontalArticlesStageName, new ArticleOutlineContextValidator());
+        ValidatorRegistry.Register(HorizontalArticlesStageName, new ArticleOutlineBudgetValidator());
     }
 
     public HorizontalArticlesStep()
@@ -83,6 +90,22 @@ public sealed class HorizontalArticlesStep : NamespaceStepBase
                 var outline = (ArticleOutlineContext)await reducer(
                     new ArticleOutlineReducerInput(context.OutputPath, currentNamespace),
                     cancellationToken);
+
+                var validationResult = await ValidatorRegistry.ValidateAsync(HorizontalArticlesStageName, outline, cancellationToken);
+                if (!validationResult.IsValid)
+                {
+                    var errorMessages = validationResult.Errors.Select(static e => e.Message).ToArray();
+                    warnings.AddRange(errorMessages);
+                    artifactFailures.Add(CreateHorizontalFailure(context, currentNamespace, warnings));
+                    return BuildResult(
+                        context,
+                        processResults,
+                        false,
+                        warnings,
+                        [new ValidatorResult("pre-ai-validation", false, errorMessages)],
+                        artifactFailures);
+                }
+
                 var renderArticleAsync = await ResolveArticleRendererAsync(context, cancellationToken);
                 var articleContent = await renderArticleAsync(outline, cancellationToken);
                 var reducerArticleDirectory = Path.Combine(context.OutputPath, "horizontal-articles");

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs
@@ -4,16 +4,20 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using Shared.Validation;
 using ToolFamilyCleanup.Models;
 using ToolFamilyCleanup.Services;
+using ToolFamilyCleanup.Validation;
 
 namespace PipelineRunner.Steps;
 
 public sealed class ToolFamilyCleanupStep : NamespaceStepBase
 {
     public const string FamilyCleanupOverrideKey = "ToolFamilyCleanupStep.FamilyCleanupOverride";
+    private const string ToolFamilyCleanupStageName = "tool-family-cleanup";
 
     private static readonly ReducerRegistry Reducers = new();
+    private static readonly PreAiValidatorRegistry ValidatorRegistry = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
 
     static ToolFamilyCleanupStep()
@@ -28,6 +32,8 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             var builder = new FamilyStructureBuilder();
             return await builder.BuildAsync(input.ToolsDirectory, input.FamilyName, input.H2HeadingsDirectory, ct);
         });
+
+        ValidatorRegistry.Register(ToolFamilyCleanupStageName, new FamilyStructureContextValidator());
     }
 
     public ToolFamilyCleanupStep()
@@ -141,7 +147,7 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
         {
             try
             {
-                var artifacts = await GenerateFamilyWithReducerAsync(
+                var (artifacts, preAiErrors) = await GenerateFamilyWithReducerAsync(
                     context,
                     toolsInputDirectory,
                     familyName,
@@ -151,7 +157,21 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
                     warnings,
                     cancellationToken);
 
-                WriteFamilyArtifacts(context.OutputPath, outputFileName, artifacts);
+                if (preAiErrors.Count > 0)
+                {
+                    var errorMessages = preAiErrors.Select(static e => e.Message).ToArray();
+                    warnings.AddRange(errorMessages);
+                    artifactFailures.Add(CreateFamilyFailure(context, familyName, outputFileName, warnings));
+                    return BuildResult(
+                        context,
+                        processResults,
+                        false,
+                        warnings,
+                        [new ValidatorResult("pre-ai-validation", false, errorMessages)],
+                        artifactFailures);
+                }
+
+                WriteFamilyArtifacts(context.OutputPath, outputFileName, artifacts!);
                 RemoveStaleFamilyFiles(context.OutputPath, familyName, outputFileName);
                 await ApplyCliTabWrappingAsync(
                     context,
@@ -596,7 +616,7 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             .ToArray();
     }
 
-    private static async Task<FamilyCleanupArtifacts> GenerateFamilyWithReducerAsync(
+    private static async Task<(FamilyCleanupArtifacts? Artifacts, IReadOnlyList<ValidationError> ValidationErrors)> GenerateFamilyWithReducerAsync(
         PipelineContext context,
         string toolsDirectory,
         string familyName,
@@ -616,8 +636,14 @@ public sealed class ToolFamilyCleanupStep : NamespaceStepBase
             new FamilyStructureReducerInput(toolsDirectory, familyName, h2HeadingsDirectory),
             cancellationToken);
 
+        var validationResult = await ValidatorRegistry.ValidateAsync(ToolFamilyCleanupStageName, structure, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return (null, validationResult.Errors);
+        }
+
         var cleanupAsync = await ResolveFamilyCleanupAsync(context, familyName, cliVersionPath, brandMappings, warnings, cancellationToken);
-        return await cleanupAsync(structure, cancellationToken);
+        return (await cleanupAsync(structure, cancellationToken), System.Array.Empty<ValidationError>());
     }
 
     private static async Task<Func<FamilyStructureContext, CancellationToken, Task<FamilyCleanupArtifacts>>> ResolveFamilyCleanupAsync(

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolGenerationStep.cs
@@ -6,8 +6,10 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using Shared;
+using Shared.Validation;
 using ToolGeneration_Improved.Models;
 using ToolGeneration_Improved.Services;
+using ToolGeneration_Improved.Validation;
 
 namespace PipelineRunner.Steps;
 
@@ -15,8 +17,10 @@ public sealed class ToolGenerationStep : NamespaceStepBase
 {
     private const int DefaultMaxTokens = 8000;
     internal const string ToolImproverOverrideKey = "ToolGenerationStep.ToolImproverOverride";
+    private const string ToolGenerationStageName = "tool-generation";
 
     private static readonly ReducerRegistry Reducers = new();
+    private static readonly PreAiValidatorRegistry ValidatorRegistry = new();
     private static readonly UpstreamArtifactResolver UpstreamArtifacts = new();
     private static readonly TimeSpan ReducerImprovementTimeout = TimeSpan.FromMinutes(5);
 
@@ -40,6 +44,9 @@ public sealed class ToolGenerationStep : NamespaceStepBase
             var reducer = new ToolGenerationReducer();
             return await reducer.ReduceAsync(input.ComposedToolsDirectory, input.ToolFileName, input.MaxTokens, ct);
         });
+
+        ValidatorRegistry.Register(ToolGenerationStageName, new ToolGenerationContextValidator());
+        ValidatorRegistry.Register(ToolGenerationStageName, new ToolGenerationBudgetValidator());
     }
 
     public ToolGenerationStep()
@@ -185,9 +192,10 @@ public sealed class ToolGenerationStep : NamespaceStepBase
 
         if (useReducerPath)
         {
+            var hadValidationFailure = false;
             try
             {
-                await ImproveToolsWithReducerAsync(
+                hadValidationFailure = await ImproveToolsWithReducerAsync(
                     context,
                     toolArtifacts,
                     composedToolsDirectory,
@@ -208,6 +216,15 @@ public sealed class ToolGenerationStep : NamespaceStepBase
                     warnings,
                     [composedToolsDirectory, improvedToolsDirectory, annotationsDirectory, parametersDirectory, examplePromptsDirectory]));
                 return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
+            }
+
+            if (hadValidationFailure)
+            {
+                artifactFailures.Add(CreateStepLevelFailure(
+                    "DocGeneration.Steps.ToolGeneration.Improvements",
+                    "Pre-AI validation failed for one or more tools; composed content was used as fallback.",
+                    warnings,
+                    [composedToolsDirectory, improvedToolsDirectory]));
             }
         }
         else
@@ -382,7 +399,7 @@ public sealed class ToolGenerationStep : NamespaceStepBase
             .Where(static fileName => !string.IsNullOrWhiteSpace(fileName))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-    private static async Task ImproveToolsWithReducerAsync(
+    private static async Task<bool> ImproveToolsWithReducerAsync(
         PipelineContext context,
         IReadOnlyList<ToolArtifacts> toolArtifacts,
         string composedToolsDirectory,
@@ -399,6 +416,7 @@ public sealed class ToolGenerationStep : NamespaceStepBase
         }
 
         var improveToolAsync = await ResolveToolImproverAsync(context, cancellationToken);
+        var anyValidationFailed = false;
 
         foreach (var artifact in toolArtifacts)
         {
@@ -407,6 +425,16 @@ public sealed class ToolGenerationStep : NamespaceStepBase
             var reduction = (ToolGenerationContext)await reducer(
                 new ToolGenerationReducerInput(composedToolsDirectory, artifact.ToolFileName, DefaultMaxTokens),
                 cancellationToken);
+
+            var validationResult = await ValidatorRegistry.ValidateAsync(ToolGenerationStageName, reduction, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                var errorSummary = string.Join("; ", validationResult.Errors.Select(static e => e.Message));
+                warnings.Add($"Pre-AI validation failed for '{artifact.ToolFileName}': {errorSummary}");
+                await File.WriteAllTextAsync(artifact.ImprovedToolPath, reduction.ComposedContent, Encoding.UTF8, cancellationToken);
+                anyValidationFailed = true;
+                continue;
+            }
 
             try
             {
@@ -433,6 +461,8 @@ public sealed class ToolGenerationStep : NamespaceStepBase
                 warnings.Add($"AI-improved tool generation failed for '{artifact.ToolFileName}': {ex.Message}");
             }
         }
+
+        return anyValidationFailed;
     }
 
     private static async Task<Func<ToolGenerationContext, CancellationToken, Task<ImprovedToolData>>> ResolveToolImproverAsync(

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/Validation/ArticleOutlineBudgetValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/Validation/ArticleOutlineBudgetValidatorTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HorizontalArticleGenerator.Models;
+using HorizontalArticleGenerator.Validation;
+using Xunit;
+
+namespace DocGeneration.Steps.HorizontalArticles.Tests.Validation;
+
+public sealed class ArticleOutlineBudgetValidatorTests
+{
+    private readonly ArticleOutlineBudgetValidator _sut = new();
+
+    private static ArticleOutlineSection MakeSection(string heading, int evidenceLength)
+        => new(heading, "howto", [new string('x', evidenceLength)]);
+
+    [Fact]
+    public async Task SmallContext_ReturnsPass()
+    {
+        var context = new ArticleOutlineContext(
+            "Title",
+            [MakeSection("A", 100), MakeSection("B", 100)],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(50, result.EstimatedPromptTokens); // (100 + 100) / 4
+        Assert.Equal(ArticleOutlineBudgetValidator.InputTokenBudget, result.TokenBudget);
+    }
+
+    [Fact]
+    public async Task ContextAtBudgetBoundary_ReturnsPass()
+    {
+        var totalChars = ArticleOutlineBudgetValidator.InputTokenBudget * ArticleOutlineBudgetValidator.CharsPerToken;
+        var context = new ArticleOutlineContext(
+            "Title",
+            [MakeSection("A", totalChars)],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task ContextOverBudget_ReturnsFail()
+    {
+        var overBudgetChars = (ArticleOutlineBudgetValidator.InputTokenBudget + 1) * ArticleOutlineBudgetValidator.CharsPerToken;
+        var context = new ArticleOutlineContext(
+            "Title",
+            [MakeSection("A", overBudgetChars)],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "Sections");
+        Assert.True(result.EstimatedPromptTokens > ArticleOutlineBudgetValidator.InputTokenBudget);
+    }
+
+    [Fact]
+    public async Task ContextOverBudget_IncludesTokenInfo()
+    {
+        var overBudgetChars = (ArticleOutlineBudgetValidator.InputTokenBudget + 500) * ArticleOutlineBudgetValidator.CharsPerToken;
+        var context = new ArticleOutlineContext(
+            "Title",
+            [MakeSection("A", overBudgetChars)],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.Equal(ArticleOutlineBudgetValidator.InputTokenBudget, result.TokenBudget);
+        Assert.True(result.EstimatedPromptTokens.HasValue);
+    }
+
+    [Fact]
+    public async Task EvidenceAcrossMultipleSections_CombinedForEstimate()
+    {
+        // 3 sections × 400 chars each = 1200 chars / 4 = 300 tokens (well within budget)
+        var context = new ArticleOutlineContext(
+            "Title",
+            [MakeSection("A", 400), MakeSection("B", 400), MakeSection("C", 400)],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(300, result.EstimatedPromptTokens);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/Validation/ArticleOutlineContextValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/Validation/ArticleOutlineContextValidatorTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HorizontalArticleGenerator.Models;
+using HorizontalArticleGenerator.Validation;
+using Xunit;
+using Shared.Validation;
+
+namespace DocGeneration.Steps.HorizontalArticles.Tests.Validation;
+
+public sealed class ArticleOutlineContextValidatorTests
+{
+    private readonly ArticleOutlineContextValidator _sut = new();
+
+    private static ArticleOutlineContext ValidContext() => new(
+        "Azure MCP Server tools overview",
+        [
+            new ArticleOutlineSection("Prerequisites", "prerequisites", ["Have an Azure subscription.", "Install the CLI."]),
+            new ArticleOutlineSection("Getting started", "howto", ["Run az mcp server start.", "Connect your client."])
+        ],
+        "azure-mcp",
+        "1.0");
+
+    [Fact]
+    public async Task ValidContext_ReturnsPass()
+    {
+        var result = await _sut.ValidateAsync(ValidContext(), CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task EmptyArticleTitle_ReturnsFail()
+    {
+        var context = ValidContext() with { ArticleTitle = string.Empty };
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "ArticleTitle");
+    }
+
+    [Fact]
+    public async Task OnlyOneSection_ReturnsFail()
+    {
+        var context = new ArticleOutlineContext(
+            "Title",
+            [new ArticleOutlineSection("Prerequisites", "prerequisites", ["Have an Azure subscription."])],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "Sections");
+    }
+
+    [Fact]
+    public async Task EmptySections_ReturnsFail()
+    {
+        var context = new ArticleOutlineContext("Title", [], "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "Sections");
+    }
+
+    [Fact]
+    public async Task SectionWithNoEvidenceItems_ReturnsFail()
+    {
+        var context = new ArticleOutlineContext(
+            "Title",
+            [
+                new ArticleOutlineSection("Prerequisites", "prerequisites", []),
+                new ArticleOutlineSection("Getting started", "howto", ["Run az mcp server start."])
+            ],
+            "azure-mcp");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field.StartsWith("Sections[") && e.Field.EndsWith(".EvidenceItems"));
+    }
+
+    [Fact]
+    public async Task WrongSchemaVersion_ReturnsFail()
+    {
+        var context = ValidContext() with { SchemaVersion = "99.0" };
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "SchemaVersion" && e.Severity == ValidationSeverity.Error);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineBudgetValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineBudgetValidator.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HorizontalArticleGenerator.Models;
+using Shared.Validation;
+
+namespace HorizontalArticleGenerator.Validation;
+
+/// <summary>
+/// Seam validator that estimates the input-token footprint of an
+/// <see cref="ArticleOutlineContext"/> and rejects it when the estimated
+/// token count exceeds the configured budget.
+/// </summary>
+public sealed class ArticleOutlineBudgetValidator : IPreAiValidator<ArticleOutlineContext>
+{
+    /// <summary>Characters-per-token estimate used for all token calculations.</summary>
+    internal const int CharsPerToken = 4;
+
+    /// <summary>Maximum input tokens allowed for the horizontal-articles AI stage.</summary>
+    internal const int InputTokenBudget = 100_000;
+
+    /// <inheritdoc />
+    public Task<PreAiValidationResult> ValidateAsync(ArticleOutlineContext context, CancellationToken cancellationToken)
+    {
+        var totalChars = context.Sections
+            .SelectMany(static section => section.EvidenceItems)
+            .Sum(static item => item.Length);
+
+        var estimatedTokens = totalChars / CharsPerToken;
+
+        if (estimatedTokens > InputTokenBudget)
+        {
+            return Task.FromResult(new PreAiValidationResult(
+                false,
+                [
+                    new ValidationError(
+                        "Sections",
+                        $"Estimated {estimatedTokens:N0} input tokens exceeds budget of {InputTokenBudget:N0}.",
+                        ValidationSeverity.Error)
+                ],
+                estimatedTokens,
+                InputTokenBudget));
+        }
+
+        return Task.FromResult(PreAiValidationResult.Pass(estimatedTokens, InputTokenBudget));
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineContextValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineContextValidator.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HorizontalArticleGenerator.Models;
+using Shared.Validation;
+
+namespace HorizontalArticleGenerator.Validation;
+
+/// <summary>
+/// Seam validator that checks the structural integrity of an
+/// <see cref="ArticleOutlineContext"/> before the LLM call is dispatched.
+/// </summary>
+public sealed class ArticleOutlineContextValidator : IPreAiValidator<ArticleOutlineContext>
+{
+    /// <inheritdoc />
+    public Task<PreAiValidationResult> ValidateAsync(ArticleOutlineContext context, CancellationToken cancellationToken)
+    {
+        var errors = new List<ValidationError>();
+
+        if (string.IsNullOrWhiteSpace(context.ArticleTitle))
+        {
+            errors.Add(new ValidationError("ArticleTitle", "ArticleTitle must not be empty.", ValidationSeverity.Error));
+        }
+
+        if (context.Sections.Count < 2)
+        {
+            errors.Add(new ValidationError(
+                "Sections",
+                $"ArticleOutlineContext must contain at least 2 sections, but found {context.Sections.Count}.",
+                ValidationSeverity.Error));
+        }
+        else
+        {
+            for (var i = 0; i < context.Sections.Count; i++)
+            {
+                if (context.Sections[i].EvidenceItems.Count == 0)
+                {
+                    errors.Add(new ValidationError(
+                        $"Sections[{i}].EvidenceItems",
+                        $"Section '{context.Sections[i].Heading}' at index {i} has no evidence items.",
+                        ValidationSeverity.Error));
+                }
+            }
+        }
+
+        if (context.SchemaVersion != "1.0")
+        {
+            errors.Add(new ValidationError(
+                "SchemaVersion",
+                $"Unrecognized SchemaVersion '{context.SchemaVersion}'. Expected '1.0'.",
+                ValidationSeverity.Error));
+        }
+
+        return Task.FromResult(errors.Count == 0
+            ? PreAiValidationResult.Pass()
+            : PreAiValidationResult.Fail([.. errors]));
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Validation/FamilyStructureContextValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/Validation/FamilyStructureContextValidatorTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Shared.Validation;
+using ToolFamilyCleanup.Models;
+using ToolFamilyCleanup.Validation;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolFamilyCleanup.Tests.Validation;
+
+public sealed class FamilyStructureContextValidatorTests
+{
+    private readonly FamilyStructureContextValidator _sut = new();
+
+    private static FamilyStructureContext ValidContext() => new(
+        "fileshares",
+        [new FamilySection("Get fileshare", ["fileshares fileshare get"], "## Get fileshare\n\nContent.")],
+        "1.0");
+
+    [Fact]
+    public async Task ValidContext_ReturnsPass()
+    {
+        var result = await _sut.ValidateAsync(ValidContext(), CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task EmptyFamilyName_ReturnsFail()
+    {
+        var context = ValidContext() with { FamilyName = string.Empty };
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "FamilyName");
+    }
+
+    [Fact]
+    public async Task EmptySections_ReturnsFail()
+    {
+        var context = new FamilyStructureContext("fileshares", [], "1.0");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "Sections");
+    }
+
+    [Fact]
+    public async Task SectionWithEmptyHeading_ReturnsFail()
+    {
+        var context = new FamilyStructureContext(
+            "fileshares",
+            [new FamilySection(string.Empty, ["fileshares fileshare get"], "Content.")],
+            "1.0");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field.StartsWith("Sections[") && e.Field.EndsWith(".Heading"));
+    }
+
+    [Fact]
+    public async Task WrongSchemaVersion_ReturnsFail()
+    {
+        var context = ValidContext() with { SchemaVersion = "2.0" };
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "SchemaVersion" && e.Severity == ValidationSeverity.Error);
+    }
+
+    [Fact]
+    public async Task MultipleSectionsAllValid_ReturnsPass()
+    {
+        var context = new FamilyStructureContext(
+            "fileshares",
+            [
+                new FamilySection("Get fileshare", ["fileshares fileshare get"], "Content A."),
+                new FamilySection("List fileshares", ["fileshares fileshare list"], "Content B.")
+            ],
+            "1.0");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Validation/FamilyStructureContextValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Validation/FamilyStructureContextValidator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Shared.Validation;
+using ToolFamilyCleanup.Models;
+
+namespace ToolFamilyCleanup.Validation;
+
+/// <summary>
+/// Seam validator that checks the structural integrity of a
+/// <see cref="FamilyStructureContext"/> before the LLM call is dispatched.
+/// </summary>
+public sealed class FamilyStructureContextValidator : IPreAiValidator<FamilyStructureContext>
+{
+    /// <inheritdoc />
+    public Task<PreAiValidationResult> ValidateAsync(FamilyStructureContext context, CancellationToken cancellationToken)
+    {
+        var errors = new List<ValidationError>();
+
+        if (string.IsNullOrWhiteSpace(context.FamilyName))
+        {
+            errors.Add(new ValidationError("FamilyName", "FamilyName must not be empty.", ValidationSeverity.Error));
+        }
+
+        if (context.Sections.Count == 0)
+        {
+            errors.Add(new ValidationError("Sections", "FamilyStructureContext must contain at least one section.", ValidationSeverity.Error));
+        }
+        else
+        {
+            for (var i = 0; i < context.Sections.Count; i++)
+            {
+                if (string.IsNullOrWhiteSpace(context.Sections[i].Heading))
+                {
+                    errors.Add(new ValidationError(
+                        $"Sections[{i}].Heading",
+                        $"Section at index {i} has an empty Heading.",
+                        ValidationSeverity.Error));
+                }
+            }
+        }
+
+        if (context.SchemaVersion != "1.0")
+        {
+            errors.Add(new ValidationError(
+                "SchemaVersion",
+                $"Unrecognized SchemaVersion '{context.SchemaVersion}'. Expected '1.0'.",
+                ValidationSeverity.Error));
+        }
+
+        return Task.FromResult(errors.Count == 0
+            ? PreAiValidationResult.Pass()
+            : PreAiValidationResult.Fail([.. errors]));
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/DocGeneration.Steps.ToolGeneration.Improvements.Tests.csproj
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/DocGeneration.Steps.ToolGeneration.Improvements.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../DocGeneration.Steps.ToolGeneration.Improvements/DocGeneration.Steps.ToolGeneration.Improvements.csproj" />
+    <ProjectReference Include="../../shared/DocGeneration.Core.Shared/DocGeneration.Core.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/Validation/ToolGenerationBudgetValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/Validation/ToolGenerationBudgetValidatorTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ToolGeneration_Improved.Models;
+using ToolGeneration_Improved.Validation;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolGeneration.Improvements.Tests.Validation;
+
+public sealed class ToolGenerationBudgetValidatorTests
+{
+    private readonly ToolGenerationBudgetValidator _sut = new();
+
+    [Fact]
+    public async Task SmallContent_ReturnsPass()
+    {
+        var content = new string('x', 1000); // 1000 chars = 250 estimated tokens
+        var context = new ToolGenerationContext("tool create", content, 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(250, result.EstimatedPromptTokens);
+        Assert.Equal(ToolGenerationBudgetValidator.InputTokenBudget, result.TokenBudget);
+    }
+
+    [Fact]
+    public async Task ContentAtBudget_ReturnsPass()
+    {
+        // exactly at budget boundary (InputTokenBudget * CharsPerToken chars)
+        var content = new string('x', ToolGenerationBudgetValidator.InputTokenBudget * ToolGenerationBudgetValidator.CharsPerToken);
+        var context = new ToolGenerationContext("tool create", content, 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task ContentOverBudget_ReturnsFail()
+    {
+        // one token over budget
+        var content = new string('x', (ToolGenerationBudgetValidator.InputTokenBudget + 1) * ToolGenerationBudgetValidator.CharsPerToken);
+        var context = new ToolGenerationContext("tool create", content, 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "ComposedContent");
+        Assert.True(result.EstimatedPromptTokens > ToolGenerationBudgetValidator.InputTokenBudget);
+    }
+
+    [Fact]
+    public async Task OverBudget_IncludesTokenInfo()
+    {
+        var content = new string('x', (ToolGenerationBudgetValidator.InputTokenBudget + 100) * ToolGenerationBudgetValidator.CharsPerToken);
+        var context = new ToolGenerationContext("tool create", content, 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.Equal(ToolGenerationBudgetValidator.InputTokenBudget, result.TokenBudget);
+        Assert.True(result.EstimatedPromptTokens.HasValue);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/Validation/ToolGenerationContextValidatorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements.Tests/Validation/ToolGenerationContextValidatorTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Shared.Validation;
+using ToolGeneration_Improved.Models;
+using ToolGeneration_Improved.Validation;
+using Xunit;
+
+namespace DocGeneration.Steps.ToolGeneration.Improvements.Tests.Validation;
+
+public sealed class ToolGenerationContextValidatorTests
+{
+    private readonly ToolGenerationContextValidator _sut = new();
+
+    [Fact]
+    public async Task ValidContext_ReturnsPass()
+    {
+        var context = new ToolGenerationContext("fileshares fileshare create", "# create\n\nContent.", 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task EmptyToolName_ReturnsFail()
+    {
+        var context = new ToolGenerationContext(string.Empty, "# create\n\nContent.", 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "ToolName");
+    }
+
+    [Fact]
+    public async Task WhitespaceToolName_ReturnsFail()
+    {
+        var context = new ToolGenerationContext("   ", "# create\n\nContent.", 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "ToolName");
+    }
+
+    [Fact]
+    public async Task EmptyComposedContent_ReturnsFail()
+    {
+        var context = new ToolGenerationContext("fileshares fileshare create", string.Empty, 8000);
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "ComposedContent");
+    }
+
+    [Fact]
+    public async Task WrongSchemaVersion_ReturnsFail()
+    {
+        var context = new ToolGenerationContext("fileshares fileshare create", "Content.", 8000, "2.0");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "SchemaVersion" && e.Severity == ValidationSeverity.Error);
+    }
+
+    [Fact]
+    public async Task MultipleInvalidFields_ReturnsAllErrors()
+    {
+        var context = new ToolGenerationContext(string.Empty, string.Empty, 8000, "99.0");
+
+        var result = await _sut.ValidateAsync(context, CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        Assert.True(result.Errors.Count >= 3);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationBudgetValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationBudgetValidator.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Shared.Validation;
+using ToolGeneration_Improved.Models;
+
+namespace ToolGeneration_Improved.Validation;
+
+/// <summary>
+/// Seam validator that estimates the input-token footprint of a
+/// <see cref="ToolGenerationContext"/> and rejects it when the estimated
+/// token count exceeds the configured budget.
+/// </summary>
+public sealed class ToolGenerationBudgetValidator : IPreAiValidator<ToolGenerationContext>
+{
+    /// <summary>Characters-per-token estimate used for all token calculations.</summary>
+    internal const int CharsPerToken = 4;
+
+    /// <summary>Maximum input tokens allowed for the tool-generation AI stage.</summary>
+    internal const int InputTokenBudget = 100_000;
+
+    /// <inheritdoc />
+    public Task<PreAiValidationResult> ValidateAsync(ToolGenerationContext context, CancellationToken cancellationToken)
+    {
+        var estimatedTokens = context.ComposedContent.Length / CharsPerToken;
+
+        if (estimatedTokens > InputTokenBudget)
+        {
+            return Task.FromResult(new PreAiValidationResult(
+                false,
+                [
+                    new ValidationError(
+                        "ComposedContent",
+                        $"Estimated {estimatedTokens:N0} input tokens exceeds budget of {InputTokenBudget:N0}.",
+                        ValidationSeverity.Error)
+                ],
+                estimatedTokens,
+                InputTokenBudget));
+        }
+
+        return Task.FromResult(PreAiValidationResult.Pass(estimatedTokens, InputTokenBudget));
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationContextValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationContextValidator.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Shared.Validation;
+using ToolGeneration_Improved.Models;
+
+namespace ToolGeneration_Improved.Validation;
+
+/// <summary>
+/// Seam validator that checks the structural integrity of a
+/// <see cref="ToolGenerationContext"/> before the LLM call is dispatched.
+/// </summary>
+public sealed class ToolGenerationContextValidator : IPreAiValidator<ToolGenerationContext>
+{
+    /// <inheritdoc />
+    public Task<PreAiValidationResult> ValidateAsync(ToolGenerationContext context, CancellationToken cancellationToken)
+    {
+        var errors = new List<ValidationError>();
+
+        if (string.IsNullOrWhiteSpace(context.ToolName))
+        {
+            errors.Add(new ValidationError("ToolName", "ToolName must not be empty.", ValidationSeverity.Error));
+        }
+
+        if (string.IsNullOrWhiteSpace(context.ComposedContent))
+        {
+            errors.Add(new ValidationError("ComposedContent", "ComposedContent must not be empty.", ValidationSeverity.Error));
+        }
+
+        if (context.SchemaVersion != "1.0")
+        {
+            errors.Add(new ValidationError(
+                "SchemaVersion",
+                $"Unrecognized SchemaVersion '{context.SchemaVersion}'. Expected '1.0'.",
+                ValidationSeverity.Error));
+        }
+
+        return Task.FromResult(errors.Count == 0
+            ? PreAiValidationResult.Pass()
+            : PreAiValidationResult.Fail([.. errors]));
+    }
+}


### PR DESCRIPTION
## Summary

Implements P10 from the Pipeline Manageability PRD - registers IPreAiValidator implementations into the PreAiValidatorRegistry (from P9) for pipeline steps 3, 4, and 6.

## New validators (5)

- ToolGenerationContextValidator (step 3): ToolName non-empty, ComposedContent non-empty, SchemaVersion 1.0
- ToolGenerationBudgetValidator (step 3): ComposedContent.Length / 4 <= 100,000 tokens
- FamilyStructureContextValidator (step 4): FamilyName non-empty, Sections >= 1, all headings non-empty, SchemaVersion 1.0
- ArticleOutlineContextValidator (step 6): ArticleTitle non-empty, Sections >= 2, each section EvidenceItems >= 1, SchemaVersion 1.0
- ArticleOutlineBudgetValidator (step 6): Total evidence length / 4 <= 100,000 tokens

## Step wiring

- ToolGenerationStep: validators in static ctor; ImproveToolsWithReducerAsync returns Task<bool>; per-tool failure writes fallback + warning + ArtifactFailure
- ToolFamilyCleanupStep: validator in static ctor; GenerateFamilyWithReducerAsync returns (FamilyCleanupArtifacts?, IReadOnlyList<ValidationError>); call site returns BuildResult(false) with ValidatorResult on failure
- HorizontalArticlesStep: validators in static ctor; inline validation gate between reducer and renderArticleAsync; returns BuildResult(false) with ValidatorResult on failure

## Tests

27 new unit tests across 5 test files (all in existing test projects). All 492 DocGeneration.PipelineRunner.Tests pass.

## PRD reference

P10 - depends on P6 (done) and P9 (done). Unlocks Phase 4 (P13, P14, P16, P18).