### PR TITLE
fix: implement 5 new post-assembly validator checks; defer boilerplate redundancy to #662 (Item C)

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyPostAssemblyValidatorRegressionTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyPostAssemblyValidatorRegressionTests.cs
@@ -91,7 +91,7 @@ public class ToolFamilyPostAssemblyValidatorRegressionTests
             Assert.Contains("Related tools completeness: ✅ PASS", reportText, StringComparison.Ordinal);
             Assert.Contains("Tone markers: ✅ none detected", reportText, StringComparison.Ordinal);
             Assert.Contains("Boilerplate redundancy: ✅ none detected", reportText, StringComparison.Ordinal);
-            Assert.Contains("Related section header: ✅ none detected", reportText, StringComparison.Ordinal);
+            Assert.Contains("Related section header: ✅ present", reportText, StringComparison.Ordinal);
             Assert.Contains("RESULT: PASS", reportText, StringComparison.Ordinal);
         }
         finally

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyPostAssemblyValidatorRegressionTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyPostAssemblyValidatorRegressionTests.cs
@@ -91,7 +91,7 @@ public class ToolFamilyPostAssemblyValidatorRegressionTests
             Assert.Contains("Related tools completeness: ✅ PASS", reportText, StringComparison.Ordinal);
             Assert.Contains("Tone markers: ✅ none detected", reportText, StringComparison.Ordinal);
             Assert.Contains("Boilerplate redundancy: ✅ none detected", reportText, StringComparison.Ordinal);
