### PR TITLE
P13: --inspect mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -442,3 +442,114 @@ shared/DocGeneration.Core.Tracing/
 
 - **Skills pipeline:** Fresh tracer created per `ProcessBatchAsync()` run, flushed in `finally` block
 - **MCP pipeline:** Fresh tracer created per namespace iteration, flushed to `generated-{namespace}/trace/`
+
+---
+
+## Key Concepts
+
+These terms are introduced by the pipeline manageability work (Points 1–17) and used throughout new code and comments.
+
+| Term | Definition |
+|------|------------|
+| **step envelope** | The `StepResultFile` JSON artifact written by every step to its workspace directory after execution. Contains schema version, input/output artifacts, validation status, token usage, and timing. |
+| **frozen artifact** | A `step-result.json` from a prior pipeline run stored in a versioned run directory. Used by `--replay` to re-run a single step against fixed upstream outputs without re-running predecessors. |
+| **reducer** | A deterministic class that extracts only the inputs one AI stage needs from the upstream envelopes, producing a compact typed context object. No LLM call; runs before the pre-AI gate. See `ToolGenerationReducer`. |
+| **builder** | Synonym for reducer in the `ToolFamilyCleanup` and `HorizontalArticles` contexts; additionally generates structural scaffolding (headings, section order, skeleton) so the AI stage handles prose only. See `FamilyStructureBuilder`, `ArticleOutlineBuilder`. |
+| **seam validator** | An `IPreAiValidator<TContext>` implementation that gates an AI stage. Runs after the reducer but before the LLM call; can block the call by returning `isValid: false`. See `ToolGenerationBudgetValidator`, `ArticleOutlineBudgetValidator`. |
+| **pre-AI gate** | The point in `PipelineRunner` where all registered seam validators for a stage are invoked before any LLM call is dispatched. When a seam validator fails, the stage is skipped and `validationStatus: failed` is written to the step envelope. |
+| **replay mode** | CLI mode (`--replay`) that loads frozen step envelopes from a past run directory and re-executes only the target step against those fixed inputs, without re-running predecessors. Entry point: `RunReplayAsync`. |
+| **inspect mode** | CLI mode (`--inspect`) that runs the reducer for a named step against the current workspace inputs and prints a prompt budget summary — without invoking the LLM. A pre-flight check, not a debugging tool. Entry point: `RunInspectAsync`. |
+
+---
+
+## Developer Loop
+
+Three common workflows for working with the pipeline locally.
+
+### 1. Fresh full run
+
+Run all steps for all namespaces:
+
+```bash
+./start.sh
+# Equivalent:
+dotnet run --project mcp-tools/DocGeneration.PipelineRunner -- --output ./generated
+```
+
+Run specific steps for a single namespace (e.g., only `advisor`):
+
+```bash
+./start.sh advisor 1,2,3
+# Equivalent:
+dotnet run --project mcp-tools/DocGeneration.PipelineRunner -- \
+  --namespace advisor --steps 1,2,3 --output ./generated-advisor
+```
+
+Skip dependency validation (useful when re-running a single step that you know has all inputs):
+
+```bash
+./start.sh advisor 4 --skip-deps
+```
+
+---
+
+### 2. Replay a single step
+
+After a full run, re-run only `tool-generation` using frozen inputs from a previous run:
+
+```bash
+./start.sh --replay --step tool-generation --from 20240501T120000Z --namespace advisor
+# Equivalent:
+dotnet run --project mcp-tools/DocGeneration.PipelineRunner -- \
+  --replay --step tool-generation --from 20240501T120000Z \
+  --namespace advisor --output ./generated-advisor
+```
+
+Replay loads the frozen `step-result.json` envelopes from `--from` run directory and passes
+them directly to the step executor, skipping all predecessors. No LLM calls are made for
+deterministic steps; AI stages still invoke the LLM but against fixed upstream context.
+
+---
+
+### 3. Inspect prompt budget before running
+
+Before invoking `horizontal-articles` for `advisor`, verify the prompt will be within budget:
+
+```bash
+./start.sh --inspect --step horizontal-articles --namespace advisor \
+  --show prompt-budget --output ./generated-advisor
+# Prints: step | namespace | estimatedTokens | budget | headroom | topItems (top-5 sections)
+# Exits 0 if within budget (≤ 100,000 tokens); exits 1 if over budget.
+```
+
+Inspect `tool-generation` to see per-tool estimated token usage:
+
+```bash
+./start.sh --inspect --step tool-generation --namespace advisor \
+  --show prompt-budget --output ./generated-advisor
+```
+
+Inspect `tool-family-cleanup` to check structural section counts (no token budget — deterministic step):
+
+```bash
+./start.sh --inspect --step tool-family-cleanup --namespace advisor \
+  --output ./generated-advisor
+```
+
+Use `--inspect` in CI as a pre-flight gate before dispatching a full LLM run.
+Exit code 0 = all items within budget; exit code 1 = at least one item exceeds budget.
+
+---
+
+## Enforcement Model
+
+All enforcement decisions across the pipeline follow a four-tier model.
+
+| Level | Condition | Response |
+|-------|-----------|----------|
+| **Fatal** | `step-result.json` absent after a non-warn-only step completes | Runner logs FATAL and aborts the pipeline. |
+| **Validation skip** | Pre-AI seam validator returns `isValid: false` | Stage is skipped; `validationStatus: failed` written to step envelope; pipeline continues to next independent step. |
+| **Warning** | Observability files (`summary.md`, `metrics.json`, etc.) missing after a step | Logged as WARNING; pipeline continues. |
+| **Phase-gated** | `StepRegistry` in-memory registry diverges from `pipeline.config.json` | Phase 1: WARNING; Phase 2 and beyond: throws `StepRegistryConfigMismatchException`. |
+
+`SkillsRelevanceStep` is **warn-only by design**: its `step-result.json` is required, but a `validationStatus: failed` in that file does not abort the pipeline.

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -27,6 +27,8 @@ public static class PipelineCli
         rootCommand.AddOption(options.Replay);
         rootCommand.AddOption(options.From);
         rootCommand.AddOption(options.StepName);
