### PR TITLE
feat: split GenerateAIContent into per-tool + namespace summary AI calls

### DIFF
--- a/.squad/decisions/inbox/morgan-summary-validation-fix.md
+++ b/.squad/decisions/inbox/morgan-summary-validation-fix.md
@@ -1,0 +1,4 @@
+### 2026-05-30: Empty namespace summary causes article failure
+**By:** Morgan
+**What:** Added validation check after AggregateAIData — if ServiceShortDescription or ServiceOverview is empty, fail the article with a clear error message rather than silently generating broken output.
+**Why:** Rubber-duck review caught that the empty-fallback path produced valid-looking but content-corrupted articles that passed all validation gates.

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/AggregateAIDataTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/AggregateAIDataTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HorizontalArticleGenerator.Models;
+using Xunit;
+using ArticleGenerator = HorizontalArticleGenerator.Generators.HorizontalArticleGenerator;
+
+namespace HorizontalArticleGenerator.Tests;
+
+/// <summary>
+/// Unit tests for HorizontalArticleGenerator.AggregateAIData.
+/// Covers normal aggregation, empty-summary mapping, capability/scenario filtering,
+/// and MoreInfoLink lookup by Command.
+/// </summary>
+public class AggregateAIDataTests
+{
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static StaticArticleData MakeStaticData(params (string command, string moreInfoLink)[] tools)
+    {
+        return new StaticArticleData
+        {
+            ServiceBrandName   = "Azure Key Vault",
+            ServiceIdentifier  = "keyvault",
+            Tools = tools.Select(t => new HorizontalToolSummary
+            {
+                Command     = t.command,
+                MoreInfoLink = t.moreInfoLink
+            }).ToList()
+        };
+    }
+
+    private static PerToolAIData MakePerToolData(string command, string capability, string? scenarioTitle = null)
+    {
+        return new PerToolAIData
+        {
+            Command          = command,
+            ShortDescription = $"Short description for {command}.",
+            Capability       = capability,
+            Scenario = scenarioTitle is null ? null : new Scenario
+            {
+                Title           = scenarioTitle,
+                Description     = $"Scenario for {command}.",
+                ExpectedOutcome = "Success."
+            }
+        };
+    }
+
+    private static NamespaceSummaryAIData MakeSummary(
+        string shortDesc  = "Manage secrets in Azure Key Vault.",
+        string overview   = "Azure Key Vault lets you store and control access to tokens, passwords, and certificates.")
+    {
+        return new NamespaceSummaryAIData
+        {
+            ServiceShortDescription      = shortDesc,
+            ServiceOverview              = overview,
+            ServiceSpecificPrerequisites = [new Prerequisite { Title = "Key Vault instance", Description = "A vault must exist." }],
+            RequiredRoles                = [new RequiredRole { Name = "Key Vault Secrets User", Purpose = "Read secrets." }],
+            BestPractices                = [new BestPractice { Title = "Rotate secrets", Description = "Rotate secrets regularly." }],
+            ServiceDocLink               = "/azure/key-vault/general/overview",
+            AdditionalLinks              = [new AdditionalLink { Title = "Quickstart", Url = "/azure/key-vault/secrets/quick-create-portal" }]
+        };
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 1: Normal aggregation — N per-tool results + populated summary
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void AggregateAIData_NormalCase_AggregatesAllFields()
+    {
+        var staticData = MakeStaticData(
+            ("keyvault secret list",   "../parameters/keyvault-secret-list-parameters.md"),
+            ("keyvault secret set",    "../parameters/keyvault-secret-set-parameters.md"),
+            ("keyvault secret delete", "../parameters/keyvault-secret-delete-parameters.md")
+        );
+
+        var perToolResults = new List<PerToolAIData>
+        {
+            MakePerToolData("keyvault secret list",   "List secrets in Azure Key Vault",    "Audit stored secrets"),
+            MakePerToolData("keyvault secret set",    "Create or update secrets",           "Store application credentials"),
+            MakePerToolData("keyvault secret delete", "Delete a secret from Key Vault",     "Remove stale credentials")
+        };
+
+        var summary = MakeSummary();
+
+        var result = ArticleGenerator.AggregateAIData(staticData, perToolResults, summary);
+
+        // Namespace-level fields come from summary
+        Assert.Equal("Manage secrets in Azure Key Vault.", result.ServiceShortDescription);
+        Assert.Equal("Azure Key Vault lets you store and control access to tokens, passwords, and certificates.", result.ServiceOverview);
+        Assert.Single(result.ServiceSpecificPrerequisites);
+        Assert.Equal("Key Vault instance", result.ServiceSpecificPrerequisites[0].Title);
+        Assert.Single(result.RequiredRoles);
+        Assert.Equal("Key Vault Secrets User", result.RequiredRoles[0].Name);
+        Assert.NotNull(result.BestPractices);
+        Assert.Single(result.BestPractices!);
+        Assert.Equal("/azure/key-vault/general/overview", result.ServiceDocLink);
+        Assert.Single(result.AdditionalLinks);
+
+        // Capabilities: one per tool
+        Assert.Equal(3, result.Capabilities.Count);
+        Assert.Contains("List secrets in Azure Key Vault", result.Capabilities);
+        Assert.Contains("Create or update secrets", result.Capabilities);
+        Assert.Contains("Delete a secret from Key Vault", result.Capabilities);
+
+        // Scenarios: one per tool (all three have scenarios)
+        Assert.Equal(3, result.Scenarios.Count);
+        Assert.Contains(result.Scenarios, s => s.Title == "Audit stored secrets");
+
+        // Tools list
+        Assert.Equal(3, result.Tools.Count);
+        Assert.All(result.Tools, t => Assert.False(string.IsNullOrEmpty(t.ShortDescription)));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 2: Empty NamespaceSummaryAIData (all defaults) — fields map to empty strings
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void AggregateAIData_EmptySummary_ProducesEmptyServiceFields()
+    {
+        var staticData = MakeStaticData(("cosmos db container list", "../parameters/cosmos-db-container-list-parameters.md"));
+
+        var perToolResults = new List<PerToolAIData>
+        {
+            MakePerToolData("cosmos db container list", "List Cosmos DB containers")
+        };
+
+        var emptySummary = new NamespaceSummaryAIData(); // all defaults — empty strings / empty lists
+
+        var result = ArticleGenerator.AggregateAIData(staticData, perToolResults, emptySummary);
+
+        // These are the fields that the validation gate in GenerateSingleArticleAsync will reject
+        Assert.True(string.IsNullOrWhiteSpace(result.ServiceShortDescription));
+        Assert.True(string.IsNullOrWhiteSpace(result.ServiceOverview));
+
+        // Other fields still aggregate normally from per-tool results
+        Assert.Single(result.Capabilities);
+        Assert.Equal("List Cosmos DB containers", result.Capabilities[0]);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 3: perToolResults with empty capability or null scenario — filtered out
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void AggregateAIData_EmptyCapabilityAndNullScenario_FilteredFromCollections()
+    {
+        var staticData = MakeStaticData(
+            ("monitor alert list",   "../parameters/monitor-alert-list-parameters.md"),
+            ("monitor alert create", "../parameters/monitor-alert-create-parameters.md"),
+            ("monitor alert delete", "../parameters/monitor-alert-delete-parameters.md")
+        );
+
+        var perToolResults = new List<PerToolAIData>
+        {
+            // Good entry
+            MakePerToolData("monitor alert list",   "List Azure Monitor alerts", "Audit active alerts"),
+            // Empty capability — should not appear in Capabilities
+            new PerToolAIData { Command = "monitor alert create", Capability = "   ", Scenario = null, ShortDescription = "Create an alert." },
+            // Null scenario — should not appear in Scenarios
+            MakePerToolData("monitor alert delete", "Delete an Azure Monitor alert", scenarioTitle: null)
+        };
+
+        var result = ArticleGenerator.AggregateAIData(staticData, perToolResults, MakeSummary());
+
+        // Only 2 non-whitespace capabilities
+        Assert.Equal(2, result.Capabilities.Count);
+        Assert.DoesNotContain("   ", result.Capabilities);
+
+        // Only 1 scenario (the one that had a non-null Scenario)
+        Assert.Single(result.Scenarios);
+        Assert.Equal("Audit active alerts", result.Scenarios[0].Title);
+
+        // All 3 tools still appear in the Tools list (ShortDescription comes through regardless)
+        Assert.Equal(3, result.Tools.Count);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 4: MoreInfoLink lookup — exact match found vs not found
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void AggregateAIData_MoreInfoLink_ExactMatchFound_UsesStaticLink()
+    {
+        const string expectedLink = "../parameters/storage-blob-list-parameters.md";
+
+        var staticData = MakeStaticData(
+            ("storage blob list",   expectedLink),
+            ("storage blob upload", "../parameters/storage-blob-upload-parameters.md")
+        );
+
+        var perToolResults = new List<PerToolAIData>
+        {
+            MakePerToolData("storage blob list",   "List blobs in Azure Storage"),
+            MakePerToolData("storage blob upload", "Upload a blob to Azure Storage")
+        };
+
+        var result = ArticleGenerator.AggregateAIData(staticData, perToolResults, MakeSummary());
+
+        var listTool = result.Tools.Single(t => t.Command == "storage blob list");
+        Assert.Equal(expectedLink, listTool.MoreInfoLink);
+    }
+
+    [Fact]
+    public void AggregateAIData_MoreInfoLink_NoMatchFound_FallsBackToEmpty()
+    {
+        // StaticData has no entry matching the per-tool command
+        var staticData = MakeStaticData(("aks nodepool list", "../parameters/aks-nodepool-list-parameters.md"));
+
+        var perToolResults = new List<PerToolAIData>
+        {
+            // Command that is NOT in staticData.Tools
+            MakePerToolData("aks cluster list", "List AKS clusters")
+        };
+
+        var result = ArticleGenerator.AggregateAIData(staticData, perToolResults, MakeSummary());
+
+        var tool = result.Tools.Single(t => t.Command == "aks cluster list");
+        Assert.Equal(string.Empty, tool.MoreInfoLink);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -98,6 +98,13 @@ public class HorizontalArticleGenerator
                 Console.WriteLine($"{progress} Generating namespace summary...");
                 var summaryData = await GenerateNamespaceSummaryAIContent(staticData, perToolResults);
                 aiData = AggregateAIData(staticData, perToolResults, summaryData);
+
+                // Fail fast if namespace summary returned empty required fields (indicates failed AI call)
+                if (string.IsNullOrWhiteSpace(aiData.ServiceShortDescription) || string.IsNullOrWhiteSpace(aiData.ServiceOverview))
+                {
+                    Console.WriteLine($"{progress} ✗ Namespace summary returned empty required fields for {staticData.ServiceBrandName} — article generation failed.");
+                    return false;
+                }
             }
 
             if (aiData == null) return false;
@@ -718,7 +725,7 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
     /// Aggregates per-tool AI results and namespace summary into a single AIGeneratedArticleData
     /// for compatibility with the existing ArticleContentProcessor and MergeData pipeline.
     /// </summary>
-    private static AIGeneratedArticleData AggregateAIData(
+    internal static AIGeneratedArticleData AggregateAIData(
         StaticArticleData staticData,
         IReadOnlyList<PerToolAIData> perToolResults,
         NamespaceSummaryAIData summaryData)

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Generators/HorizontalArticleGenerator.cs
@@ -32,31 +32,76 @@ public class HorizontalArticleGenerator
         return Math.Clamp(calculatedTokens, 8000, 24000);
     }
 
+    /// <summary>
+    /// Calculates the maximum token budget for per-tool AI calls or namespace summary calls.
+    /// Per-tool calls are small and bounded (~2000 tokens each).
+    /// Namespace summary calls use a compact tool list (command + description only), so a lower cap applies.
+    /// </summary>
+    internal static int CalculateMaxTokens(int toolCount, bool isPerToolCall)
+    {
+        if (isPerToolCall) return 2000;
+        // Namespace summary: compact list only; lower base and per-tool factor than full article
+        var calculatedTokens = 2000 + (toolCount * 150);
+        return Math.Clamp(calculatedTokens, 3000, 8000);
+    }
+
     // Extracted method for generating a single article
     private async Task<bool> GenerateSingleArticleAsync(StaticArticleData staticData, string outputDir, string progress)
     {
         try
         {
             Console.WriteLine($"{progress} Processing {staticData.ServiceBrandName}...");
-            // Generate AI content
-            var aiResponse = await GenerateAIContent(staticData);
+
             AIGeneratedArticleData? aiData = null;
-            bool parseFailed = false;
-            try
+
+            // Use per-tool + namespace-summary approach when new prompt files are present.
+            // Fall back to legacy single-call if Sage's prompt files haven't landed yet.
+            var toolSystemPromptPath = Path.GetFullPath(TOOL_SYSTEM_PROMPT_PATH);
+            var toolUserPromptPath   = Path.GetFullPath(TOOL_USER_PROMPT_PATH);
+            var namespaceUserPromptPath = Path.GetFullPath(NAMESPACE_USER_PROMPT_PATH);
+
+            if (!File.Exists(toolSystemPromptPath) || !File.Exists(toolUserPromptPath) || !File.Exists(namespaceUserPromptPath))
             {
-                aiData = ParseAIResponse(aiResponse);
+                Console.WriteLine($"{progress} ⚠️  Per-tool prompt files not found — using legacy single-call AI generation.");
+                string aiResponse;
+#pragma warning disable CS0618
+                aiResponse = await GenerateAIContent(staticData);
+#pragma warning restore CS0618
+                try
+                {
+                    aiData = ParseAIResponse(aiResponse);
+                }
+                catch (Exception jsonEx)
+                {
+                    Console.WriteLine($"{progress} ✗ Failed to parse AI response for {staticData.ServiceBrandName}: {jsonEx.Message}");
+                    var errorLog = Path.Combine(outputDir, $"error-{staticData.ServiceIdentifier}-airesponse.txt");
+                    await File.WriteAllTextAsync(errorLog, $"Raw AI response:\n{aiResponse}\n\nError: {jsonEx.Message}\n{jsonEx.StackTrace}", Encoding.UTF8);
+                    Console.WriteLine($"Raw AI response logged to: {errorLog}");
+                    Console.WriteLine();
+                    return false;
+                }
             }
-            catch (Exception jsonEx)
+            else
             {
-                Console.WriteLine($"{progress} ✗ Failed to parse AI response for {staticData.ServiceBrandName}: {jsonEx.Message}");
-                var errorLog = Path.Combine(outputDir, $"error-{staticData.ServiceIdentifier}-airesponse.txt");
-                await File.WriteAllTextAsync(errorLog, $"Raw AI response:\n{aiResponse}\n\nError: {jsonEx.Message}\n{jsonEx.StackTrace}", Encoding.UTF8);
-                Console.WriteLine($"Raw AI response logged to: {errorLog}");
-                Console.WriteLine();
-                parseFailed = true;
+                // Per-tool AI calls: one per tool, bounded token budget (~2000 tokens each)
+                Console.WriteLine($"{progress} Generating per-tool AI content ({staticData.Tools.Count} tools)...");
+                var perToolResults = new List<PerToolAIData>();
+                for (int i = 0; i < staticData.Tools.Count; i++)
+                {
+                    var tool = staticData.Tools[i];
+                    Console.WriteLine($"{progress} ({i + 1}/{staticData.Tools.Count}) Tool: {tool.Command}");
+                    var perToolData = await GenerateAIContentForTool(tool, staticData.ServiceBrandName, staticData.ServiceIdentifier, i);
+                    perToolResults.Add(perToolData);
+                }
+
+                // Namespace summary AI call: one call after all per-tool calls, compact tool list
+                Console.WriteLine($"{progress} Generating namespace summary...");
+                var summaryData = await GenerateNamespaceSummaryAIContent(staticData, perToolResults);
+                aiData = AggregateAIData(staticData, perToolResults, summaryData);
             }
-            if (parseFailed || aiData == null) return false; // Skip this article
-            
+
+            if (aiData == null) return false;
+
             // Validate and transform AI-generated content via ArticleContentProcessor
             var processor = new ArticleContentProcessor(_transformationEngine);
             var validationResult = processor.Process(aiData, staticData.ServiceBrandName, staticData.ServiceIdentifier);
@@ -117,6 +162,11 @@ public class HorizontalArticleGenerator
     private const string SYSTEM_PROMPT_PATH = "./DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-system-prompt.txt";
     private const string USER_PROMPT_PATH = "./DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-user-prompt.txt";
     private const string TEMPLATE_PATH = "./DocGeneration.Steps.HorizontalArticles/templates/horizontal-article-template.hbs";
+
+    // Per-tool AI call prompts (written by Sage; may not exist yet — generator falls back gracefully)
+    private const string TOOL_SYSTEM_PROMPT_PATH = "./DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-system-prompt.txt";
+    private const string TOOL_USER_PROMPT_PATH = "./DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-user-prompt.txt";
+    private const string NAMESPACE_USER_PROMPT_PATH = "./DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-namespace-user-prompt.txt";
     
     private readonly GenerativeAIClient _aiClient;
     private readonly bool _useTextTransformation;
@@ -217,7 +267,9 @@ public class HorizontalArticleGenerator
     {
         cancellationToken.ThrowIfCancellationRequested();
         var staticData = await BuildStaticArticleDataAsync(outlineContext, cancellationToken);
+#pragma warning disable CS0618
         var aiResponse = await GenerateAIContent(staticData);
+#pragma warning restore CS0618
         var aiData = ParseAIResponse(aiResponse);
         var processor = new ArticleContentProcessor(_transformationEngine);
         var validationResult = processor.Process(aiData, staticData.ServiceBrandName, staticData.ServiceIdentifier);
@@ -402,6 +454,7 @@ public class HorizontalArticleGenerator
     /// <summary>
     /// Phase 2: Generate AI content using prompts
     /// </summary>
+    [Obsolete("Use GenerateAIContentForTool + GenerateNamespaceSummaryAIContent instead. This single-call method causes token overflow on large namespaces.")]
     private async Task<string> GenerateAIContent(StaticArticleData staticData)
     {
         // Load prompts
@@ -481,6 +534,229 @@ Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
         return response;
     }
     
+    /// <summary>
+    /// Calls AI once for a single tool to generate its short description, scenario, and capability.
+    /// Returns a static-data fallback if prompt files are not present (Sage may not have written them yet).
+    /// </summary>
+    private async Task<PerToolAIData> GenerateAIContentForTool(
+        HorizontalToolSummary tool,
+        string serviceBrandName,
+        string serviceIdentifier,
+        int toolIndex)
+    {
+        var systemPromptPath = Path.GetFullPath(TOOL_SYSTEM_PROMPT_PATH);
+        var userPromptPath   = Path.GetFullPath(TOOL_USER_PROMPT_PATH);
+
+        if (!File.Exists(systemPromptPath) || !File.Exists(userPromptPath))
+        {
+            Console.WriteLine($"    ⚠️  Per-tool prompt files not found; using static description as fallback for: {tool.Command}");
+            return new PerToolAIData { Command = tool.Command, ShortDescription = tool.Description };
+        }
+
+        try
+        {
+            var systemPrompt = await File.ReadAllTextAsync(systemPromptPath);
+            systemPrompt = PromptTokenResolver.Resolve(systemPrompt, Path.Combine(AppContext.BaseDirectory, "data"));
+            var userPromptTemplate = await File.ReadAllTextAsync(userPromptPath);
+
+            var handlebars = HandlebarsDotNet.Handlebars.Create();
+            var userPromptCompiled = handlebars.Compile(userPromptTemplate);
+
+            var promptContext = new
+            {
+                serviceBrandName,
+                serviceIdentifier,
+                tool = new
+                {
+                    command = tool.Command,
+                    description = tool.Description,
+                    parameterCount = tool.ParameterCount,
+                    metadata = new
+                    {
+                        destructive = new { value = tool.Metadata.GetValueOrDefault("destructive", new MetadataValue()).Value },
+                        readOnly    = new { value = tool.Metadata.GetValueOrDefault("readOnly", new MetadataValue()).Value },
+                        secret      = new { value = tool.Metadata.GetValueOrDefault("secret", new MetadataValue()).Value }
+                    }
+                }
+            };
+
+            var userPrompt = userPromptCompiled(promptContext);
+
+            // Save prompt for debugging
+            Directory.CreateDirectory(_promptOutputDir);
+            var promptFileName = $"horizontal-article-{serviceIdentifier}-tool-{toolIndex:D2}-prompt.md";
+            var promptFilePath = Path.Combine(_promptOutputDir, promptFileName);
+            var promptContent = $"""
+# Per-Tool Prompt: {tool.Command} ({serviceBrandName})
+
+Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
+
+## System Prompt
+
+{systemPrompt}
+
+## User Prompt
+
+{userPrompt}
+""";
+            await File.WriteAllTextAsync(promptFilePath, promptContent, Encoding.UTF8);
+
+            var maxTokens = CalculateMaxTokens(1, isPerToolCall: true);
+            var response = await _aiClient.GetChatCompletionAsync(systemPrompt, userPrompt, maxTokens);
+
+            await File.AppendAllTextAsync(promptFilePath, $"""
+
+
+## AI Response
+
+```json
+{response}
+```
+""");
+
+            var jsonContent = ExtractJsonFromResponse(response);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var result = JsonSerializer.Deserialize<PerToolAIData>(jsonContent, options)
+                ?? new PerToolAIData { Command = tool.Command, ShortDescription = tool.Description };
+            result.Command = tool.Command; // Always set — JSON won't include it
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"    ⚠️  AI call failed for tool {tool.Command}: {ex.Message} — using static fallback.");
+            return new PerToolAIData { Command = tool.Command, ShortDescription = tool.Description };
+        }
+    }
+
+    /// <summary>
+    /// Calls AI once for the namespace-level summary after all per-tool calls complete.
+    /// Input is a compact list (command + description only) to keep the token count low.
+    /// Returns an empty summary if the namespace user prompt file is not present.
+    /// </summary>
+    private async Task<NamespaceSummaryAIData> GenerateNamespaceSummaryAIContent(
+        StaticArticleData staticData,
+        IReadOnlyList<PerToolAIData> perToolResults)
+    {
+        var systemPromptPath = Path.GetFullPath(SYSTEM_PROMPT_PATH);
+        var userPromptPath   = Path.GetFullPath(NAMESPACE_USER_PROMPT_PATH);
+
+        if (!File.Exists(userPromptPath))
+        {
+            Console.WriteLine($"    ⚠️  Namespace summary user prompt not found; using empty summary for: {staticData.ServiceBrandName}");
+            return new NamespaceSummaryAIData();
+        }
+
+        try
+        {
+            var systemPrompt = await File.ReadAllTextAsync(systemPromptPath);
+            systemPrompt = PromptTokenResolver.Resolve(systemPrompt, Path.Combine(AppContext.BaseDirectory, "data"));
+            var userPromptTemplate = await File.ReadAllTextAsync(userPromptPath);
+
+            var handlebars = HandlebarsDotNet.Handlebars.Create();
+            var userPromptCompiled = handlebars.Compile(userPromptTemplate);
+
+            // Compact tool list: only command + description to stay within token budget
+            var promptContext = new
+            {
+                serviceBrandName   = staticData.ServiceBrandName,
+                serviceIdentifier  = staticData.ServiceIdentifier,
+                toolsReferenceLink = staticData.ToolsReferenceLink,
+                tools = staticData.Tools.Select(t => new { command = t.Command, description = t.Description })
+            };
+
+            var userPrompt = userPromptCompiled(promptContext);
+
+            // Save prompt for debugging
+            Directory.CreateDirectory(_promptOutputDir);
+            var promptFileName = $"horizontal-article-{staticData.ServiceIdentifier}-namespace-prompt.md";
+            var promptFilePath = Path.Combine(_promptOutputDir, promptFileName);
+            var promptContent = $"""
+# Namespace Summary Prompt: {staticData.ServiceBrandName}
+
+Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
+
+## System Prompt
+
+{systemPrompt}
+
+## User Prompt
+
+{userPrompt}
+""";
+            await File.WriteAllTextAsync(promptFilePath, promptContent, Encoding.UTF8);
+
+            var maxTokens = CalculateMaxTokens(staticData.Tools.Count, isPerToolCall: false);
+            var response = await _aiClient.GetChatCompletionAsync(systemPrompt, userPrompt, maxTokens);
+
+            await File.AppendAllTextAsync(promptFilePath, $"""
+
+
+## AI Response
+
+```json
+{response}
+```
+""");
+
+            var jsonContent = ExtractJsonFromResponse(response);
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            };
+            return JsonSerializer.Deserialize<NamespaceSummaryAIData>(jsonContent, options)
+                ?? new NamespaceSummaryAIData();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"    ⚠️  Namespace summary AI call failed for {staticData.ServiceBrandName}: {ex.Message} — using empty summary.");
+            return new NamespaceSummaryAIData();
+        }
+    }
+
+    /// <summary>
+    /// Aggregates per-tool AI results and namespace summary into a single AIGeneratedArticleData
+    /// for compatibility with the existing ArticleContentProcessor and MergeData pipeline.
+    /// </summary>
+    private static AIGeneratedArticleData AggregateAIData(
+        StaticArticleData staticData,
+        IReadOnlyList<PerToolAIData> perToolResults,
+        NamespaceSummaryAIData summaryData)
+    {
+        return new AIGeneratedArticleData
+        {
+            // Namespace-level fields from summary call
+            ServiceShortDescription      = summaryData.ServiceShortDescription,
+            ServiceOverview              = summaryData.ServiceOverview,
+            ServiceSpecificPrerequisites = summaryData.ServiceSpecificPrerequisites,
+            RequiredRoles                = summaryData.RequiredRoles,
+            BestPractices                = summaryData.BestPractices,
+            ServiceDocLink               = summaryData.ServiceDocLink,
+            AdditionalLinks              = summaryData.AdditionalLinks,
+
+            // Capabilities: one entry per tool
+            Capabilities = perToolResults
+                .Where(p => !string.IsNullOrWhiteSpace(p.Capability))
+                .Select(p => p.Capability)
+                .ToList(),
+
+            // Scenarios: one scenario per tool that returned one
+            Scenarios = perToolResults
+                .Where(p => p.Scenario != null)
+                .Select(p => p.Scenario!)
+                .ToList(),
+
+            // Per-tool short descriptions mapped to ToolWithAIDescription
+            Tools = perToolResults.Select(p => new ToolWithAIDescription
+            {
+                Command          = p.Command,
+                ShortDescription = p.ShortDescription,
+                MoreInfoLink     = staticData.Tools
+                    .FirstOrDefault(t => t.Command == p.Command)?.MoreInfoLink ?? string.Empty
+            }).ToList()
+        };
+    }
+
     /// <summary>
     /// Parse AI response JSON
     /// </summary>

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/NamespaceSummaryAIData.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/NamespaceSummaryAIData.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace HorizontalArticleGenerator.Models;
+
+/// <summary>
+/// AI-generated namespace-level summary data.
+/// Returned by the single namespace summary AI call made after all per-tool calls complete.
+/// Contains service-level content that does not depend on individual tool details.
+/// </summary>
+public class NamespaceSummaryAIData
+{
+    [JsonPropertyName("genai-serviceShortDescription")]
+    public string ServiceShortDescription { get; set; } = string.Empty;
+
+    [JsonPropertyName("genai-serviceOverview")]
+    public string ServiceOverview { get; set; } = string.Empty;
+
+    [JsonPropertyName("genai-serviceSpecificPrerequisites")]
+    public List<Prerequisite> ServiceSpecificPrerequisites { get; set; } = new();
+
+    [JsonPropertyName("genai-requiredRoles")]
+    public List<RequiredRole> RequiredRoles { get; set; } = new();
+
+    [JsonPropertyName("genai-bestPractices")]
+    public List<BestPractice>? BestPractices { get; set; }
+
+    [JsonPropertyName("genai-serviceDocLink")]
+    public string? ServiceDocLink { get; set; }
+
+    [JsonPropertyName("genai-additionalLinks")]
+    public List<AdditionalLink> AdditionalLinks { get; set; } = new();
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/PerToolAIData.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/Models/PerToolAIData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace HorizontalArticleGenerator.Models;
+
+/// <summary>
+/// AI-generated data for a single MCP tool.
+/// Returned by the per-tool AI call (one call per tool, not one per namespace).
+/// </summary>
+public class PerToolAIData
+{
+    /// <summary>
+    /// 10-15 word description of this tool. Maps to tools[].genai-shortDescription.
+    /// </summary>
+    [JsonPropertyName("genai-shortDescription")]
+    public string ShortDescription { get; set; } = string.Empty;
+
+    /// <summary>
+    /// A usage scenario for this specific tool. Aggregated into AIGeneratedArticleData.Scenarios.
+    /// </summary>
+    [JsonPropertyName("genai-scenario")]
+    public Scenario? Scenario { get; set; }
+
+    /// <summary>
+    /// Action phrase describing this tool's capability. Aggregated into AIGeneratedArticleData.Capabilities.
+    /// </summary>
+    [JsonPropertyName("genai-capability")]
+    public string Capability { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The command this data was generated for. Set by the caller, not deserialized from AI response.
+    /// </summary>
+    [JsonIgnore]
+    public string Command { get; set; } = string.Empty;
+}

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-namespace-user-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-namespace-user-prompt.txt
@@ -1,0 +1,79 @@
+Generate JSON data for a how-to article about managing {{serviceBrandName}} with Azure MCP Server.
+
+## Input Data
+
+**Service Information:**
+- Service Brand Name: {{serviceBrandName}}
+- Service Identifier: {{serviceIdentifier}}
+- Tools Reference Link: {{toolsReferenceLink}}
+
+**Available MCP Tools for this service (compact list):**
+{{#each tools}}
+- {{command}} — {{description}}
+{{/each}}
+
+## Your Task
+
+**FIRST**: Analyze the tool list to determine the service's primary plane focus:
+- **Data plane**: Majority of tools work with data in existing resources (get, list, query, read, upload, execute, write)
+- **Management plane**: Majority of tools manage resource lifecycle (create, delete, update, provision, configure)
+- **Mixed**: Roughly equal split between data and management operations
+
+**SECOND**: Search official Azure documentation for {{serviceBrandName}}. Find:
+- Official service overview and description
+- Prerequisites and setup requirements
+- RBAC roles and permissions (data plane vs management plane roles)
+- Best practices and security recommendations
+- Service documentation URL path
+
+**THEN**: Generate a JSON object following the system prompt schema. Focus on:
+
+1. **genai-serviceShortDescription**: A noun phrase describing what users manage via MCP tools. MUST NOT end with a period. Must read naturally after "Manage" — e.g., "keys, secrets, and certificates" or "web applications and database connections". Keep under 8 words. This is about MCP tool capabilities, not Azure service marketing.
+
+2. **genai-serviceOverview**: A 2-3 sentence description of {{serviceBrandName}}. CRITICAL: Do NOT start with the service name — the template prepends it automatically. Start with "is a..." or "provides...". Include what problem the service solves and key capabilities. Grounded in official Azure documentation.
+
+3. **genai-serviceSpecificPrerequisites**: Service-specific prerequisites only. Do NOT include "Azure subscription" — already in the template. Titles must be short resource/service names only (no verbs, no state words like "existing" or "provisioned" — move that context to the description field).
+
+4. **genai-requiredRoles**: RBAC roles grounded ONLY to the tool operations in the compact list above.
+   - **Authoritative source ONLY**: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles — every role name MUST appear on that page
+   - Apply minimum privilege: if all tools are read-only, suggest only Reader-level roles; if tools include write or delete operations, include Contributor-level roles
+   - The `purpose` field must reference the specific tool operations that require that role
+   - NEVER invent role names — use the exact names from the authoritative source
+   - NEVER use patterns like "[Service] Knowledge Base Data Reader", "[Service] Feature Data Reader", or "[Service] Administrator" (fabricated patterns)
+   - If unsure whether a role exists: use a verified generic fallback (e.g., "Contributor", "Reader", "[Service] Service Contributor")
+   - Suggest at least 2 roles: one read-only (for list/get tools), one contributor (for write/delete tools) — omit the write role if no write tools exist
+
+5. **genai-bestPractices**: 2-5 best practices scoped to using these MCP tools effectively.
+   - Every best practice must directly relate to how a user should use the tools listed above
+   - Reference specific tool commands when giving advice (e.g., "Use `{{serviceIdentifier}} list` before running delete operations to confirm the target resource")
+   - Do NOT include general Azure service administration advice (scaling, monitoring, backup, disaster recovery) unless a tool in the list directly supports that operation
+   - Titles MUST NOT end with a period
+   - Priority order: security (Entra ID / RBAC), safe usage (read before write), efficiency (filtering, batching)
+
+6. **genai-serviceDocLink**: Path to the official Azure service documentation overview. Remove `https://learn.microsoft.com/en-us` prefix — use `/azure/...` format. Use `/azure/ai-services/` instead of deprecated `/azure/cognitive-services/`. **If you are not confident the URL path is correct, leave this as an empty string** — an empty link is better than a fabricated 404.
+
+7. **genai-additionalLinks**: 2-4 additional documentation links relevant to these tool operations. Use `/azure/...` paths (remove `https://learn.microsoft.com/en-us` prefix). Empty string is better than a fabricated URL.
+
+## Key Constraints
+
+- **Do NOT generate per-tool descriptions** — those come from separate per-tool AI calls. This call produces only service-level content.
+- **Do NOT generate `genai-capabilities`, `tools`, or `genai-scenarios`** — those fields are assembled from per-tool call results.
+- **SEO Differentiation**: This article is about using Azure MCP Server tools with {{serviceBrandName}}, not a replacement for the official Azure service documentation. Content must complement, not compete.
+- **Authentication**: Azure MCP Server uses `DefaultAzureCredential` (Microsoft Entra ID). Do NOT mention API keys anywhere.
+- **Naming**: Use "Microsoft Entra ID" — NEVER "Azure Active Directory".
+- **No trailing periods** on: `genai-serviceShortDescription`, best practice titles, prerequisite titles, additional link titles.
+- **URL discipline**: Remove `https://learn.microsoft.com/en-us` prefix from all URLs. If uncertain about a path, use an empty string.
+- **Universality**: This prompt runs for ALL 52 Azure MCP namespaces. Apply all rules generically regardless of which service is provided above.
+
+## Output Format
+
+Return ONLY valid JSON — no markdown code blocks, no explanations. The response must begin with `{` and end with `}`.
+
+The JSON must contain exactly these top-level keys:
+- `genai-serviceShortDescription`
+- `genai-serviceOverview`
+- `genai-serviceSpecificPrerequisites`
+- `genai-requiredRoles`
+- `genai-bestPractices`
+- `genai-serviceDocLink`
+- `genai-additionalLinks`

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-system-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-system-prompt.txt
@@ -1,0 +1,106 @@
+You are an expert technical writer creating Microsoft Learn-style reference content for a single Azure MCP Server tool. Your task is to generate a JSON object containing a short description, a usage scenario, and a capability phrase for ONE specific tool.
+
+**UNIVERSALITY REQUIREMENT**: This prompt runs for every individual tool across ALL 52 Azure MCP namespaces. Apply all rules generically — do not assume any specific Azure service context. Every rule below must hold for any tool, from Azure Key Vault to Azure AI Search to Azure Monitor.
+
+## Output Format
+
+Generate a JSON object with EXACTLY this structure. All fields are required:
+
+```json
+{
+  "genai-shortDescription": "string - 10-15 word condensed description of this specific tool's purpose",
+  "genai-scenario": {
+    "title": "string - Short action phrase describing this scenario (MUST NOT end with a period)",
+    "description": "string - 1 sentence explaining the business motivation for using this tool",
+    "examples": ["array of 3-5 natural language prompts for this specific tool using real resource names"],
+    "expectedOutcome": "string - What the user sees or receives as a result of using this tool"
+  },
+  "genai-capability": "string - single action phrase describing what this tool enables (MUST NOT end with a period)"
+}
+```
+
+## SEO Differentiation Rules (CRITICAL)
+
+These articles document Azure MCP Server tools, NOT the Azure services themselves. Content must complement official Azure service documentation — never compete with it in search results.
+
+- **Tool framing**: All generated content must position this as a reference for using a specific MCP tool, not a general Azure service guide
+- **genai-shortDescription**: Describe what this MCP tool does — concrete action and target resource. This is about MCP tool capability, not Azure service marketing
+- **genai-capability**: Frame as "what you can do with this Azure MCP Server tool" — not "what the Azure service can do"
+- **Keywords**: Focus on MCP-specific terms and the tool's specific operation. Do NOT optimize for generic Azure service queries
+
+## Field-by-Field Rules
+
+### genai-shortDescription
+Condense the tool description to its essential action and target resource.
+- **Target length**: 10-15 words (max 15)
+- **Be specific**: Include what data or resource type is affected, not just "get details"
+- **Start with a verb**: "Retrieve", "Create", "Delete", "List", "Set", "Upload", "Execute"
+- **Examples of GOOD descriptions**:
+  - "Retrieve secret value and metadata from an existing key vault" ✓
+  - "Create a new blob container with specified access tier and metadata" ✓
+  - "List all indexes with schema, field definitions, and scoring profiles" ✓
+- **Examples of BAD descriptions** (too generic):
+  - "Get information about resources" ✗
+  - "Manage service settings" ✗
+  - "Perform operations on data" ✗
+
+### genai-scenario
+Create exactly ONE scenario grounded to this specific tool's operation.
+- **title**: Short action phrase — no trailing period. Example: "Retrieve a secret from a key vault"
+- **description**: One sentence explaining the real-world business motivation for using this tool. Why would a developer or operator want to do this?
+- **examples**: 3-5 natural language prompts that invoke this specific tool. Rules:
+  - Use conversational phrasing: "Get the secret 'db-password' from key vault 'prod-secrets'" not "keyvault secret get"
+  - Include real resource names, regions, and parameter values (not placeholders like `<name>`)
+  - Vary the prompts: cover the same tool with different parameters, contexts, or resource names
+  - The first example must be the most representative and specific prompt
+  - **For data plane tools** (get, list, query, read, upload, execute): Assume resources already exist. Example: "List all blobs in container 'logs' in storage account 'prodstore'"
+  - **For management plane tools** (create, delete, update, configure): Focus on provisioning. Example: "Create a new key vault named 'prod-secrets' in the East US region"
+  - **Use service-specific terminology**: Include actual feature names, SKU values, tiers, or configuration options relevant to this tool's service
+  - Do NOT generate prompts for operations this tool does not support
+- **expectedOutcome**: Describe what the user sees in the AI assistant's response — the category of result, not fabricated field names. Examples:
+  - "A list of secret names and their enabled/disabled status" ✓
+  - "Confirmation that the container was created with the specified settings" ✓
+  - "The index schema including field names, types, and analyzer configurations" ✓
+  - "Details of the secret value, content type, and expiration date" ✗ (do not assert specific fields unless documented)
+
+### genai-capability
+A single action phrase describing this tool's core user-facing capability.
+- Rephrase the tool description into a user-facing action phrase
+- Start with an action verb: "Create and configure", "Retrieve and inspect", "Delete and remove", "List and filter", "Upload and manage"
+- **MUST NOT end with a period**
+- Focus on the business outcome, not the technical implementation
+- Scope strictly to what this one tool does — do not broaden to the full service
+
+## Content Constraints
+
+**CRITICAL — Ground content to this tool only**:
+- The scenario, examples, and capability must ONLY reference operations this specific tool supports
+- Do NOT invent additional features, related operations, or capabilities this tool does not have
+- If the tool is read-only, the scenario must use read-only prompts — do NOT add write examples
+- If the tool is destructive, acknowledge that in the expectedOutcome (e.g., "Confirmation that the resource was deleted")
+
+**CRITICAL — Authentication Model**:
+- Azure MCP Server uses `DefaultAzureCredential` (Microsoft Entra ID)
+- NEVER mention API keys as an authentication method — not in examples, not in expected outcomes, not anywhere
+- Authentication references (if any) must focus on Entra ID, managed identities, and RBAC role assignments
+
+**CRITICAL — Service Naming**:
+- Use "Microsoft Entra ID" — NEVER "Azure Active Directory" (renamed in 2023)
+- Use the official Azure service name from official documentation
+- Do NOT use shortened names in descriptions (e.g., use "Azure Key Vault" not "Key Vault")
+
+**No trailing periods**:
+- `genai-capability` MUST NOT end with a period
+- `genai-scenario.title` MUST NOT end with a period
+- `genai-shortDescription` should not end with a period (it reads mid-sentence in templates)
+
+**Sentence quality**:
+- No broken sentences: a period followed by a lowercase word (e.g., "manage data. without writing code") is invalid
+- Use second person ("you can", "your key vault") to address readers directly
+- Use "might" instead of "may" ("may" implies permission, "might" implies possibility)
+- Active voice: "create a resource" not "a resource is created"
+- No run-on sentences exceeding 35 words
+
+## Output
+
+Return ONLY valid JSON — no markdown code blocks, no preamble text, no explanations. The response must begin with `{` and end with `}`.

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-user-prompt.txt
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles/prompts/horizontal-article-tool-user-prompt.txt
@@ -1,0 +1,48 @@
+Generate JSON data for a single Azure MCP Server tool used with {{serviceBrandName}}.
+
+## Input Data
+
+**Service Information:**
+- Service Brand Name: {{serviceBrandName}}
+- Service Identifier: {{serviceIdentifier}}
+
+**Tool:**
+- Command: {{toolCommand}}
+- Description: {{toolDescription}}
+- Parameter Count (non-common): {{parameterCount}}
+- Characteristics:
+  - Destructive: {{isDestructive}}
+  - Read-only: {{isReadOnly}}
+  - Requires secrets: {{requiresSecret}}
+
+## Your Task
+
+**FIRST**: Analyze the tool to determine data plane vs management plane focus:
+- **Data plane tools**: Work with data or functionality in existing resources (get, list, query, read, upload, execute, write)
+- **Management plane tools**: Manage resource lifecycle (create, delete, update, provision, configure resources)
+- **Default assumption**: If unclear, assume **data plane** unless the command explicitly includes resource lifecycle verbs such as "create", "delete", or "provision"
+
+**SECOND**: Based on the analysis above, generate a JSON object following the system prompt schema. For each field:
+
+1. **genai-shortDescription**: Condense the tool description to its essential action and target. 10-15 words. Start with a verb. Be specific — include what data or resource type is affected.
+
+2. **genai-scenario**: Create exactly ONE scenario that maps to this specific tool:
+   - `title`: Short action phrase for this scenario. No trailing period.
+   - `description`: One sentence stating the real-world business motivation.
+   - `examples`: 3-5 conversational natural language prompts using real resource names (e.g., "prod-secrets", "eastus", "Standard_LRS"). The first example must be the most representative. For data plane tools, assume the resource already exists. For management plane tools, focus on provisioning.
+   - `expectedOutcome`: Describe the category of result the user sees — do NOT assert specific field names unless documented in the tool description.
+
+3. **genai-capability**: A single action phrase describing what this tool enables. Rephrase the tool description as a user-facing outcome. MUST NOT end with a period.
+
+## Key Constraints
+
+- **Tool grounding**: Every field must be grounded to THIS tool's operation only. Do NOT reference operations, features, or parameters that this tool does not support.
+- **Authentication**: Azure MCP Server uses `DefaultAzureCredential` (Microsoft Entra ID). Do NOT mention API keys anywhere.
+- **Naming**: Use "Microsoft Entra ID" — NEVER "Azure Active Directory".
+- **No trailing periods** on `genai-capability`, `genai-scenario.title`, or `genai-shortDescription`.
+- **Destructive tools**: If `isDestructive` is true, the expectedOutcome must acknowledge the destructive nature (e.g., "Confirmation that the resource was permanently deleted").
+- **Read-only tools**: If `isReadOnly` is true, all examples must be read-only operations — do NOT add write or delete examples.
+
+## Output Format
+
+Return ONLY valid JSON — no markdown code blocks, no explanations. The response must begin with `{` and end with `}`.


### PR DESCRIPTION
## Summary

Fixes token overflow on large namespaces (e.g. storage with 18k+ token input) by splitting the single namespace-level AI call into two types:

1. **Per-tool AI call** (N calls, one per tool) — bounded ~2000 tokens each
2. **Namespace summary AI call** (1 call after all per-tool calls) — compact tool list

## New models
- \Models/PerToolAIData.cs\ — per-tool result: \genai-shortDescription\, \genai-scenario\, \genai-capability\
- \Models/NamespaceSummaryAIData.cs\ — namespace result: service description, overview, prerequisites, roles, best practices, links

## Generator changes
- \GenerateAIContentForTool\ — one AI call per tool, ~2000 token budget, static fallback on AI failure
- \GenerateNamespaceSummaryAIContent\ — one AI call after all per-tool calls, compact tool list
- \AggregateAIData\ — merges both result types into existing \AIGeneratedArticleData\ shape
- \CalculateMaxTokens(toolCount, isPerToolCall)\ overload added; original signature kept
- \GenerateAIContent\ marked \[Obsolete]\ — kept for \GenerateArticleMarkdownAsync\ and graceful legacy fallback
- \GenerateSingleArticleAsync\ falls back to legacy single-call if new prompt files are absent (safe during prompt authoring)

## Template and output shape unchanged
\AIGeneratedArticleData\, \HorizontalArticleTemplateData\, and the Handlebars template are not modified.

## Prompt files (from Sage)
Three new prompt files included in this branch (Sage had already written them).

## Testing
- Build passes: \dotnet build DocGeneration.Steps.HorizontalArticles.csproj --configuration Release\ ✅
- Zero new compiler warnings