-            Assert.Contains("Related section header: ✅ present", reportText, StringComparison.Ordinal);
+            Assert.Contains("Related section header: ✅ none detected", reportText, StringComparison.Ordinal);
             Assert.Contains("RESULT: PASS", reportText, StringComparison.Ordinal);
         }
         finally

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyValidatorIntegrationTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilyValidatorIntegrationTests.cs
@@ -21,7 +21,7 @@ public class ToolFamilyValidatorIntegrationTests
             Directory.CreateDirectory(outputPath);
             SeedFile(Path.Combine(outputPath, "tools", "compute-list.md"), "---\n---\n# Tool\n\n<!-- @mcpcli compute list -->\nBody\n");
             SeedFile(Path.Combine(outputPath, "tool-family", "compute.md"),
-                "---\ntitle: Compute\ntool_count: 1\n---\n# Compute\n\n## List virtual machines\n<!-- @mcpcli compute list -->\nExample prompts include:\n- List resources where resource group name is 'rg-one'\n| Parameter | Required |\n| --- | --- |\n| resource group name | Yes |\n\n## Related content\n- Link\n");
+                "---\ntitle: Compute\ntool_count: 1\n---\n# Compute\n\n## List virtual machines\n<!-- @mcpcli compute list -->\nExample prompts include:\n- List resources where resource group name is 'rg-one' in location 'eastus'\n| Parameter | Required |\n| --- | --- |\n| resource group name | Yes |\n| location | No |\n\n## Related content\n- Link\n");
 
             var context = new PipelineContext
             {

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PreAiValidationGateObservabilityTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PreAiValidationGateObservabilityTests.cs
@@ -247,11 +247,11 @@ public class PreAiValidationGateObservabilityTests
         public override async ValueTask<StepResult> ExecuteAsync(
             PipelineContext context, CancellationToken cancellationToken)
         {
-            var registry = new PreAiValidatorRegistry();
-            var stageName = $"step-{id}-pre-ai";
-            registry.Register(stageName, new TrackingValidator());
+            var registry = new ReducerRegistry();
+            registry.RegisterValidator(new TrackingValidator());
 
-            var validationResult = await registry.ValidateAsync(stageName, new object(), cancellationToken);
+            var validationResult = await ReducerRegistry.AggregateAsync(
+                registry.GetValidators<object>(), new object(), cancellationToken);
             ValidatorFired = true;
 
             var validatorResults = new[]

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PreAiValidationGateObservabilityTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/PreAiValidationGateObservabilityTests.cs
@@ -248,11 +248,13 @@ public class PreAiValidationGateObservabilityTests
             PipelineContext context, CancellationToken cancellationToken)
         {
             var registry = new ReducerRegistry();
-            registry.RegisterValidator(new TrackingValidator());
+            var tracker = new TrackingValidator();
+            registry.RegisterValidator(tracker);
 
+            var validators = registry.GetValidators<object>();
             var validationResult = await ReducerRegistry.AggregateAsync(
-                registry.GetValidators<object>(), new object(), cancellationToken);
-            ValidatorFired = true;
+                validators, new object(), cancellationToken);
+            ValidatorFired = tracker.WasCalled;
 
             var validatorResults = new[]
             {
@@ -285,9 +287,14 @@ public class PreAiValidationGateObservabilityTests
 
     private sealed class TrackingValidator : IPreAiValidator<object>
     {
+        public bool WasCalled { get; private set; }
+
         public Task<PreAiValidationResult> ValidateAsync(
             object context, CancellationToken cancellationToken)
-            => Task.FromResult(PreAiValidationResult.Pass());
+        {
+            WasCalled = true;
+            return Task.FromResult(PreAiValidationResult.Pass());
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -259,18 +259,20 @@ public class ToolFamilyPostAssemblyValidatorTests
         ## List virtual machines
         <!-- @mcpcli compute list -->
         Example prompts include:
-        - List resources where resource group name is 'rg-one'
+        - List resources where resource group name is 'rg-one' in location 'eastus'
         | Parameter | Required |
         | --- | --- |
         | resource group name | Yes |
+        | location | No |
 
         ## Show virtual machine
         <!-- @mcpcli compute show -->
         Example prompts include:
-        - Show the VM named 'vm-one'
+        - Show the VM named 'vm-one' in resource group 'rg-one'
         | Parameter | Required |
         | --- | --- |
         | vm name | Yes |
+        | resource group name | No |
 
         ## Related content
         - Link
@@ -412,26 +414,29 @@ public class ToolFamilyPostAssemblyValidatorTests
         ## List virtual machines
         <!-- @mcpcli compute list -->
         Example prompts include:
-        - List all virtual machines
+        - List all virtual machines in resource group 'rg-one'
         | Parameter | Required |
         | --- | --- |
         | subscription | No |
+        | resource group | No |
 
         ## Show virtual machine
         <!-- @mcpcli compute show -->
         Example prompts include:
-        - Show the VM named 'vm-one'
+        - Show the VM named 'vm-one' in resource group 'rg-one'
         | Parameter | Required |
         | --- | --- |
         | vm name | Yes |
+        | resource group | No |
 
         ## Delete virtual machine
         <!-- @mcpcli compute delete -->
         Example prompts include:
-        - Delete the VM named 'vm-test'
+        - Delete the VM named 'vm-test' in resource group 'rg-dev'
         | Parameter | Required |
         | --- | --- |
         | vm name | Yes |
+        | resource group | Yes |
 
         ## Related content
         - Link
@@ -448,18 +453,20 @@ public class ToolFamilyPostAssemblyValidatorTests
         ## List virtual machines
         <!-- @mcpcli compute list -->
         Example prompts include:
-        - List all virtual machines
+        - List all virtual machines in resource group 'rg-one'
         | Parameter | Required |
         | --- | --- |
         | subscription | No |
+        | resource group | No |
 
         ## Show virtual machine
         <!-- @mcpcli compute show -->
         Example prompts include:
-        - Show the VM named 'vm-one'
+        - Show the VM named 'vm-one' in resource group 'rg-one'
         | Parameter | Required |
         | --- | --- |
         | vm name | Yes |
+        | resource group | No |
 
         ## Related content
         - Link

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -413,7 +413,7 @@ public class ToolFamilyPostAssemblyValidatorTests
             Assert.False(result.Success);
             Assert.Contains(result.Warnings, warning => warning.Contains("example prompt header is Examples:", StringComparison.Ordinal));
             Assert.Contains(result.Warnings, warning =>
-                warning.StartsWith("Blocking: ⚠️", StringComparison.Ordinal)
+                warning.StartsWith("Blocking: 🛑", StringComparison.Ordinal)
                 && warning.Contains("missing 'resource group name'", StringComparison.Ordinal));
             Assert.Contains(result.Warnings, warning => warning.Contains("Branding: Use \"this tool\" instead of \"this command\".", StringComparison.Ordinal));
             Assert.Contains("Required params in prompts:", reportText, StringComparison.Ordinal);

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -50,7 +50,8 @@ public class ToolFamilyPostAssemblyValidatorTests
 
             Assert.True(result.Success);
             Assert.Contains(result.Warnings, warning =>
-                warning.Contains("Tone marker", StringComparison.Ordinal)
+                warning.StartsWith("⚠️ Tone marker", StringComparison.Ordinal)
+                && warning.Contains("Tone marker", StringComparison.Ordinal)
                 && warning.Contains("you can", StringComparison.OrdinalIgnoreCase));
         }
         finally
@@ -74,7 +75,8 @@ public class ToolFamilyPostAssemblyValidatorTests
 
             Assert.True(result.Success);
             Assert.Contains(result.Warnings, warning =>
-                warning.Contains("Tone marker", StringComparison.Ordinal)
+                warning.StartsWith("⚠️ Tone marker", StringComparison.Ordinal)
+                && warning.Contains("Tone marker", StringComparison.Ordinal)
                 && warning.Contains("you can", StringComparison.OrdinalIgnoreCase));
         }
         finally
@@ -121,6 +123,27 @@ public class ToolFamilyPostAssemblyValidatorTests
 
             Assert.True(result.Success);
             Assert.DoesNotContain(result.Warnings, warning => warning.Contains("Tone marker", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnbalancedFencedBlock_DoesNotThrow()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithUnbalancedFencedBlock());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.NotNull(result);
         }
         finally
         {
@@ -241,7 +264,8 @@ public class ToolFamilyPostAssemblyValidatorTests
 
             Assert.True(result.Success);
             Assert.Contains(result.Warnings, warning =>
-                warning.Contains("Related section", StringComparison.Ordinal)
+                warning.StartsWith("⚠️ Related section", StringComparison.Ordinal)
+                && warning.Contains("Related section", StringComparison.Ordinal)
                 && warning.Contains("absent", StringComparison.OrdinalIgnoreCase));
         }
         finally
@@ -323,6 +347,31 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_SectionWithNoParameterTable_TotalParameterCountIsZero()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithNoParameterTable());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("list", StringComparison.OrdinalIgnoreCase)
+                && (warning.Contains("0 documented parameter", StringComparison.OrdinalIgnoreCase)
+                    || warning.Contains("only 0", StringComparison.OrdinalIgnoreCase)));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_BlockingFailure_ReturnsFailedResult()
     {
         var testRoot = CreateTestRoot();
@@ -348,7 +397,7 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
-    public async Task ValidateAsync_WarningScenario_AccumulatesWarnings()
+    public async Task ValidateAsync_MissingRequiredParam_IsBlockingAndRenderedAsBlockingInReport()
     {
         var testRoot = CreateTestRoot();
         try
@@ -361,13 +410,40 @@ public class ToolFamilyPostAssemblyValidatorTests
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
             var reportText = File.ReadAllText(Path.Combine(context.OutputPath, "reports", "tool-family-validation-compute.txt"));
 
-            Assert.True(result.Success);
+            Assert.False(result.Success);
             Assert.Contains(result.Warnings, warning => warning.Contains("example prompt header is Examples:", StringComparison.Ordinal));
-            Assert.Contains(result.Warnings, warning => warning.Contains("missing 'resource group name'", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning =>
+                warning.StartsWith("Blocking: ⚠️", StringComparison.Ordinal)
+                && warning.Contains("missing 'resource group name'", StringComparison.Ordinal));
             Assert.Contains(result.Warnings, warning => warning.Contains("Branding: Use \"this tool\" instead of \"this command\".", StringComparison.Ordinal));
             Assert.Contains("Required params in prompts:", reportText, StringComparison.Ordinal);
-            Assert.Contains("⚠️ 0/1 tools have all required params in examples", reportText, StringComparison.Ordinal);
-            Assert.DoesNotContain("RESULT: FAIL", reportText, StringComparison.Ordinal);
+            Assert.Contains("❌ 0/1 tools have all required params in examples", reportText, StringComparison.Ordinal);
+            Assert.Contains("RESULT: FAIL", reportText, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnrelatedMultiwordRelatedTerm_DoesNotMatchByLastSegment()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-vm-show.md"), "compute vm show");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithUnrelatedMultiwordRelatedToolReference());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Contains("compute host show", StringComparison.OrdinalIgnoreCase)
+                && warning.Contains("related section", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -599,6 +675,29 @@ public class ToolFamilyPostAssemblyValidatorTests
         | --- | --- |
         | resource group | Yes |
         | location | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithUnbalancedFencedBlock()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+        ```csharp
+        var command = "compute list --resource-group rg-one";
 
         ## Related content
         - Link
@@ -853,6 +952,24 @@ public class ToolFamilyPostAssemblyValidatorTests
         - Link
         """;
 
+    private static string ArticleWithNoParameterTable()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one'
+        - Show virtual machines in location 'eastus'
+
+        ## Related content
+        - Link
+        """;
+
     private static string WarningArticleContent()
         => """
         ---
@@ -866,13 +983,43 @@ public class ToolFamilyPostAssemblyValidatorTests
         ## List virtual machines
         <!-- @mcpcli compute list -->
         Examples:
-        - List resources with <resource-group-name>
+        - List all compute resources in the current environment
         | Parameter | Required |
         | --- | --- |
         | resource group name | Yes |
 
         ## Related content
         - Link
+        """;
+
+    private static string ArticleWithUnrelatedMultiwordRelatedToolReference()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 2
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines where resource group name is 'rg-one' in location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+        | location | No |
+
+        ## Show VM details
+        <!-- @mcpcli compute vm show -->
+        Example prompts include:
+        - Show the VM named 'vm-one' in resource group 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+        | resource group | No |
+
+        ## Related content
+        - For a different workflow, see `compute host show`.
         """;
 
     private static void SeedToolFile(string path, string command)
@@ -900,7 +1047,7 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
-    public async Task ValidateAsync_GroupedArticleWithH2CategoriesAndH3Tools_CountsMarkers()
+    public async Task ValidateAsync_FlatArticleWithThreeToolSections_CountsMarkers()
     {
         var testRoot = CreateTestRoot();
         try
@@ -909,7 +1056,7 @@ public class ToolFamilyPostAssemblyValidatorTests
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-delete.md"), "compute delete");
-            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), GroupedArticleWithCategories());
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), FlatArticleWithThreeToolSections());
 
             var validator = new ToolFamilyPostAssemblyValidator();
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
@@ -930,7 +1077,7 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
-    public async Task ValidateAsync_GroupedArticleWithCorrectMarkerCount_PassesValidation()
+    public async Task ValidateAsync_FlatArticleWithCorrectMarkerCount_PassesValidation()
     {
         var testRoot = CreateTestRoot();
         try
@@ -938,7 +1085,7 @@ public class ToolFamilyPostAssemblyValidatorTests
             var context = CreateContext(testRoot);
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
-            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), GroupedArticleWithCorrectCount());
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), FlatArticleWithCorrectCount());
 
             var validator = new ToolFamilyPostAssemblyValidator();
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
@@ -958,7 +1105,7 @@ public class ToolFamilyPostAssemblyValidatorTests
         }
     }
 
-    private static string GroupedArticleWithCategories()
+    private static string FlatArticleWithThreeToolSections()
         => """
         ---
         title: Compute tools
@@ -997,7 +1144,7 @@ public class ToolFamilyPostAssemblyValidatorTests
         - Link
         """;
 
-    private static string GroupedArticleWithCorrectCount()
+    private static string FlatArticleWithCorrectCount()
         => """
         ---
         title: Compute tools

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -60,6 +60,30 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ToneMarkerInBulletItem_IsDetected()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithToneMarkerInBulletItem());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("Tone marker", StringComparison.Ordinal)
+                && warning.Contains("you can", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_ToneMarkerInTableRow_NotDetected()
     {
         var testRoot = CreateTestRoot();
@@ -68,6 +92,29 @@ public class ToolFamilyPostAssemblyValidatorTests
             var context = CreateContext(testRoot);
             SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
             SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithToneMarkerOnlyInTableRow());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("Tone marker", StringComparison.Ordinal));
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("documented parameter", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ToneMarkerInsideFencedCodeBlock_NotDetected()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithToneMarkerOnlyInFencedCodeBlock());
 
             var validator = new ToolFamilyPostAssemblyValidator();
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
@@ -130,6 +177,56 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_SpaceFormInternalToolReferencedInRelatedSection_WithNoH2_IsBlocking()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute show");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithSpaceFormInternalRelatedToolMissingH2());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("Blocking: 🛑 'compute show' is referenced in the related section", StringComparison.OrdinalIgnoreCase)
+                && warning.Contains("no matching H2 section", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InternalToolReferencedInRelatedSection_WithMatchingH2_NotFlagged()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute compute-list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute compute-show");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithInternalRelatedToolMatchingH2());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Contains("compute-show", StringComparison.OrdinalIgnoreCase)
+                && warning.Contains("no matching H2 section", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_MissingRelatedSection_ReturnsWarning()
     {
         var testRoot = CreateTestRoot();
@@ -154,6 +251,28 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_AlternateExampleHeader_NotBlocking()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithAlternateExampleHeader());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("no example prompt header", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_ToolWithNoExampleHeader_IsBlocking()
     {
         var testRoot = CreateTestRoot();
@@ -170,6 +289,32 @@ public class ToolFamilyPostAssemblyValidatorTests
             Assert.Contains(result.Warnings, warning =>
                 warning.Contains("list", StringComparison.OrdinalIgnoreCase)
                 && warning.Contains("no example prompt header", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ToolWithOneParameter_EmitsLowParamWarning()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithOneParameter());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                (warning.Contains("compute-list", StringComparison.OrdinalIgnoreCase)
+                    || warning.Contains("list", StringComparison.OrdinalIgnoreCase))
+                && (warning.Contains("1 documented parameter", StringComparison.OrdinalIgnoreCase)
+                    || warning.Contains("only 1", StringComparison.OrdinalIgnoreCase)));
         }
         finally
         {
@@ -214,11 +359,15 @@ public class ToolFamilyPostAssemblyValidatorTests
 
             var validator = new ToolFamilyPostAssemblyValidator();
             var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+            var reportText = File.ReadAllText(Path.Combine(context.OutputPath, "reports", "tool-family-validation-compute.txt"));
 
-            Assert.False(result.Success);
+            Assert.True(result.Success);
             Assert.Contains(result.Warnings, warning => warning.Contains("example prompt header is Examples:", StringComparison.Ordinal));
             Assert.Contains(result.Warnings, warning => warning.Contains("missing 'resource group name'", StringComparison.Ordinal));
             Assert.Contains(result.Warnings, warning => warning.Contains("Branding: Use \"this tool\" instead of \"this command\".", StringComparison.Ordinal));
+            Assert.Contains("Required params in prompts:", reportText, StringComparison.Ordinal);
+            Assert.Contains("⚠️ 0/1 tools have all required params in examples", reportText, StringComparison.Ordinal);
+            Assert.DoesNotContain("RESULT: FAIL", reportText, StringComparison.Ordinal);
         }
         finally
         {
@@ -409,6 +558,52 @@ public class ToolFamilyPostAssemblyValidatorTests
         - Link
         """;
 
+    private static string ArticleWithToneMarkerInBulletItem()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - you can list VMs by resource group
+        - List virtual machines where resource group name is 'rg-one' in location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+        | location | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithToneMarkerOnlyInFencedCodeBlock()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        ```text
+        you can use this example as a placeholder inside the code block
+        ```
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+
+        ## Related content
+        - Link
+        """;
+
     private static PipelineContext CreateContext(string testRoot)
     {
         var outputPath = Path.Combine(testRoot, "generated-compute");
@@ -528,6 +723,57 @@ public class ToolFamilyPostAssemblyValidatorTests
         - Use `compute-show` when you need details for a single virtual machine.
         """;
 
+    private static string ArticleWithSpaceFormInternalRelatedToolMissingH2()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 2
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+
+        ## Related content
+        - Use `compute show` when you need details for a single virtual machine.
+        """;
+
+    private static string ArticleWithInternalRelatedToolMatchingH2()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 2
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute compute-list -->
+        Example prompts include:
+        - List virtual machines where resource group name is 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+        | location | No |
+
+        ## Show virtual machine
+        <!-- @mcpcli compute compute-show -->
+        Example prompts include:
+        - Show the virtual machine where vm name is 'vm-one' in resource group name 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vm name | Yes |
+        | resource group name | No |
+
+        ## Related content
+        - Use `compute-show` when you need details for a single virtual machine.
+        """;
+
     private static string ArticleWithoutRelatedSection()
         => """
         ---
@@ -561,6 +807,47 @@ public class ToolFamilyPostAssemblyValidatorTests
         | --- | --- |
         | resource group | Yes |
         | location | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithAlternateExampleHeader()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Examples:
+        - List virtual machines where resource group name is 'rg-one' in location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+        | location | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithOneParameter()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines where resource group name is 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
 
         ## Related content
         - Link

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -36,6 +36,148 @@ public class ToolFamilyPostAssemblyValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ToneMarkerPhrase_ReturnsWarning()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithToneMarkerPhrase());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("Tone marker", StringComparison.Ordinal)
+                && warning.Contains("you can", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ToneMarkerInTableRow_NotDetected()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithToneMarkerOnlyInTableRow());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("Tone marker", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ExternalToolReferenceInRelatedSection_NotFlagged()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithExternalRelatedToolReferences());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("az vm list", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("referenced in related section", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InternalToolReferencedInRelatedSection_WithNoH2_IsBlocking()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute compute-list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-show.md"), "compute compute-show");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithInternalRelatedToolMissingH2());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("'compute-show' is referenced in the related section", StringComparison.OrdinalIgnoreCase)
+                && warning.Contains("no matching H2 section", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingRelatedSection_ReturnsWarning()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithoutRelatedSection());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("Related section", StringComparison.Ordinal)
+                && warning.Contains("absent", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ToolWithNoExampleHeader_IsBlocking()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ArticleWithMissingExampleHeader());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("list", StringComparison.OrdinalIgnoreCase)
+                && warning.Contains("no example prompt header", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_BlockingFailure_ReturnsFailedResult()
     {
         var testRoot = CreateTestRoot();
@@ -221,6 +363,52 @@ public class ToolFamilyPostAssemblyValidatorTests
         - Link
         """;
 
+    private static string ArticleWithToneMarkerPhrase()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        You can list virtual machines by resource group and location.
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithToneMarkerOnlyInTableRow()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Note | Guidance |
+        | --- | --- |
+        | example | you can use this row for formatting only |
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+
+        ## Related content
+        - Link
+        """;
+
     private static PipelineContext CreateContext(string testRoot)
     {
         var outputPath = Path.Combine(testRoot, "generated-compute");
@@ -293,6 +481,86 @@ public class ToolFamilyPostAssemblyValidatorTests
         | Parameter | Required |
         | --- | --- |
         | resource group name | Yes |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string ArticleWithExternalRelatedToolReferences()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List resources where resource group name is 'rg-one' in location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group name | Yes |
+        | location | No |
+
+        ## Related content
+        - For cross-namespace workflows, see `monitor query` and `az vm list`.
+        """;
+
+    private static string ArticleWithInternalRelatedToolMissingH2()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 2
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute compute-list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+
+        ## Related content
+        - Use `compute-show` when you need details for a single virtual machine.
+        """;
+
+    private static string ArticleWithoutRelatedSection()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Example prompts include:
+        - List virtual machines in resource group 'rg-one' for location 'eastus'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
+        """;
+
+    private static string ArticleWithMissingExampleHeader()
+        => """
+        ---
+        title: Compute tools
+        tool_count: 1
+        ---
+        # Compute tools
+
+        ## List virtual machines
+        <!-- @mcpcli compute list -->
+        Use this tool to list virtual machines by resource group and location.
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | Yes |
+        | location | No |
 
         ## Related content
         - Link

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGatePipelineTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ValidationGatePipelineTests.cs
@@ -278,12 +278,19 @@ public class ValidationGatePipelineTests
                 Array.Empty<ArtifactFailure>()));
     }
 
-    private sealed class OrderTrackingStep(int id, string name, StepScope scope, List<string> order)
-        : StepDefinition(id, name, scope, FailurePolicy.Fatal)
+    private sealed class OrderTrackingStep : StepDefinition
     {
+        private readonly List<string> _order;
+
+        public OrderTrackingStep(int id, string name, StepScope scope, List<string> order)
+            : base(id, name, scope, FailurePolicy.Fatal)
+        {
+            _order = order;
+        }
+
         public override ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken ct)
         {
-            order.Add($"step:{id}");
+            _order.Add($"step:{Id}");
             return ValueTask.FromResult(new StepResult(true, Array.Empty<string>(), TimeSpan.Zero,
                 Array.Empty<string>(), Array.Empty<string>(), Array.Empty<ValidatorResult>(),
                 Array.Empty<ArtifactFailure>()));

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -142,11 +142,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     blockingIssues.Add($"Cross-reference check failed. {string.Join(". ", parts)}.");
                 }
 
-                // With section freezing (AD-017), missing required params
-                // indicates a freeze failure — treat as blocking error.
+                // Missing required params in example prompts are surfaced as warnings
+                // and rendered in the report's required-params section.
                 foreach (var warning in GetRequiredParameterWarnings(sections))
                 {
-                    blockingIssues.Add(warning);
+                    warningIssues.Add(warning);
                 }
 
                 foreach (var warning in GetExampleHeaderWarnings(sections))
@@ -185,7 +185,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                 var lowParamCountWarnings = GetLowParameterCountWarnings(sections);
                 warningIssues.AddRange(lowParamCountWarnings);
 
-                var newChecks = new NewCheckResults(
+                var postAssemblyChecks = new PostAssemblyCheckSummary(
                     relatedToolsIssues,
                     toneMarkerWarnings,
                     boilerplateWarnings,
@@ -203,7 +203,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     blockingIssues,
                     warningIssues,
                     brandingIssues,
-                    newChecks));
+                    postAssemblyChecks));
 
                 await WriteReportAsync(reportDirectory, reportPath, reportLines, cancellationToken);
             }
@@ -465,68 +465,89 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
     private static IReadOnlyList<ParameterRow> GetSectionParameterRows(IReadOnlyList<string> lines)
     {
-        var tableLines = new List<string>();
-        var tableStarted = false;
-        foreach (var line in lines)
-        {
-            var trimmed = line.Trim();
-            if (trimmed.StartsWith('|'))
-            {
-                tableStarted = true;
-                tableLines.Add(trimmed);
-                continue;
-            }
-
-            if (tableStarted)
-            {
-                break;
-            }
-        }
-
-        if (tableLines.Count < 2)
-        {
-            return Array.Empty<ParameterRow>();
-        }
-
-        var headerCells = ConvertTableLineToCells(tableLines[0]);
-        var parameterIndex = -1;
-        var requiredIndex = -1;
-        for (var index = 0; index < headerCells.Count; index++)
-        {
-            var header = ParameterCoverageChecker.RemoveMarkup(headerCells[index]);
-            if (Regex.IsMatch(header, "(?i)^parameter$"))
-            {
-                parameterIndex = index;
-            }
-            if (Regex.IsMatch(header, "(?i)required"))
-            {
-                requiredIndex = index;
-            }
-        }
-
-        if (parameterIndex < 0 || requiredIndex < 0)
-        {
-            return Array.Empty<ParameterRow>();
-        }
-
         var rows = new List<ParameterRow>();
-        foreach (var line in tableLines.Skip(1))
+
+        static bool IsTableLine(string line)
+            => line.Trim().StartsWith('|');
+
+        static bool IsSeparatorLine(string line)
+            => Regex.IsMatch(line.Trim(), "^\\|\\s*[-: ]+\\|");
+
+        static void AddParameterRowsFromTable(List<string> sourceTableLines, List<ParameterRow> targetRows)
         {
-            if (Regex.IsMatch(line, "^\\|\\s*[-: ]+\\|"))
+            if (sourceTableLines.Count < 2)
+            {
+                return;
+            }
+
+            var headerCells = ConvertTableLineToCells(sourceTableLines[0]);
+            var parameterIndex = -1;
+            var requiredIndex = -1;
+            for (var index = 0; index < headerCells.Count; index++)
+            {
+                var header = ParameterCoverageChecker.RemoveMarkup(headerCells[index]);
+                if (Regex.IsMatch(header, "(?i)^parameter$"))
+                {
+                    parameterIndex = index;
+                }
+                if (Regex.IsMatch(header, "(?i)required"))
+                {
+                    requiredIndex = index;
+                }
+            }
+
+            if (parameterIndex < 0 || requiredIndex < 0)
+            {
+                return;
+            }
+
+            foreach (var line in sourceTableLines.Skip(1))
+            {
+                if (Regex.IsMatch(line, "^\\|\\s*[-: ]+\\|"))
+                {
+                    continue;
+                }
+
+                var cells = ConvertTableLineToCells(line);
+                if (cells.Count <= Math.Max(parameterIndex, requiredIndex))
+                {
+                    continue;
+                }
+
+                var parameterName = ParameterCoverageChecker.RemoveMarkup(cells[parameterIndex]);
+                var requiredValue = ParameterCoverageChecker.RemoveMarkup(cells[requiredIndex]);
+                var isRequired = Regex.IsMatch(requiredValue, "(?i)^(yes|✅|required\\*?)$") || Regex.IsMatch(requiredValue, "(?i)^required");
+                targetRows.Add(new ParameterRow(parameterName, requiredValue, isRequired));
+            }
+        }
+
+        for (var index = 0; index < lines.Count - 1; index++)
+        {
+            if (!IsTableLine(lines[index]) || !IsSeparatorLine(lines[index + 1]))
             {
                 continue;
             }
 
-            var cells = ConvertTableLineToCells(line);
-            if (cells.Count <= Math.Max(parameterIndex, requiredIndex))
+            var tableLines = new List<string>
             {
-                continue;
+                lines[index].Trim(),
+                lines[index + 1].Trim(),
+            };
+
+            var rowIndex = index + 2;
+            while (rowIndex < lines.Count && IsTableLine(lines[rowIndex]))
+            {
+                if (rowIndex + 1 < lines.Count && IsTableLine(lines[rowIndex]) && IsSeparatorLine(lines[rowIndex + 1]))
+                {
+                    break;
+                }
+
+                tableLines.Add(lines[rowIndex].Trim());
+                rowIndex++;
             }
 
-            var parameterName = ParameterCoverageChecker.RemoveMarkup(cells[parameterIndex]);
-            var requiredValue = ParameterCoverageChecker.RemoveMarkup(cells[requiredIndex]);
-            var isRequired = Regex.IsMatch(requiredValue, "(?i)^(yes|✅|required\\*?)$") || Regex.IsMatch(requiredValue, "(?i)^required");
-            rows.Add(new ParameterRow(parameterName, requiredValue, isRequired));
+            AddParameterRowsFromTable(tableLines, rows);
+            index = rowIndex - 1;
         }
 
         return rows;
@@ -579,7 +600,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             {
                 var suffix = missingParameters.Count > 1 ? "s" : string.Empty;
                 var joined = string.Join(", ", missingParameters.Select(parameter => $"'{parameter}'"));
-                warnings.Add($"🛑 {section.ToolKey}: missing {joined} in example prompt{suffix} (section freeze failure)");
+                warnings.Add($"⚠️ {section.ToolKey}: missing {joined} in example prompt{suffix}");
             }
         }
 
@@ -741,14 +762,14 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         reportLines.Add(string.Empty);
 
         // 6 new post-assembly checks (PRD-QUALITY Item C)
-        AppendPassFailSection(reportLines, "Related tools completeness", ctx.NewChecks.RelatedToolsIssues);
-        AppendCountSection(reportLines, "Tone markers", ctx.NewChecks.ToneMarkerWarnings, isBlocking: false);
-        AppendCountSection(reportLines, "Boilerplate redundancy", ctx.NewChecks.BoilerplateWarnings, isBlocking: false);
-        reportLines.Add(ctx.NewChecks.HasRelatedSection
+        AppendPassFailSection(reportLines, "Related tools completeness", ctx.PostAssemblyChecks.RelatedToolsIssues);
+        AppendCountSection(reportLines, "Tone markers", ctx.PostAssemblyChecks.ToneMarkerWarnings, isBlocking: false);
+        AppendCountSection(reportLines, "Boilerplate redundancy", ctx.PostAssemblyChecks.BoilerplateWarnings, isBlocking: false);
+        reportLines.Add(ctx.PostAssemblyChecks.HasRelatedSection
             ? "Related section header: ✅ present"
             : "Related section header: ⚠️ absent");
-        AppendRatioSection(reportLines, "Tool examples", ctx.NewChecks.MissingExampleIssues, ctx.Sections.Count, isBlocking: true, itemDescription: "tools have examples");
-        AppendRatioSection(reportLines, "Parameter count", ctx.NewChecks.LowParamCountWarnings, ctx.Sections.Count, isBlocking: false, itemDescription: "tools have ≥2 parameters");
+        AppendRatioSection(reportLines, "Tool examples", ctx.PostAssemblyChecks.MissingExampleIssues, ctx.Sections.Count, isBlocking: true, itemDescription: "tools have examples");
+        AppendRatioSection(reportLines, "Parameter count", ctx.PostAssemblyChecks.LowParamCountWarnings, ctx.Sections.Count, isBlocking: false, itemDescription: "tools have ≥2 parameters");
         reportLines.Add(string.Empty);
 
         if (ctx.BlockingIssues.Count == 0)
@@ -784,9 +805,10 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         IReadOnlyList<ArticleSection> sections,
         IReadOnlyList<NamespaceToolFile> toolFiles)
     {
-        // Checks that backtick terms in the related section which reference THIS family's own tools
-        // are present as H2 sections. External tool references (other namespaces, Azure CLI commands,
-        // etc.) are skipped because they won't match this family's tool keys.
+        // Checks backtick terms in the related section that match THIS family's tool keys.
+        // External references (other namespaces, Azure CLI commands, etc.) are typically skipped
+        // because they don't match this family's keys, but short or coincidentally matching
+        // terms could produce false positives.
         if (string.IsNullOrWhiteSpace(relatedSectionText))
         {
             return Array.Empty<string>();
@@ -816,8 +838,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         foreach (var term in backtickTerms)
         {
             var normalizedTerm = term.Replace(' ', '-');
+            var normalizedSegments = normalizedTerm.Split('-', StringSplitOptions.RemoveEmptyEntries);
+            var termLastSegment = normalizedSegments.Length > 0 ? normalizedSegments[^1] : normalizedTerm;
             var isInternalTool = familyToolKeys.Any(key =>
                 string.Equals(key, normalizedTerm, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(key, termLastSegment, StringComparison.OrdinalIgnoreCase)
                 || key.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase));
             if (!isInternalTool)
             {
@@ -826,10 +851,12 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
             var found = sections.Any(s =>
                 s.Heading.Contains(term, StringComparison.OrdinalIgnoreCase)
-                || s.ToolKey.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase));
+                || s.Heading.Contains(termLastSegment, StringComparison.OrdinalIgnoreCase)
+                || s.ToolKey.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase)
+                || s.ToolKey.Contains(termLastSegment, StringComparison.OrdinalIgnoreCase));
             if (!found)
             {
-                issues.Add($"⚠️ '{term}' is referenced in the related section but has no matching H2 section in this article");
+                issues.Add($"🛑 '{term}' is referenced in the related section but has no matching H2 section in this article");
             }
         }
 
@@ -840,14 +867,46 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
     {
         var warnings = new List<string>();
         var normalized = articleContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var inFencedBlock = false;
+        var inHtmlCommentBlock = false;
         foreach (var line in normalized.Split('\n'))
         {
             var trimmed = line.Trim();
+
+            if (trimmed.StartsWith("```", StringComparison.Ordinal))
+            {
+                inFencedBlock = !inFencedBlock;
+                continue;
+            }
+
+            if (inFencedBlock)
+            {
+                continue;
+            }
+
+            if (inHtmlCommentBlock)
+            {
+                if (trimmed.Contains("-->", StringComparison.Ordinal))
+                {
+                    inHtmlCommentBlock = false;
+                }
+
+                continue;
+            }
+
+            if (trimmed.StartsWith("<!--", StringComparison.Ordinal))
+            {
+                if (!trimmed.Contains("-->", StringComparison.Ordinal))
+                {
+                    inHtmlCommentBlock = true;
+                }
+
+                continue;
+            }
+
             if (string.IsNullOrWhiteSpace(trimmed)
                 || trimmed.StartsWith('|')
-                || trimmed.StartsWith('#')
-                || trimmed.StartsWith("```", StringComparison.Ordinal)
-                || trimmed.StartsWith("<!-- ", StringComparison.Ordinal))
+                || trimmed.StartsWith('#'))
             {
                 continue;
             }
@@ -874,7 +933,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
     private static IReadOnlyList<string> GetBoilerplateRedundancyWarnings()
     {
         // Placeholder: boilerplate redundancy check not yet implemented.
-        // Tracked for future implementation — always returns empty for now.
+        // Tracked in #662 — always returns empty for now.
         return Array.Empty<string>();
     }
 
@@ -966,7 +1025,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         bool HasRelatedSection,
         string RelatedSectionText);
 
-    private sealed record NewCheckResults(
+    private sealed record PostAssemblyCheckSummary(
         IReadOnlyList<string> RelatedToolsIssues,
         IReadOnlyList<string> ToneMarkerWarnings,
         IReadOnlyList<string> BoilerplateWarnings,
@@ -984,7 +1043,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         IReadOnlyList<string> BlockingIssues,
         IReadOnlyList<string> WarningIssues,
         IReadOnlyList<string> BrandingIssues,
-        NewCheckResults NewChecks);
+        PostAssemblyCheckSummary PostAssemblyChecks);
 
     private sealed record BrandingRule(string PatternText, string Message)
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -14,6 +14,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
     private static readonly Regex FrontmatterRegex = new(@"^---\s*\n(.*?)\n---\s*\n?", RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex HeadingRegex = new(@"(?m)^##\s+(.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex McpCliRegex = new(@"(?m)^\s*<!--\s*@mcpcli\s+(.+?)\s*-->$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FencedCodeDelimiterRegex = new(@"^`{3,}(?:\s*[A-Za-z0-9_-]+)?\s*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly BrandingRule[] BrandingRules =
     [
@@ -42,6 +43,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var blockingIssues = new List<string>();
         var warningIssues = new List<string>();
         var brandingIssues = new List<string>();
+        var requiredParamIssues = new List<string>();
         var toolFiles = Array.Empty<NamespaceToolFile>();
         var sections = Array.Empty<ArticleSection>();
         var toolFileCount = 0;
@@ -142,11 +144,10 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     blockingIssues.Add($"Cross-reference check failed. {string.Join(". ", parts)}.");
                 }
 
-                // Missing required params in example prompts are surfaced as warnings
-                // and rendered in the report's required-params section.
-                foreach (var warning in GetRequiredParameterWarnings(sections))
+                foreach (var issue in GetRequiredParameterIssues(sections))
                 {
-                    warningIssues.Add(warning);
+                    requiredParamIssues.Add(issue);
+                    blockingIssues.Add(issue);
                 }
 
                 foreach (var warning in GetExampleHeaderWarnings(sections))
@@ -202,6 +203,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     missingFromFiles,
                     blockingIssues,
                     warningIssues,
+                    requiredParamIssues,
                     brandingIssues,
                     postAssemblyChecks));
 
@@ -373,6 +375,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             var exampleHeaderIndex = -1;
             var tableStartIndex = -1;
             string? alternateExampleHeader = null;
+            var alternateExampleHeaderIndex = -1;
 
             for (var lineIndex = 0; lineIndex < sectionLines.Length; lineIndex++)
             {
@@ -392,10 +395,14 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                 if (alternateExampleHeader is null && Regex.IsMatch(trimmed, "^(?i)(example prompts|example commands|usage examples|examples|try this|to .* use commands like):"))
                 {
                     alternateExampleHeader = trimmed;
+                    alternateExampleHeaderIndex = lineIndex;
                 }
             }
 
-            var examplePrompts = ExtractExamplePrompts(sectionLines, exampleHeaderIndex);
+            var examplePromptStartIndex = exampleHeaderIndex >= 0
+                ? exampleHeaderIndex
+                : alternateExampleHeaderIndex;
+            var examplePrompts = ExtractExamplePrompts(sectionLines, examplePromptStartIndex);
             var parameterRows = GetSectionParameterRows(sectionLines);
             var requiredParameters = parameterRows
                 .Where(row => row.IsRequired)
@@ -576,9 +583,9 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         => sections.GroupBy(section => section.ToolKey, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
 
-    private static IReadOnlyList<string> GetRequiredParameterWarnings(IEnumerable<ArticleSection> sections)
+    private static IReadOnlyList<string> GetRequiredParameterIssues(IEnumerable<ArticleSection> sections)
     {
-        var warnings = new List<string>();
+        var issues = new List<string>();
         foreach (var section in sections)
         {
             if (section.RequiredParameters.Count == 0)
@@ -600,11 +607,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             {
                 var suffix = missingParameters.Count > 1 ? "s" : string.Empty;
                 var joined = string.Join(", ", missingParameters.Select(parameter => $"'{parameter}'"));
-                warnings.Add($"⚠️ {section.ToolKey}: missing {joined} in example prompt{suffix}");
+                issues.Add($"⚠️ {section.ToolKey}: missing {joined} in example prompt{suffix}");
             }
         }
 
-        return warnings;
+        return issues;
     }
 
     private static IReadOnlyList<string> GetExampleHeaderWarnings(IEnumerable<ArticleSection> sections)
@@ -739,12 +746,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
         reportLines.Add(string.Empty);
         reportLines.Add("Required params in prompts:");
-        var requiredParamWarnings = ctx.WarningIssues.Where(issue => issue.Contains("missing", StringComparison.OrdinalIgnoreCase)).ToArray();
-        var requiredParamsPassingTools = ctx.Sections.Count - requiredParamWarnings.Length;
-        reportLines.Add(requiredParamWarnings.Length == 0
+        var requiredParamsPassingTools = ctx.Sections.Count - ctx.RequiredParamIssues.Count;
+        reportLines.Add(ctx.RequiredParamIssues.Count == 0
             ? $"  ✅ {requiredParamsPassingTools}/{ctx.Sections.Count} tools have all required params in examples"
-            : $"  ⚠️ {requiredParamsPassingTools}/{ctx.Sections.Count} tools have all required params in examples");
-        reportLines.AddRange(requiredParamWarnings.Select(warning => $"  {warning}"));
+            : $"  ❌ {requiredParamsPassingTools}/{ctx.Sections.Count} tools have all required params in examples");
+        reportLines.AddRange(ctx.RequiredParamIssues.Select(issue => $"  {issue}"));
 
         reportLines.Add(string.Empty);
         var markerWarnings = ctx.WarningIssues.Where(issue => issue.Contains("annotation marker", StringComparison.OrdinalIgnoreCase)).ToArray();
@@ -765,9 +771,10 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         AppendPassFailSection(reportLines, "Related tools completeness", ctx.PostAssemblyChecks.RelatedToolsIssues);
         AppendCountSection(reportLines, "Tone markers", ctx.PostAssemblyChecks.ToneMarkerWarnings, isBlocking: false);
         AppendCountSection(reportLines, "Boilerplate redundancy", ctx.PostAssemblyChecks.BoilerplateWarnings, isBlocking: false);
-        reportLines.Add(ctx.PostAssemblyChecks.HasRelatedSection
-            ? "Related section header: ✅ present"
-            : "Related section header: ⚠️ absent");
+        var relatedSectionIssues = ctx.PostAssemblyChecks.HasRelatedSection
+            ? Array.Empty<string>()
+            : ["Related section header absent"];
+        AppendCountSection(reportLines, "Related section header", relatedSectionIssues, isBlocking: false);
         AppendRatioSection(reportLines, "Tool examples", ctx.PostAssemblyChecks.MissingExampleIssues, ctx.Sections.Count, isBlocking: true, itemDescription: "tools have examples");
         AppendRatioSection(reportLines, "Parameter count", ctx.PostAssemblyChecks.LowParamCountWarnings, ctx.Sections.Count, isBlocking: false, itemDescription: "tools have ≥2 parameters");
         reportLines.Add(string.Empty);
@@ -837,23 +844,14 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var issues = new List<string>();
         foreach (var term in backtickTerms)
         {
-            var normalizedTerm = term.Replace(' ', '-');
-            var normalizedSegments = normalizedTerm.Split('-', StringSplitOptions.RemoveEmptyEntries);
-            var termLastSegment = normalizedSegments.Length > 0 ? normalizedSegments[^1] : normalizedTerm;
-            var isInternalTool = familyToolKeys.Any(key =>
-                string.Equals(key, normalizedTerm, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(key, termLastSegment, StringComparison.OrdinalIgnoreCase)
-                || key.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase));
+            var normalizedTerm = ParameterCoverageChecker.ConvertToSlug(term);
+            var isInternalTool = familyToolKeys.Any(key => MatchesRelatedToolKey(key, normalizedTerm));
             if (!isInternalTool)
             {
                 continue;
             }
 
-            var found = sections.Any(s =>
-                s.Heading.Contains(term, StringComparison.OrdinalIgnoreCase)
-                || s.Heading.Contains(termLastSegment, StringComparison.OrdinalIgnoreCase)
-                || s.ToolKey.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase)
-                || s.ToolKey.Contains(termLastSegment, StringComparison.OrdinalIgnoreCase));
+            var found = sections.Any(s => MatchesRelatedToolKey(s.ToolKey, normalizedTerm));
             if (!found)
             {
                 issues.Add($"🛑 '{term}' is referenced in the related section but has no matching H2 section in this article");
@@ -873,7 +871,9 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         {
             var trimmed = line.Trim();
 
-            if (trimmed.StartsWith("```", StringComparison.Ordinal))
+            // Standard Markdown fenced blocks are supported here.
+            // Nested 3-backtick fences inside 4+ backtick fences are not supported and are not expected in generated articles.
+            if (FencedCodeDelimiterRegex.IsMatch(trimmed))
             {
                 inFencedBlock = !inFencedBlock;
                 continue;
@@ -915,7 +915,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             {
                 if (trimmed.Contains(phrase, StringComparison.OrdinalIgnoreCase))
                 {
-                    warnings.Add($"Tone marker: second-person phrase '{phrase}' found: [{trimmed}]");
+                    warnings.Add($"⚠️ Tone marker: second-person phrase '{phrase}' found: [{trimmed}]");
                     break;
                 }
             }
@@ -923,7 +923,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             var match = ToneMarkerSuperlativeRegex.Match(trimmed);
             if (match.Success)
             {
-                warnings.Add($"Tone marker: prohibited superlative '{match.Value}' found: [{trimmed}]");
+                warnings.Add($"⚠️ Tone marker: prohibited superlative '{match.Value}' found: [{trimmed}]");
             }
         }
 
@@ -940,7 +940,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
     private static IReadOnlyList<string> GetRelatedSectionHeaderWarnings(bool hasRelatedSection)
         => hasRelatedSection
             ? Array.Empty<string>()
-            : new[] { "Related section header absent: article is missing a '## See also' or '## Related content' section" };
+            : new[] { "⚠️ Related section header absent: article is missing a '## See also' or '## Related content' section" };
 
     private static IReadOnlyList<string> GetMissingExampleIssues(IReadOnlyList<ArticleSection> sections)
     {
@@ -969,6 +969,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
         return warnings;
     }
+
+    private static bool MatchesRelatedToolKey(string candidateKey, string normalizedTerm)
+        => string.Equals(candidateKey, normalizedTerm, StringComparison.OrdinalIgnoreCase)
+            || normalizedTerm.EndsWith("-" + candidateKey, StringComparison.OrdinalIgnoreCase)
+            || candidateKey.EndsWith("-" + normalizedTerm, StringComparison.OrdinalIgnoreCase);
 
 
     private static async Task WriteReportAsync(string reportDirectory, string reportPath, IReadOnlyList<string> reportLines, CancellationToken cancellationToken)
@@ -1042,6 +1047,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         IReadOnlyList<string> MissingFromFiles,
         IReadOnlyList<string> BlockingIssues,
         IReadOnlyList<string> WarningIssues,
+        IReadOnlyList<string> RequiredParamIssues,
         IReadOnlyList<string> BrandingIssues,
         PostAssemblyCheckSummary PostAssemblyChecks);
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -24,6 +24,10 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         new(@"\bFoundry\b", "Verify first mention uses the full product name (for example, \"Microsoft Foundry\")."),
     ];
 
+    private static readonly Regex BacktickTermRegex = new(@"`([^`]{4,})`", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly string[] ToneMarkerPhrases = ["you can", "you will", "you use", "you should"];
+    private static readonly Regex ToneMarkerSuperlativeRegex = new(@"\b(powerful|seamless|cutting-edge|game-changing)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     public string Name => "ToolFamilyPostAssemblyValidator";
 
     public async ValueTask<ValidatorResult> ValidateAsync(PipelineContext context, IPipelineStep step, CancellationToken cancellationToken)
@@ -157,6 +161,38 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
                 brandingIssues.AddRange(GetBrandingIssues(articleContent));
 
+                var relatedToolsIssues = GetRelatedToolsCompletenessIssues(article.RelatedSectionText, sections);
+                foreach (var issue in relatedToolsIssues)
+                {
+                    blockingIssues.Add(issue);
+                }
+
+                var toneMarkerWarnings = GetToneMarkerWarnings(articleContent);
+                warningIssues.AddRange(toneMarkerWarnings);
+
+                var boilerplateWarnings = await GetBoilerplateRedundancyWarningsAsync(familyName, context, cancellationToken);
+                warningIssues.AddRange(boilerplateWarnings);
+
+                var relatedSectionWarnings = GetRelatedSectionHeaderWarnings(article.HasRelatedSection);
+                warningIssues.AddRange(relatedSectionWarnings);
+
+                var missingExampleIssues = GetMissingExampleIssues(sections);
+                foreach (var issue in missingExampleIssues)
+                {
+                    blockingIssues.Add(issue);
+                }
+
+                var lowParamCountWarnings = GetLowParameterCountWarnings(sections);
+                warningIssues.AddRange(lowParamCountWarnings);
+
+                var newChecks = new NewCheckResults(
+                    relatedToolsIssues,
+                    toneMarkerWarnings,
+                    boilerplateWarnings,
+                    article.HasRelatedSection,
+                    missingExampleIssues,
+                    lowParamCountWarnings);
+
                 var reportLines = BuildReportLines(
                     familyName,
                     toolFiles,
@@ -166,7 +202,8 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     missingFromFiles,
                     blockingIssues,
                     warningIssues,
-                    brandingIssues);
+                    brandingIssues,
+                    newChecks);
 
                 await WriteReportAsync(reportDirectory, reportPath, reportLines, cancellationToken);
             }
@@ -307,17 +344,24 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var body = normalized[frontmatterMatch.Length..];
         var headingMatches = HeadingRegex.Matches(body);
         var sections = new List<ArticleSection>();
+        var hasRelatedSection = false;
+        var relatedSectionText = string.Empty;
 
         for (var index = 0; index < headingMatches.Count; index++)
         {
             var heading = headingMatches[index].Groups[1].Value.Trim();
-            if (string.Equals(heading, "Related content", StringComparison.OrdinalIgnoreCase))
+            var startIndex = headingMatches[index].Index;
+            var endIndex = index < headingMatches.Count - 1 ? headingMatches[index + 1].Index : body.Length;
+
+            if (string.Equals(heading, "Related content", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(heading, "See also", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(heading, "Related tools", StringComparison.OrdinalIgnoreCase))
             {
+                hasRelatedSection = true;
+                relatedSectionText = body.Substring(startIndex, endIndex - startIndex).TrimEnd();
                 continue;
             }
 
-            var startIndex = headingMatches[index].Index;
-            var endIndex = index < headingMatches.Count - 1 ? headingMatches[index + 1].Index : body.Length;
             var sectionText = body.Substring(startIndex, endIndex - startIndex).TrimEnd();
             var sectionLines = sectionText.Split('\n');
             var commands = GetMcpCliCommands(sectionText);
@@ -352,7 +396,8 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             }
 
             var examplePrompts = ExtractExamplePrompts(sectionLines, exampleHeaderIndex);
-            var requiredParameters = GetSectionParameterRows(sectionLines)
+            var parameterRows = GetSectionParameterRows(sectionLines);
+            var requiredParameters = parameterRows
                 .Where(row => row.IsRequired)
                 .Select(row => row.ParameterName)
                 .ToArray();
@@ -367,10 +412,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                 tableStartIndex,
                 alternateExampleHeader,
                 examplePrompts,
-                requiredParameters));
+                requiredParameters,
+                parameterRows.Count));
         }
 
-        return new ParsedArticle(frontmatter, sections);
+        return new ParsedArticle(frontmatter, sections, hasRelatedSection, relatedSectionText);
     }
 
     private static IReadOnlyList<string> ExtractExamplePrompts(IReadOnlyList<string> sectionLines, int exampleHeaderIndex)
@@ -614,7 +660,8 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         IReadOnlyList<string> missingFromFiles,
         IReadOnlyList<string> blockingIssues,
         IReadOnlyList<string> warningIssues,
-        IReadOnlyList<string> brandingIssues)
+        IReadOnlyList<string> brandingIssues,
+        NewCheckResults newChecks)
     {
         var reportLines = new List<string>
         {
@@ -674,6 +721,40 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         reportLines.AddRange(brandingIssues.Select(issue => $"  - {issue}"));
         reportLines.Add(string.Empty);
 
+        // 6 new post-assembly checks (PRD-QUALITY Item C)
+        var relatedToolsPass = newChecks.RelatedToolsIssues.Count == 0;
+        reportLines.Add(relatedToolsPass
+            ? "Related tools completeness: ✅ PASS"
+            : $"Related tools completeness: ❌ FAIL ({newChecks.RelatedToolsIssues.Count} issue(s))");
+        reportLines.AddRange(newChecks.RelatedToolsIssues.Select(issue => $"  - {issue}"));
+
+        reportLines.Add(newChecks.ToneMarkerWarnings.Count == 0
+            ? "Tone markers: ✅ none detected"
+            : $"Tone markers: ⚠️ {newChecks.ToneMarkerWarnings.Count} detected");
+        reportLines.AddRange(newChecks.ToneMarkerWarnings.Select(w => $"  {w}"));
+
+        reportLines.Add(newChecks.BoilerplateWarnings.Count == 0
+            ? "Boilerplate redundancy: ✅ none detected"
+            : $"Boilerplate redundancy: ⚠️ {newChecks.BoilerplateWarnings.Count} detected");
+        reportLines.AddRange(newChecks.BoilerplateWarnings.Select(w => $"  {w}"));
+
+        reportLines.Add(newChecks.HasRelatedSection
+            ? "Related section header: ✅ present"
+            : "Related section header: ⚠️ absent");
+
+        var toolsWithExamples = sections.Count - newChecks.MissingExampleIssues.Count;
+        reportLines.Add(newChecks.MissingExampleIssues.Count == 0
+            ? $"Tool examples: ✅ {toolsWithExamples}/{sections.Count} tools have examples"
+            : $"Tool examples: ❌ {toolsWithExamples}/{sections.Count} tools have examples");
+        reportLines.AddRange(newChecks.MissingExampleIssues.Select(issue => $"  {issue}"));
+
+        var toolsWithEnoughParams = sections.Count - newChecks.LowParamCountWarnings.Count;
+        reportLines.Add(newChecks.LowParamCountWarnings.Count == 0
+            ? $"Parameter count: ✅ {toolsWithEnoughParams}/{sections.Count} tools have ≥2 parameters"
+            : $"Parameter count: ⚠️ {toolsWithEnoughParams}/{sections.Count} tools have ≥2 parameters");
+        reportLines.AddRange(newChecks.LowParamCountWarnings.Select(w => $"  {w}"));
+        reportLines.Add(string.Empty);
+
         if (blockingIssues.Count == 0)
         {
             reportLines.Add($"RESULT: PASS {(warningIssues.Count > 0 || brandingIssues.Count > 0 ? $"({warningIssues.Count + brandingIssues.Count} warning{(warningIssues.Count + brandingIssues.Count == 1 ? string.Empty : "s")})" : "(clean)")}");
@@ -701,6 +782,126 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         reportLines.Add($"RESULT: FAIL ({blockingIssues.Count} blocking issue{(blockingIssues.Count == 1 ? string.Empty : "s")}, 0 warnings)");
         return reportLines;
     }
+
+    private static IReadOnlyList<string> GetRelatedToolsCompletenessIssues(
+        string relatedSectionText,
+        IReadOnlyList<ArticleSection> sections)
+    {
+        if (string.IsNullOrWhiteSpace(relatedSectionText))
+        {
+            return Array.Empty<string>();
+        }
+
+        var backtickTerms = BacktickTermRegex.Matches(relatedSectionText)
+            .Select(m => m.Groups[1].Value.Trim())
+            .Where(t => t.Length >= 4)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (backtickTerms.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var issues = new List<string>();
+        foreach (var term in backtickTerms)
+        {
+            var found = sections.Any(s =>
+                s.Heading.Contains(term, StringComparison.OrdinalIgnoreCase)
+                || s.ToolKey.Contains(term.Replace(' ', '-'), StringComparison.OrdinalIgnoreCase));
+            if (!found)
+            {
+                issues.Add($"Related tools completeness: '{term}' referenced in related section but has no matching H2 section");
+            }
+        }
+
+        return issues;
+    }
+
+    private static IReadOnlyList<string> GetToneMarkerWarnings(string articleContent)
+    {
+        var warnings = new List<string>();
+        var normalized = articleContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        foreach (var line in normalized.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed)
+                || trimmed.StartsWith('|')
+                || trimmed.StartsWith('#')
+                || trimmed.StartsWith("```", StringComparison.Ordinal)
+                || trimmed.StartsWith("<!-- ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var phrase in ToneMarkerPhrases)
+            {
+                if (trimmed.Contains(phrase, StringComparison.OrdinalIgnoreCase))
+                {
+                    warnings.Add($"Tone marker: second-person phrase '{phrase}' found: [{trimmed}]");
+                    break;
+                }
+            }
+
+            var match = ToneMarkerSuperlativeRegex.Match(trimmed);
+            if (match.Success)
+            {
+                warnings.Add($"Tone marker: prohibited superlative '{match.Value}' found: [{trimmed}]");
+            }
+        }
+
+        return warnings.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static Task<IReadOnlyList<string>> GetBoilerplateRedundancyWarningsAsync(
+        string familyName,
+        PipelineContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var contextFilePath = Path.Combine(context.OutputPath, $"{familyName}.context.json");
+        if (!File.Exists(contextFilePath))
+        {
+            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        }
+
+        // Full boilerplate check deferred when context file is present (non-blocking for now)
+        return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+    }
+
+    private static IReadOnlyList<string> GetRelatedSectionHeaderWarnings(bool hasRelatedSection)
+        => hasRelatedSection
+            ? Array.Empty<string>()
+            : new[] { "Related section header absent: article is missing a '## See also' or '## Related content' section" };
+
+    private static IReadOnlyList<string> GetMissingExampleIssues(IReadOnlyList<ArticleSection> sections)
+    {
+        var issues = new List<string>();
+        foreach (var section in sections)
+        {
+            if (section.ExampleHeaderIndex < 0 && section.AlternateExampleHeader is null)
+            {
+                issues.Add($"🛑 {section.ToolKey}: no example prompt header found (section requires 'Example prompts include:' or recognized alternate)");
+            }
+        }
+
+        return issues;
+    }
+
+    private static IReadOnlyList<string> GetLowParameterCountWarnings(IReadOnlyList<ArticleSection> sections)
+    {
+        var warnings = new List<string>();
+        foreach (var section in sections)
+        {
+            if (section.ParameterCount < 2)
+            {
+                warnings.Add($"⚠️ {section.ToolKey}: only {section.ParameterCount} documented parameter(s) (expected ≥2)");
+            }
+        }
+
+        return warnings;
+    }
+
 
     private static async Task WriteReportAsync(string reportDirectory, string reportPath, IReadOnlyList<string> reportLines, CancellationToken cancellationToken)
     {
@@ -747,9 +948,22 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         int TableStartIndex,
         string? AlternateExampleHeader,
         IReadOnlyList<string> ExamplePrompts,
-        IReadOnlyList<string> RequiredParameters);
+        IReadOnlyList<string> RequiredParameters,
+        int ParameterCount);
 
-    private sealed record ParsedArticle(string Frontmatter, IReadOnlyList<ArticleSection> Sections);
+    private sealed record ParsedArticle(
+        string Frontmatter,
+        IReadOnlyList<ArticleSection> Sections,
+        bool HasRelatedSection,
+        string RelatedSectionText);
+
+    private sealed record NewCheckResults(
+        IReadOnlyList<string> RelatedToolsIssues,
+        IReadOnlyList<string> ToneMarkerWarnings,
+        IReadOnlyList<string> BoilerplateWarnings,
+        bool HasRelatedSection,
+        IReadOnlyList<string> MissingExampleIssues,
+        IReadOnlyList<string> LowParamCountWarnings);
 
     private sealed record BrandingRule(string PatternText, string Message)
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -161,7 +161,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
                 brandingIssues.AddRange(GetBrandingIssues(articleContent));
 
-                var relatedToolsIssues = GetRelatedToolsCompletenessIssues(article.RelatedSectionText, sections);
+                var relatedToolsIssues = GetRelatedToolsCompletenessIssues(article.RelatedSectionText, sections, toolFiles);
                 foreach (var issue in relatedToolsIssues)
                 {
                     blockingIssues.Add(issue);
@@ -170,7 +170,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                 var toneMarkerWarnings = GetToneMarkerWarnings(articleContent);
                 warningIssues.AddRange(toneMarkerWarnings);
 
-                var boilerplateWarnings = await GetBoilerplateRedundancyWarningsAsync(familyName, context, cancellationToken);
+                var boilerplateWarnings = GetBoilerplateRedundancyWarnings();
                 warningIssues.AddRange(boilerplateWarnings);
 
                 var relatedSectionWarnings = GetRelatedSectionHeaderWarnings(article.HasRelatedSection);
@@ -193,7 +193,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     missingExampleIssues,
                     lowParamCountWarnings);
 
-                var reportLines = BuildReportLines(
+                var reportLines = BuildReportLines(new ValidatorReportContext(
                     familyName,
                     toolFiles,
                     sections,
@@ -203,7 +203,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
                     blockingIssues,
                     warningIssues,
                     brandingIssues,
-                    newChecks);
+                    newChecks));
 
                 await WriteReportAsync(reportDirectory, reportPath, reportLines, cancellationToken);
             }
@@ -651,117 +651,113 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             .ToArray();
     }
 
-    private static IReadOnlyList<string> BuildReportLines(
-        string familyName,
-        IReadOnlyList<NamespaceToolFile> toolFiles,
-        IReadOnlyList<ArticleSection> sections,
-        int? frontmatterToolCount,
-        IReadOnlyList<string> missingFromArticle,
-        IReadOnlyList<string> missingFromFiles,
-        IReadOnlyList<string> blockingIssues,
-        IReadOnlyList<string> warningIssues,
-        IReadOnlyList<string> brandingIssues,
-        NewCheckResults newChecks)
+    private static void AppendPassFailSection(
+        List<string> lines, string label, IReadOnlyList<string> issues)
+    {
+        lines.Add(issues.Count == 0
+            ? $"{label}: ✅ PASS"
+            : $"{label}: ❌ FAIL ({issues.Count} issue(s))");
+        lines.AddRange(issues.Select(issue => $"  - {issue}"));
+    }
+
+    private static void AppendCountSection(
+        List<string> lines, string label, IReadOnlyList<string> items, bool isBlocking)
+    {
+        lines.Add(items.Count == 0
+            ? $"{label}: ✅ none detected"
+            : $"{label}: {(isBlocking ? "❌" : "⚠️")} {items.Count} detected");
+        lines.AddRange(items.Select(item => $"  {item}"));
+    }
+
+    private static void AppendRatioSection(
+        List<string> lines, string label, IReadOnlyList<string> issues, int total,
+        bool isBlocking, string itemDescription)
+    {
+        var passing = total - issues.Count;
+        lines.Add(issues.Count == 0
+            ? $"{label}: ✅ {passing}/{total} {itemDescription}"
+            : $"{label}: {(isBlocking ? "❌" : "⚠️")} {passing}/{total} {itemDescription}");
+        lines.AddRange(issues.Select(item => $"  {item}"));
+    }
+
+    private static IReadOnlyList<string> BuildReportLines(ValidatorReportContext ctx)
     {
         var reportLines = new List<string>
         {
-            $"=== Tool Family Validation: {familyName} ===",
-            $"Tool files found: {toolFiles.Count}",
-            $"Article H2 sections: {sections.Count}",
-            $"Frontmatter tool_count: {(frontmatterToolCount is not null ? frontmatterToolCount.Value : "missing")}",
-            toolFiles.Count == sections.Count && frontmatterToolCount == toolFiles.Count
+            $"=== Tool Family Validation: {ctx.FamilyName} ===",
+            $"Tool files found: {ctx.ToolFiles.Count}",
+            $"Article H2 sections: {ctx.Sections.Count}",
+            $"Frontmatter tool_count: {(ctx.FrontmatterToolCount is not null ? ctx.FrontmatterToolCount.Value : "missing")}",
+            ctx.ToolFiles.Count == ctx.Sections.Count && ctx.FrontmatterToolCount == ctx.ToolFiles.Count
                 ? "✅ Tool count integrity: PASS"
                 : "❌ Tool count integrity: FAIL",
             string.Empty,
             "Cross-reference:",
-            missingFromArticle.Count == 0
-                ? $"  ✅ All {toolFiles.Count} tool files have matching article sections"
-                : $"  ❌ Missing from article: {missingFromArticle.Count}",
+            ctx.MissingFromArticle.Count == 0
+                ? $"  ✅ All {ctx.ToolFiles.Count} tool files have matching article sections"
+                : $"  ❌ Missing from article: {ctx.MissingFromArticle.Count}",
         };
 
-        if (missingFromArticle.Count > 0)
+        if (ctx.MissingFromArticle.Count > 0)
         {
-            reportLines.AddRange(missingFromArticle.Select(item => $"    - {item}"));
+            reportLines.AddRange(ctx.MissingFromArticle.Select(item => $"    - {item}"));
         }
 
-        reportLines.Add(missingFromFiles.Count == 0
-            ? $"  ✅ All {sections.Count} article sections have matching tool files"
-            : $"  ❌ Missing from files: {missingFromFiles.Count}");
-        if (missingFromFiles.Count > 0)
+        reportLines.Add(ctx.MissingFromFiles.Count == 0
+            ? $"  ✅ All {ctx.Sections.Count} article sections have matching tool files"
+            : $"  ❌ Missing from files: {ctx.MissingFromFiles.Count}");
+        if (ctx.MissingFromFiles.Count > 0)
         {
-            reportLines.AddRange(missingFromFiles.Select(item => $"    - {item}"));
+            reportLines.AddRange(ctx.MissingFromFiles.Select(item => $"    - {item}"));
         }
 
-        foreach (var duplicateIssue in blockingIssues.Where(issue => issue.StartsWith("Duplicate ", StringComparison.Ordinal)))
+        foreach (var duplicateIssue in ctx.BlockingIssues.Where(issue => issue.StartsWith("Duplicate ", StringComparison.Ordinal)))
         {
             reportLines.Add($"  ❌ {duplicateIssue}");
         }
 
         reportLines.Add(string.Empty);
         reportLines.Add("Required params in prompts:");
-        var requiredParamWarnings = warningIssues.Where(issue => issue.Contains("missing", StringComparison.OrdinalIgnoreCase)).ToArray();
-        var requiredParamsPassingTools = sections.Count - requiredParamWarnings.Length;
+        var requiredParamWarnings = ctx.WarningIssues.Where(issue => issue.Contains("missing", StringComparison.OrdinalIgnoreCase)).ToArray();
+        var requiredParamsPassingTools = ctx.Sections.Count - requiredParamWarnings.Length;
         reportLines.Add(requiredParamWarnings.Length == 0
-            ? $"  ✅ {requiredParamsPassingTools}/{sections.Count} tools have all required params in examples"
-            : $"  ⚠️ {requiredParamsPassingTools}/{sections.Count} tools have all required params in examples");
+            ? $"  ✅ {requiredParamsPassingTools}/{ctx.Sections.Count} tools have all required params in examples"
+            : $"  ⚠️ {requiredParamsPassingTools}/{ctx.Sections.Count} tools have all required params in examples");
         reportLines.AddRange(requiredParamWarnings.Select(warning => $"  {warning}"));
 
         reportLines.Add(string.Empty);
-        var markerWarnings = warningIssues.Where(issue => issue.Contains("annotation marker", StringComparison.OrdinalIgnoreCase)).ToArray();
-        var totalMarkers = sections.Sum(section => section.MarkerCount);
-        reportLines.Add($"Annotation markers: {totalMarkers} found (expected {sections.Count}) {(markerWarnings.Length == 0 && totalMarkers == sections.Count ? "✅" : "⚠️")}");
+        var markerWarnings = ctx.WarningIssues.Where(issue => issue.Contains("annotation marker", StringComparison.OrdinalIgnoreCase)).ToArray();
+        var totalMarkers = ctx.Sections.Sum(section => section.MarkerCount);
+        reportLines.Add($"Annotation markers: {totalMarkers} found (expected {ctx.Sections.Count}) {(markerWarnings.Length == 0 && totalMarkers == ctx.Sections.Count ? "✅" : "⚠️")}");
         reportLines.AddRange(markerWarnings.Select(warning => $"  {warning}"));
 
-        var headerWarnings = warningIssues.Where(issue => issue.Contains("example prompt header", StringComparison.OrdinalIgnoreCase)).ToArray();
-        var standardHeaderSections = sections.Count - headerWarnings.Length;
-        reportLines.Add($"Example headers: {standardHeaderSections}/{sections.Count} use standard format {(headerWarnings.Length == 0 ? "✅" : "⚠️")}");
+        var headerWarnings = ctx.WarningIssues.Where(issue => issue.Contains("example prompt header", StringComparison.OrdinalIgnoreCase)).ToArray();
+        var standardHeaderSections = ctx.Sections.Count - headerWarnings.Length;
+        reportLines.Add($"Example headers: {standardHeaderSections}/{ctx.Sections.Count} use standard format {(headerWarnings.Length == 0 ? "✅" : "⚠️")}");
         reportLines.AddRange(headerWarnings.Select(warning => $"  {warning}"));
 
-        reportLines.Add($"Branding: {brandingIssues.Count} issue{(brandingIssues.Count == 1 ? string.Empty : "s")} found {(brandingIssues.Count == 0 ? "✅" : "ℹ️")}");
-        reportLines.AddRange(brandingIssues.Select(issue => $"  - {issue}"));
+        reportLines.Add($"Branding: {ctx.BrandingIssues.Count} issue{(ctx.BrandingIssues.Count == 1 ? string.Empty : "s")} found {(ctx.BrandingIssues.Count == 0 ? "✅" : "ℹ️")}");
+        reportLines.AddRange(ctx.BrandingIssues.Select(issue => $"  - {issue}"));
         reportLines.Add(string.Empty);
 
         // 6 new post-assembly checks (PRD-QUALITY Item C)
-        var relatedToolsPass = newChecks.RelatedToolsIssues.Count == 0;
-        reportLines.Add(relatedToolsPass
-            ? "Related tools completeness: ✅ PASS"
-            : $"Related tools completeness: ❌ FAIL ({newChecks.RelatedToolsIssues.Count} issue(s))");
-        reportLines.AddRange(newChecks.RelatedToolsIssues.Select(issue => $"  - {issue}"));
-
-        reportLines.Add(newChecks.ToneMarkerWarnings.Count == 0
-            ? "Tone markers: ✅ none detected"
-            : $"Tone markers: ⚠️ {newChecks.ToneMarkerWarnings.Count} detected");
-        reportLines.AddRange(newChecks.ToneMarkerWarnings.Select(w => $"  {w}"));
-
-        reportLines.Add(newChecks.BoilerplateWarnings.Count == 0
-            ? "Boilerplate redundancy: ✅ none detected"
-            : $"Boilerplate redundancy: ⚠️ {newChecks.BoilerplateWarnings.Count} detected");
-        reportLines.AddRange(newChecks.BoilerplateWarnings.Select(w => $"  {w}"));
-
-        reportLines.Add(newChecks.HasRelatedSection
+        AppendPassFailSection(reportLines, "Related tools completeness", ctx.NewChecks.RelatedToolsIssues);
+        AppendCountSection(reportLines, "Tone markers", ctx.NewChecks.ToneMarkerWarnings, isBlocking: false);
+        AppendCountSection(reportLines, "Boilerplate redundancy", ctx.NewChecks.BoilerplateWarnings, isBlocking: false);
+        reportLines.Add(ctx.NewChecks.HasRelatedSection
             ? "Related section header: ✅ present"
             : "Related section header: ⚠️ absent");
-
-        var toolsWithExamples = sections.Count - newChecks.MissingExampleIssues.Count;
-        reportLines.Add(newChecks.MissingExampleIssues.Count == 0
-            ? $"Tool examples: ✅ {toolsWithExamples}/{sections.Count} tools have examples"
-            : $"Tool examples: ❌ {toolsWithExamples}/{sections.Count} tools have examples");
-        reportLines.AddRange(newChecks.MissingExampleIssues.Select(issue => $"  {issue}"));
-
-        var toolsWithEnoughParams = sections.Count - newChecks.LowParamCountWarnings.Count;
-        reportLines.Add(newChecks.LowParamCountWarnings.Count == 0
-            ? $"Parameter count: ✅ {toolsWithEnoughParams}/{sections.Count} tools have ≥2 parameters"
-            : $"Parameter count: ⚠️ {toolsWithEnoughParams}/{sections.Count} tools have ≥2 parameters");
-        reportLines.AddRange(newChecks.LowParamCountWarnings.Select(w => $"  {w}"));
+        AppendRatioSection(reportLines, "Tool examples", ctx.NewChecks.MissingExampleIssues, ctx.Sections.Count, isBlocking: true, itemDescription: "tools have examples");
+        AppendRatioSection(reportLines, "Parameter count", ctx.NewChecks.LowParamCountWarnings, ctx.Sections.Count, isBlocking: false, itemDescription: "tools have ≥2 parameters");
         reportLines.Add(string.Empty);
 
-        if (blockingIssues.Count == 0)
+        if (ctx.BlockingIssues.Count == 0)
         {
-            reportLines.Add($"RESULT: PASS {(warningIssues.Count > 0 || brandingIssues.Count > 0 ? $"({warningIssues.Count + brandingIssues.Count} warning{(warningIssues.Count + brandingIssues.Count == 1 ? string.Empty : "s")})" : "(clean)")}");
+            reportLines.Add($"RESULT: PASS {(ctx.WarningIssues.Count > 0 || ctx.BrandingIssues.Count > 0 ? $"({ctx.WarningIssues.Count + ctx.BrandingIssues.Count} warning{(ctx.WarningIssues.Count + ctx.BrandingIssues.Count == 1 ? string.Empty : "s")})" : "(clean)")}");
         }
         else
         {
-            reportLines.Add($"RESULT: FAIL ({blockingIssues.Count} blocking issue{(blockingIssues.Count == 1 ? string.Empty : "s")}, {warningIssues.Count + brandingIssues.Count} warning{(warningIssues.Count + brandingIssues.Count == 1 ? string.Empty : "s")})");
+            reportLines.Add($"RESULT: FAIL ({ctx.BlockingIssues.Count} blocking issue{(ctx.BlockingIssues.Count == 1 ? string.Empty : "s")}, {ctx.WarningIssues.Count + ctx.BrandingIssues.Count} warning{(ctx.WarningIssues.Count + ctx.BrandingIssues.Count == 1 ? string.Empty : "s")})");
         }
 
         return reportLines;
@@ -785,9 +781,22 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
 
     private static IReadOnlyList<string> GetRelatedToolsCompletenessIssues(
         string relatedSectionText,
-        IReadOnlyList<ArticleSection> sections)
+        IReadOnlyList<ArticleSection> sections,
+        IReadOnlyList<NamespaceToolFile> toolFiles)
     {
+        // Checks that backtick terms in the related section which reference THIS family's own tools
+        // are present as H2 sections. External tool references (other namespaces, Azure CLI commands,
+        // etc.) are skipped because they won't match this family's tool keys.
         if (string.IsNullOrWhiteSpace(relatedSectionText))
+        {
+            return Array.Empty<string>();
+        }
+
+        var familyToolKeys = toolFiles
+            .Select(file => file.ToolKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (familyToolKeys.Count == 0)
         {
             return Array.Empty<string>();
         }
@@ -806,12 +815,21 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var issues = new List<string>();
         foreach (var term in backtickTerms)
         {
+            var normalizedTerm = term.Replace(' ', '-');
+            var isInternalTool = familyToolKeys.Any(key =>
+                string.Equals(key, normalizedTerm, StringComparison.OrdinalIgnoreCase)
+                || key.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase));
+            if (!isInternalTool)
+            {
+                continue;
+            }
+
             var found = sections.Any(s =>
                 s.Heading.Contains(term, StringComparison.OrdinalIgnoreCase)
-                || s.ToolKey.Contains(term.Replace(' ', '-'), StringComparison.OrdinalIgnoreCase));
+                || s.ToolKey.Contains(normalizedTerm, StringComparison.OrdinalIgnoreCase));
             if (!found)
             {
-                issues.Add($"Related tools completeness: '{term}' referenced in related section but has no matching H2 section");
+                issues.Add($"⚠️ '{term}' is referenced in the related section but has no matching H2 section in this article");
             }
         }
 
@@ -853,20 +871,11 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         return warnings.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
-    private static Task<IReadOnlyList<string>> GetBoilerplateRedundancyWarningsAsync(
-        string familyName,
-        PipelineContext context,
-        CancellationToken cancellationToken)
+    private static IReadOnlyList<string> GetBoilerplateRedundancyWarnings()
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        var contextFilePath = Path.Combine(context.OutputPath, $"{familyName}.context.json");
-        if (!File.Exists(contextFilePath))
-        {
-            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
-        }
-
-        // Full boilerplate check deferred when context file is present (non-blocking for now)
-        return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        // Placeholder: boilerplate redundancy check not yet implemented.
+        // Tracked for future implementation — always returns empty for now.
+        return Array.Empty<string>();
     }
 
     private static IReadOnlyList<string> GetRelatedSectionHeaderWarnings(bool hasRelatedSection)