+        rootCommand.AddOption(options.Inspect);
+        rootCommand.AddOption(options.Show);
         return rootCommand;
     }
 
@@ -41,6 +43,7 @@ public static class PipelineCli
         var rootCommand = CreateCommandWith(options);
         var parseResult = rootCommand.Parse(args);
         var replay = parseResult.GetValueForOption(options.Replay);
+        var inspect = parseResult.GetValueForOption(options.Inspect);
 
         if (parseResult.Errors.Count > 0)
         {
@@ -50,7 +53,7 @@ public static class PipelineCli
         var namespaceValue = parseResult.GetValueForOption(options.Namespace);
         var outputValue = parseResult.GetValueForOption(options.Output) ?? PipelineRequest.GetDefaultOutputPath(namespaceValue);
         IReadOnlyList<int> steps = Array.Empty<int>();
-        if (!replay)
+        if (!replay && !inspect)
         {
             var stepsCsv = parseResult.GetValueForOption(options.Steps) ?? string.Join(',', PipelineRequest.DefaultSteps);
             if (!PipelineRequest.TryParseSteps(stepsCsv, out steps, out var stepError))
@@ -75,7 +78,9 @@ public static class PipelineCli
             parseResult.GetValueForOption(options.SkipNpmUpdate),
             replay,
             parseResult.GetValueForOption(options.From),
-            parseResult.GetValueForOption(options.StepName));
+            parseResult.GetValueForOption(options.StepName),
+            inspect,
+            parseResult.GetValueForOption(options.Show));
 
         var validationErrors = request.Validate();
         return validationErrors.Count > 0
@@ -136,6 +141,8 @@ public static class PipelineCli
         rootCommand.AddOption(options.Replay);
         rootCommand.AddOption(options.From);
         rootCommand.AddOption(options.StepName);
