### PR TITLE
fix: update timestamp test and help text for readable output folder format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **#666: Readable output folder timestamp format** — `GetDefaultOutputPath()` in `PipelineRequest.cs` now uses `yyyy-MM-dd-HHmmss` instead of `yyyyMMddTHHmmssfffZ`, producing folders like `generated-appconfig-2026-05-31-062940` that are easier to read and sort. CLI help text for `--output` updated to show the new format. Test regex updated to match new pattern. Resolves #666.
+
 - **PRD-QUALITY Item A: Step 3 style guide** — `system-prompt.txt` for `ToolGenerationStep` now includes a "Style Guide for Tool Descriptions" section covering contraction rules (Microsoft Learn style), backtick conventions (CLI flags, example values, tool names), MCP acronym expansion on first body mention, and prohibited patterns (second-person phrases, marketing superlatives, deprecated product names). `user-prompt-template.txt` adds "Tone Consistency Heuristics" for active voice, lead-with-action, and avoiding service-level context in per-tool descriptions. `cli-prose-system-prompt.txt` updated with matching backtick conventions and prohibited patterns.
 - **PRD-QUALITY Item A: TDD contract tests** — `StitcherStep3PromptHandlingTests.cs` added with 6 tests defining the new contract: `FamilyFileStitcher.Stitch()` does NOT apply contractions, MCP acronym expansion, VM acronym expansion, or bare example-value backtick wrapping (these are now Step 3 AI responsibilities).
 - **PRD-QUALITY Item C: Step 4 post-assembly validation extended** — `ToolFamilyPostAssemblyValidator` now runs 6 additional inline checks after tool-family article assembly:

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/CliArgumentParsingTests.cs
@@ -25,7 +25,7 @@ public class CliArgumentParsingTests
         var result = PipelineCli.Parse(["--namespace", "compute"]);
 
         Assert.NotNull(result.Request);
-        Assert.Matches(@"^\.\\generated-compute-\d{8}T\d{9}Z$", result.Request!.OutputPath);
+        Assert.Matches(@"^\.\\generated-compute-\d{4}-\d{2}-\d{2}-\d{6}$", result.Request!.OutputPath);
         Assert.Equal(PipelineRequest.DefaultSteps, result.Request.Steps);
     }
 

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineCli.cs
@@ -152,7 +152,7 @@ public static class PipelineCli
         => new(
             new Option<string?>("--namespace", "Namespace/service area to process. Omit to process all namespaces."),
             new Option<string>("--steps", () => string.Join(',', PipelineRequest.DefaultSteps), "Comma-separated list of step identifiers to run."),
-            new Option<string?>("--output", "Output directory. Defaults to .\\generated-<timestamp> or .\\generated-<namespace>-<timestamp>."),
+            new Option<string?>("--output", "Output directory. Defaults to .\\generated-<yyyy-MM-dd-HHmmss> or .\\generated-<namespace>-<yyyy-MM-dd-HHmmss>."),
             new Option<bool>("--skip-build", "Skip build work and require existing Release outputs."),
             new Option<bool>("--skip-validation", "Skip validation checks executed by the typed runner."),
             new Option<bool>("--skip-env-validation", "Skip Azure OpenAI environment validation during bootstrap."),

--- a/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Cli/PipelineRequest.cs
@@ -65,9 +65,9 @@ public sealed record PipelineRequest(
 
     public static string GetDefaultOutputPath(string? targetNamespace, TimeProvider? timeProvider = null)
     {
-        // Millisecond precision keeps default paths readable while making same-moment collisions vanishingly unlikely.
+        // Human-readable timestamp format (yyyy-MM-dd-HHmmss) keeps default paths easy to sort and identify.
         // Callers can still pass --output explicitly when they need a fully caller-controlled path.
-        var timestamp = (timeProvider ?? TimeProvider.System).GetUtcNow().ToString("yyyyMMddTHHmmssfffZ");
+        var timestamp = (timeProvider ?? TimeProvider.System).GetUtcNow().ToString("yyyy-MM-dd-HHmmss");
         return string.IsNullOrWhiteSpace(targetNamespace)
             ? $".\\generated-{timestamp}"
             : $".\\generated-{targetNamespace.Trim()}-{timestamp}";


### PR DESCRIPTION
## Summary

Resolves #666.

The output folder timestamp format was changed from \yyyyMMddTHHmmssfffZ\ (e.g. \generated-appconfig-20260531T062940173Z\) to \yyyy-MM-dd-HHmmss\ (e.g. \generated-appconfig-2026-05-31-062940\) for better readability and sortability.

## Changes

| File | Change |
|------|--------|
| \PipelineRequest.cs\ | Format string updated to \yyyy-MM-dd-HHmmss\; comment updated |
| \CliArgumentParsingTests.cs\ | Regex updated from \\d{8}T\d{9}Z\ to \\d{4}-\d{2}-\d{2}-\d{6}\ |
| \PipelineCli.cs\ | \--output\ help text now shows \yyyy-MM-dd-HHmmss\ format |
| \CHANGELOG.md\ | Entry added under \[Unreleased]\ |

## Tests

11 CLI argument parsing tests pass. Zero warnings in Release build.