@@ -893,9 +902,9 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var warnings = new List<string>();
         foreach (var section in sections)
         {
-            if (section.ParameterCount < 2)
+            if (section.TotalParameterCount < 2)
             {
-                warnings.Add($"⚠️ {section.ToolKey}: only {section.ParameterCount} documented parameter(s) (expected ≥2)");
+                warnings.Add($"⚠️ {section.ToolKey}: only {section.TotalParameterCount} documented parameter(s) (expected ≥2)");
             }
         }
 
@@ -949,7 +958,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         string? AlternateExampleHeader,
         IReadOnlyList<string> ExamplePrompts,
         IReadOnlyList<string> RequiredParameters,
-        int ParameterCount);
+        int TotalParameterCount);
 
     private sealed record ParsedArticle(
         string Frontmatter,
@@ -964,6 +973,18 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         bool HasRelatedSection,
         IReadOnlyList<string> MissingExampleIssues,
         IReadOnlyList<string> LowParamCountWarnings);
+
+    private sealed record ValidatorReportContext(
+        string FamilyName,
+        IReadOnlyList<NamespaceToolFile> ToolFiles,
+        IReadOnlyList<ArticleSection> Sections,
+        int? FrontmatterToolCount,
+        IReadOnlyList<string> MissingFromArticle,
+        IReadOnlyList<string> MissingFromFiles,
+        IReadOnlyList<string> BlockingIssues,
+        IReadOnlyList<string> WarningIssues,
+        IReadOnlyList<string> BrandingIssues,
+        NewCheckResults NewChecks);
 
     private sealed record BrandingRule(string PatternText, string Message)
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -607,7 +607,7 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
             {
                 var suffix = missingParameters.Count > 1 ? "s" : string.Empty;
                 var joined = string.Join(", ", missingParameters.Select(parameter => $"'{parameter}'"));
-                issues.Add($"⚠️ {section.ToolKey}: missing {joined} in example prompt{suffix}");
+                issues.Add($"🛑 {section.ToolKey}: missing {joined} in example prompt{suffix}");
             }
         }
 