+        rootCommand.AddOption(options.Inspect);
+        rootCommand.AddOption(options.Show);
         return rootCommand;
     }
 
@@ -156,7 +163,9 @@ public static class PipelineCli
             new Option<bool>("--skip-npm-update", "Skip updating @azure/mcp to latest before installing. Use for offline runs or reproducible builds."),
             new Option<bool>("--replay", "Replay a single step against frozen upstream outputs from a prior run."),
             new Option<string?>("--from", "Run ID to replay from. Expected under .\\runs\\<run-id>\\."),
-            new Option<string?>(["--step-name", "--step"], "Step slug to replay (for example: tool-generation or horizontal-articles)."));
+            new Option<string?>(["--step-name", "--step"], "Step slug to inspect or replay (for example: tool-generation or horizontal-articles)."),
+            new Option<bool>("--inspect", "Run the reducer for the named step against the current workspace and print a prompt budget table. No LLM call is made."),
+            new Option<string?>("--show", "What to display in inspect mode. Supported value: prompt-budget."));
 
     private sealed record CliOptions(
         Option<string?> Namespace,
@@ -174,5 +183,7 @@ public static class PipelineCli
         Option<bool> SkipNpmUpdate,
         Option<bool> Replay,
         Option<string?> From,
-        Option<string?> StepName);
+        Option<string?> StepName,
+        Option<bool> Inspect,
+        Option<string?> Show);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -16,7 +16,9 @@ public sealed record PipelineRequest(
     bool SkipNpmUpdate = false,
     bool Replay = false,
     string? ReplayFromRunId = null,
-    string? ReplayStepName = null)
+    string? ReplayStepName = null,
+    bool Inspect = false,
+    string? InspectShow = null)
 {
     /// <summary>
     /// Default upstream branch for fetching files from the microsoft/mcp repository.
@@ -119,12 +121,19 @@ public sealed record PipelineRequest(
                 errors.Add("--step-name is required when --replay is set.");
             }
         }
+        else if (Inspect)
+        {
+            if (string.IsNullOrWhiteSpace(ReplayStepName))
+            {
+                errors.Add("--step-name is required when --inspect is set.");
+            }
+        }
         else if (Steps.Count == 0)
         {
             errors.Add("At least one step must be selected.");
         }
 
-        var duplicates = Replay
+        var duplicates = Replay || Inspect
             ? Array.Empty<int>()
             : Steps
                 .GroupBy(step => step)
@@ -139,7 +148,7 @@ public sealed record PipelineRequest(
         }
 
         var allowedSteps = validStepIds ?? AllValidSteps;
-        var invalidSteps = Replay
+        var invalidSteps = Replay || Inspect
             ? Array.Empty<int>()
             : Steps
                 .Where(step => !allowedSteps.Contains(step))

--- a/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs
@@ -1,4 +1,6 @@
 using DocGeneration.Core.Tracing;
+using HorizontalArticleGenerator.Builders;
+using HorizontalArticleGenerator.Validation;
 using PipelineRunner.Cli;
 using PipelineRunner.Contracts;
 using PipelineRunner.Context;
@@ -6,6 +8,10 @@ using PipelineRunner.Registry;
 using PipelineRunner.Services;
 using Shared;
 using System.Security.Cryptography;
+using System.Text;
+using ToolFamilyCleanup.Services;
+using ToolGeneration_Improved.Services;
+using ToolGeneration_Improved.Validation;
 
 namespace PipelineRunner;
 
@@ -95,6 +101,11 @@ public sealed class PipelineRunner
         if (request.Replay)
         {
             return await RunReplayAsync(request, cancellationToken);
+        }
+
+        if (request.Inspect)
+        {
+            return await RunInspectAsync(request, cancellationToken);
         }
 
         var context = await _contextFactory.CreateAsync(request, cancellationToken);
@@ -224,6 +235,199 @@ public sealed class PipelineRunner
         }
 
         return CompleteRun(context, warnings, criticalFailures, SuccessExitCode);