@@ -771,10 +771,13 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         AppendPassFailSection(reportLines, "Related tools completeness", ctx.PostAssemblyChecks.RelatedToolsIssues);
         AppendCountSection(reportLines, "Tone markers", ctx.PostAssemblyChecks.ToneMarkerWarnings, isBlocking: false);
         AppendCountSection(reportLines, "Boilerplate redundancy", ctx.PostAssemblyChecks.BoilerplateWarnings, isBlocking: false);
-        var relatedSectionIssues = ctx.PostAssemblyChecks.HasRelatedSection
-            ? Array.Empty<string>()
-            : ["Related section header absent"];
-        AppendCountSection(reportLines, "Related section header", relatedSectionIssues, isBlocking: false);
+        reportLines.Add(ctx.PostAssemblyChecks.HasRelatedSection
+            ? "Related section header: ✅ present"
+            : "Related section header: ⚠️ absent");
+        if (!ctx.PostAssemblyChecks.HasRelatedSection)
+        {
+            reportLines.Add("  ⚠️ Related section header absent: article is missing a '## See also' or '## Related content' section");
+        }
         AppendRatioSection(reportLines, "Tool examples", ctx.PostAssemblyChecks.MissingExampleIssues, ctx.Sections.Count, isBlocking: true, itemDescription: "tools have examples");
         AppendRatioSection(reportLines, "Parameter count", ctx.PostAssemblyChecks.LowParamCountWarnings, ctx.Sections.Count, isBlocking: false, itemDescription: "tools have ≥2 parameters");
         reportLines.Add(string.Empty);

--- a/shared/DocGeneration.Core.TextTransformation/DocGeneration.Core.TextTransformation.csproj
+++ b/shared/DocGeneration.Core.TextTransformation/DocGeneration.Core.TextTransformation.csproj
@@ -6,7 +6,4 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>DocGeneration.Core.TextTransformation</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Implements 5 new post-assembly validator checks for tool-family articles (Item C from the quality PRD), plus 1 deferred stub tracked in #662.

## Checks implemented

| Check | Severity | Status |
|---|---|---|
| GetRelatedToolsCompletenessIssues | Blocking | ✅ Implemented |
| GetMissingExampleIssues | Blocking | ✅ Implemented |
| GetToneMarkerWarnings | Warning | ✅ Implemented |
| GetRelatedSectionHeaderWarnings | Warning | ✅ Implemented |
| GetLowParameterCountWarnings | Warning | ✅ Implemented |
| GetBoilerplateRedundancyWarnings | Warning | 🔜 Stub — deferred to #662 |

## Also includes
- ValidatorReportContext record replaces 10-parameter BuildReportLines signature
- PostAssemblyCheckSummary record groups all 6 check outputs
- AppendPassFailSection / AppendCountSection / AppendRatioSection report helpers
- TotalParameterCount (renamed from ParameterCount) counts all parameter tables per section
- GetToneMarkerWarnings skips fenced code blocks and table rows
- ValidatorFired observability fix (TrackingValidator.WasCalled)
- Unused System.Text.Json package reference removed (NU1510)
- 10 new unit tests covering all implemented checks