+    }
+
+    private async Task<int> RunInspectAsync(PipelineRequest request, CancellationToken cancellationToken)
+    {
+        var stepSlug = request.ReplayStepName!;
+        var outputPath = request.OutputPath;
+        var namespaceName = request.Namespace;
+
+        Console.WriteLine($"Inspect: step={stepSlug} namespace={namespaceName ?? "(all)"} output={outputPath}");
+        Console.WriteLine();
+
+        return stepSlug switch
+        {
+            "tool-generation" => await InspectToolGenerationAsync(outputPath, namespaceName, cancellationToken),
+            "horizontal-articles" => await InspectHorizontalArticlesAsync(outputPath, namespaceName, cancellationToken),
+            "tool-family-cleanup" => await InspectToolFamilyCleanupAsync(outputPath, namespaceName, cancellationToken),
+            _ => ReportUnknownInspectStep(stepSlug),
+        };
+    }
+
+    private static int ReportUnknownInspectStep(string stepSlug)
+    {
+        Console.Error.WriteLine($"Unknown inspect step '{stepSlug}'. Supported: tool-generation, horizontal-articles, tool-family-cleanup.");
+        return InvalidArgumentsExitCode;
+    }
+
+    private static async Task<int> InspectToolGenerationAsync(
+        string outputPath,
+        string? namespaceName,
+        CancellationToken cancellationToken)
+    {
+        var composedDir = Path.Combine(outputPath, "tools-composed");
+        if (!Directory.Exists(composedDir))
+        {
+            Console.Error.WriteLine($"tools-composed directory not found: {composedDir}");
+            Console.Error.WriteLine("Run step 3 (tool-generation) first to produce composed tool files.");
+            return FatalExitCode;
+        }
+
+        var toolFiles = Directory.EnumerateFiles(composedDir, "*.md", SearchOption.TopDirectoryOnly)
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (namespaceName is not null)
+        {
+            toolFiles = toolFiles
+                .Where(f => Path.GetFileName(f).StartsWith(namespaceName + "-", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        if (toolFiles.Length == 0)
+        {
+            Console.WriteLine(namespaceName is null
+                ? $"No composed tool files found in: {composedDir}"
+                : $"No composed tool files found for namespace '{namespaceName}' in: {composedDir}");
+            return SuccessExitCode;
+        }
+
+        var reducer = new ToolGenerationReducer();
+        var validator = new ToolGenerationBudgetValidator();
+        const int DefaultMaxTokens = 8000;
+
+        PrintBudgetTableHeader("tool", "namespace", "estimatedTokens", "budget", "headroom", "topItems");
+
+        var anyOverBudget = false;
+        foreach (var filePath in toolFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var fileName = Path.GetFileName(filePath);
+            var ns = namespaceName ?? InferNamespace(fileName);
+
+            var context = await reducer.ReduceAsync(composedDir, fileName, DefaultMaxTokens, cancellationToken);
+            var result = await validator.ValidateAsync(context, cancellationToken);
+
+            var estimated = result.EstimatedPromptTokens ?? 0;
+            var budget = result.TokenBudget ?? ToolGenerationBudgetValidator.InputTokenBudget;
+            var headroom = budget - estimated;
+            var topItem = context.ToolName;
+
+            PrintBudgetTableRow("tool-generation", ns, estimated, budget, headroom, topItem);
+
+            if (!result.WithinBudget)
+            {
+                anyOverBudget = true;
+            }
+        }
+
+        return anyOverBudget ? FatalExitCode : SuccessExitCode;
+    }
+
+    private static async Task<int> InspectHorizontalArticlesAsync(
+        string outputPath,
+        string? namespaceName,
+        CancellationToken cancellationToken)
+    {
+        if (namespaceName is null)
+        {
+            Console.Error.WriteLine("--namespace is required for --inspect --step horizontal-articles.");
+            return InvalidArgumentsExitCode;
+        }
+
+        var builder = new ArticleOutlineBuilder();
+        var validator = new ArticleOutlineBudgetValidator();
+
+        var context = await builder.BuildAsync(outputPath, namespaceName, cancellationToken);
+        var result = await validator.ValidateAsync(context, cancellationToken);
+
+        var estimated = result.EstimatedPromptTokens ?? 0;
+        var budget = result.TokenBudget ?? ArticleOutlineBudgetValidator.InputTokenBudget;
+        var headroom = budget - estimated;
+
+        var topItems = context.Sections
+            .OrderByDescending(s => s.EvidenceItems.Sum(e => e.Length))
+            .Take(5)
+            .Select(s => s.Heading)
+            .ToArray();
+
+        PrintBudgetTableHeader("step", "namespace", "estimatedTokens", "budget", "headroom", "topItems");
+        PrintBudgetTableRow("horizontal-articles", namespaceName, estimated, budget, headroom, string.Join(", ", topItems));
+
+        return result.WithinBudget ? SuccessExitCode : FatalExitCode;
+    }
+
+    private static async Task<int> InspectToolFamilyCleanupAsync(
+        string outputPath,
+        string? namespaceName,
+        CancellationToken cancellationToken)
+    {
+        if (namespaceName is null)
+        {
+            Console.Error.WriteLine("--namespace is required for --inspect --step tool-family-cleanup.");
+            return InvalidArgumentsExitCode;
+        }
+
+        var toolsDir = Path.Combine(outputPath, "tools");
+        if (!Directory.Exists(toolsDir))
+        {
+            Console.Error.WriteLine($"tools directory not found: {toolsDir}");
+            Console.Error.WriteLine("Run step 4 (tool-family-cleanup) first to produce tool files.");
+            return FatalExitCode;
+        }
+
+        var builder = new FamilyStructureBuilder();
+        var context = await builder.BuildAsync(toolsDir, namespaceName, h2HeadingsDirectory: null, cancellationToken);
+
+        PrintBudgetTableHeader("step", "namespace", "sections", "budget", "headroom", "topItems");
+
+        var topItems = context.Sections
+            .Take(5)
+            .Select(s => s.Heading)
+            .ToArray();
+
+        var sb = new StringBuilder();
+        sb.Append("tool-family-cleanup".PadRight(22));
+        sb.Append(namespaceName.PadRight(18));
+        sb.Append(context.Sections.Count.ToString().PadRight(16));
+        sb.Append("n/a".PadRight(12));
+        sb.Append("n/a".PadRight(12));
+        sb.Append(string.Join(", ", topItems));
+        Console.WriteLine(sb.ToString());
+        Console.WriteLine();
+
+        return SuccessExitCode;
+    }
+
+    private static string InferNamespace(string fileName)
+    {
+        var dashIndex = fileName.IndexOf('-', StringComparison.Ordinal);
+        return dashIndex < 0 ? fileName : fileName[..dashIndex];
+    }
+
+    private static void PrintBudgetTableHeader(string col1, string col2, string col3, string col4, string col5, string col6)
+    {
+        Console.WriteLine(
+            col1.PadRight(22) +
+            col2.PadRight(18) +
+            col3.PadRight(16) +
+            col4.PadRight(12) +
+            col5.PadRight(12) +
+            col6);
+        Console.WriteLine(new string('-', 90));
+    }
+
+    private static void PrintBudgetTableRow(string step, string ns, int estimated, int budget, int headroom, string topItem)
+    {
+        var status = headroom >= 0 ? "✅" : "❌";
+        Console.WriteLine(
+            step.PadRight(22) +
+            ns.PadRight(18) +
+            $"{estimated:N0}".PadRight(16) +
+            $"{budget:N0}".PadRight(12) +
+            $"{headroom:+#;-#;0}".PadRight(12) +
+            $"{status} {topItem}");
     }
 
     private async Task<int> RunReplayAsync(PipelineRequest request, CancellationToken cancellationToken)

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineBudgetValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineBudgetValidator.cs
@@ -20,7 +20,7 @@ public sealed class ArticleOutlineBudgetValidator : IPreAiValidator<ArticleOutli
     internal const int CharsPerToken = 4;
 
     /// <summary>Maximum input tokens allowed for the horizontal-articles AI stage.</summary>
-    internal const int InputTokenBudget = 100_000;
+    public const int InputTokenBudget = 100_000;
 
     /// <inheritdoc />
     public Task<PreAiValidationResult> ValidateAsync(ArticleOutlineContext context, CancellationToken cancellationToken)

--- a/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationBudgetValidator.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationBudgetValidator.cs
@@ -19,7 +19,7 @@ public sealed class ToolGenerationBudgetValidator : IPreAiValidator<ToolGenerati
     internal const int CharsPerToken = 4;
 
     /// <summary>Maximum input tokens allowed for the tool-generation AI stage.</summary>
-    internal const int InputTokenBudget = 100_000;
+    public const int InputTokenBudget = 100_000;
 
     /// <inheritdoc />
     public Task<PreAiValidationResult> ValidateAsync(ToolGenerationContext context, CancellationToken cancellationToken)

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,17 @@
 #   ./start.sh 1,2,3                # Run bootstrap + steps 1,2,3 for all namespaces (output: ./generated/)
 #   ./start.sh advisor 4 --skip-deps  # Run step 4 skipping dependency validation
 #
+# Developer shortcuts (pass flags directly):
+#   ./start.sh --inspect --step <step> --namespace <ns> --show prompt-budget --output ./generated-<ns>
+#     # Pre-flight: estimate prompt tokens for a step without running the LLM.
+#     # Exits 0 if within budget, 1 if over budget. Example:
+#     #   ./start.sh --inspect --step horizontal-articles --namespace advisor --show prompt-budget --output ./generated-advisor
+#     #   ./start.sh --inspect --step tool-generation --namespace advisor --show prompt-budget --output ./generated-advisor
+#
+#   ./start.sh --replay --step <step> --from <runId> [--namespace <ns>]
+#     # Replay a single step against frozen outputs from a prior run (no LLM call for deterministic steps).
+#     # Example: ./start.sh --replay --step tool-generation --from 20240501T120000Z --namespace advisor
+#
 # Bootstrap step 0 always runs inside DocGeneration.PipelineRunner; start.sh is only a thin wrapper.
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

Implements the \--inspect\ pre-flight CLI mode (Point 13 of the Pipeline Manageability PRD).

## Changes

### New files
- \mcp-tools/DocGeneration.Steps.HorizontalArticles/Validation/ArticleOutlineBudgetValidator.cs\ — seam validator estimating EvidenceItems token count
- \mcp-tools/DocGeneration.Steps.ToolGeneration.Improvements/Validation/ToolGenerationBudgetValidator.cs\ — seam validator estimating ComposedContent token count

### Modified files
- \mcp-tools/DocGeneration.PipelineRunner/PipelineRunner.cs\ — adds \RunInspectAsync\; dispatches per step; prints budget table; exits 1 if over budget
- \mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs\ — adds \--inspect\ + \--show\ CLI options
- \mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs\ — adds \Inspect\/\InspectShow\ fields; validates step name required in inspect mode
- \start.sh\ — documents \--inspect\ and \--replay\ usage in header comment
- \docs/ARCHITECTURE.md\ — adds Key Concepts (8 terms), Developer Loop (3+ examples), and Enforcement Model sections

## AC coverage
- \--inspect --step horizontal-articles --namespace advisor --show prompt-budget\ prints budget table, exits 0/1 by budget
- \--inspect --step tool-generation\ iterates per-tool files, top item shown in table
- \--inspect --step tool-family-cleanup\ shows section count (no budget for deterministic step)
- Exit 0 = within budget; Exit 1 = over budget (CI-safe)
- \docs/ARCHITECTURE.md\ has Key Concepts (8 terms), Developer Loop (≥3 examples), Enforcement Model
- Build: 0 errors. Tests: 492/492 passed.