### PR TITLE
fix: pin azure.mcp to 3.0.0-beta.15 in run-focus.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Cosmos regeneration no longer downgrades `azure.mcp` from prerelease to stable** — `run-focus.sh` now pre-installs `azure.mcp@3.0.0-beta.15` before dispatching any namespace and always forwards `--skip-npm-update` to `start.sh`, preventing `BootstrapStep` from attempting a conflicting stable-tool downgrade during focus runs.
+
 - **#673: MCP Server tab now appears before CLI tab** — `CliTabWrapper.BuildTabBlock()` previously emitted the Azure MCP CLI tab first, then the MCP Server tab. The order is now corrected: MCP Server tab is emitted first, followed by the Azure MCP CLI tab. All existing `CliTabWrapperTests` updated to reflect the new ordering; new unit test `WrapWithTabs_McpServerTabAppearsBeforeCliTab` added. Resolves #673.
 
 - **#664A: `prompt-preview.txt` never written for AI/Hybrid pipeline steps** — `ObservabilityWriter.WritePromptPreview()` added and called for all non-deterministic steps (Steps 2, 3, 4, 6) in `PipelineRunner.WriteObservabilityOutputs()`. Previously only deterministic steps wrote `prompt-preview-na.txt`, leaving AI/Hybrid steps without the file `StageOutputContract` expected, causing a spurious "observability contract missing file" warning on every AI step run. The new method writes a pipeline-level placeholder (`"AI step — prompt preview not captured at pipeline level."`) that satisfies the contract. Test `RunAsync_AiStep_MissingPromptPreviewLogsWarning` renamed to `RunAsync_AiStep_WritesPromptPreviewAndNoContractWarning` and updated to assert the file is present and no contract warning is emitted; `WritePromptPreview_CreatesFileWithExpectedContent` unit test added. Resolves #664 sub-issue A.

--- a/docs/START-SCRIPTS.md
+++ b/docs/START-SCRIPTS.md
@@ -138,6 +138,17 @@ Each namespace writes to its own `generated-{namespace}/` directory with no shar
 # Check: generated-advisor/reports/tool-family-validation-*.txt
 ```
 
+## Focus Regression Helper
+
+`run-focus.sh` is a thin convenience wrapper for high-friction namespace combinations such as `cosmos`, `storage`, and `monitor-workbooks`.
+
+```bash
+./run-focus.sh cosmos
+./run-focus.sh storage 3,4 --dry-run
+```
+
+Before dispatching any namespace, `run-focus.sh` ensures `azure.mcp@3.0.0-beta.15` is installed and always forwards `--skip-npm-update` to `start.sh`. This keeps focus runs on the expected prerelease tool version and prevents `BootstrapStep` from trying to downgrade to the latest stable package during regeneration.
+
 ## Post-Assembly Merge (AD-011)
 
 After all namespaces complete, `start.sh` automatically calls `merge-namespaces.sh` to combine multi-namespace tool-family articles. This is config-driven via `brand-to-server-mapping.json` merge fields.

--- a/run-focus.sh
+++ b/run-focus.sh
@@ -22,11 +22,24 @@ YELLOW='\033[0;33m'
 RED='\033[0;31m'
 RESET='\033[0m'
 
+MCP_VERSION="3.0.0-beta.15"
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 info()    { echo -e "${YELLOW}[run-focus] $*${RESET}"; }
 success() { echo -e "${GREEN}[run-focus] $*${RESET}"; }
 error()   { echo -e "${RED}[run-focus] ERROR: $*${RESET}" >&2; }
+
+ensure_mcp_version() {
+    info "Ensuring azure.mcp@${MCP_VERSION} is installed..."
+    if dotnet tool update --global azure.mcp --version "$MCP_VERSION" 2>/dev/null; then
+        success "azure.mcp updated to ${MCP_VERSION}"
+    elif dotnet tool install --global azure.mcp --version "$MCP_VERSION" 2>/dev/null; then
+        success "azure.mcp installed at ${MCP_VERSION}"
+    else
+        error "azure.mcp@${MCP_VERSION} is already at this version or install failed — continuing"
+    fi
+}
 
 print_header() {
     local label="$1"
@@ -132,6 +145,7 @@ done
 # Build the args array to forward to start.sh
 START_ARGS=()
 [[ -n "$STEPS" ]] && START_ARGS+=("$STEPS")
+START_ARGS+=("--skip-npm-update")
 START_ARGS+=("${EXTRA_FLAGS[@]+"${EXTRA_FLAGS[@]}"}")
 
 # ── dispatch ──────────────────────────────────────────────────────────────────
@@ -150,9 +164,11 @@ run_monitor_workbooks() {
     fi
 }
 
+ensure_mcp_version
+
 case "$TARGET" in
     monitor-workbooks)
-        run_monitor_workbooks
+    run_monitor_workbooks
         ;;
     storage)
         run_namespace "storage" "${START_ARGS[@]+"${START_ARGS[@]}"}"

--- a/tests/run-focus-version-pin.test.sh
+++ b/tests/run-focus-version-pin.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_ROOT="$REPO_ROOT/.test-artifacts/run-focus-version-pin"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_file_contains() {
+    local file="$1"
+    local expected="$2"
+    grep -F -- "$expected" "$file" >/dev/null || fail "Expected '$expected' in $file"
+}
+
+assert_file_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -F -- "$unexpected" "$file" >/dev/null; then
+        fail "Did not expect '$unexpected' in $file"
+    fi
+}
+
+setup_fixture() {
+    rm -rf "$TEST_ROOT"
+    mkdir -p "$TEST_ROOT/bin"
+    cp "$REPO_ROOT/run-focus.sh" "$TEST_ROOT/run-focus.sh"
+
+    cat > "$TEST_ROOT/start.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >> "$TEST_ROOT/start-args.log"
+EOF
+    chmod +x "$TEST_ROOT/start.sh"
+
+    cat > "$TEST_ROOT/bin/dotnet" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_ROOT/dotnet.log"
+if [[ "${1-}" == "tool" && "${2-}" == "update" ]]; then
+    if [[ "${DOTNET_UPDATE_EXIT:-0}" == "0" ]]; then
+        exit 0
+    fi
+    exit "${DOTNET_UPDATE_EXIT}"
+fi
+if [[ "${1-}" == "tool" && "${2-}" == "install" ]]; then
+    exit "${DOTNET_INSTALL_EXIT:-0}"
+fi
+exit 0
+EOF
+    chmod +x "$TEST_ROOT/bin/dotnet"
+}
+
+run_fixture() {
+    local scenario="$1"
+    shift
+
+    rm -f "$TEST_ROOT/dotnet.log" "$TEST_ROOT/start-args.log"
+    (
+        export TEST_ROOT
+        export PATH="$TEST_ROOT/bin:$PATH"
+        export DOTNET_UPDATE_EXIT="${DOTNET_UPDATE_EXIT:-0}"
+        export DOTNET_INSTALL_EXIT="${DOTNET_INSTALL_EXIT:-0}"
+        cd "$TEST_ROOT"
+        bash ./run-focus.sh "$@"
+    ) >"$TEST_ROOT/$scenario.out" 2>&1
+}
+
+test_update_path() {
+    setup_fixture
+    DOTNET_UPDATE_EXIT=0 DOTNET_INSTALL_EXIT=99 run_fixture update-path cosmos 4 --dry-run
+
+    assert_file_contains "$TEST_ROOT/dotnet.log" "tool update --global azure.mcp --version 3.0.0-beta.15"
+    assert_file_not_contains "$TEST_ROOT/dotnet.log" "tool install --global azure.mcp --version 3.0.0-beta.15"
+
+    cat > "$TEST_ROOT/expected-start-args.log" <<'EOF'
+cosmos
+4
+--skip-npm-update
+--dry-run
+EOF
+    cmp -s "$TEST_ROOT/start-args.log" "$TEST_ROOT/expected-start-args.log" || fail "Unexpected start.sh args for update path"
+}
+
+test_install_fallback_path() {
+    setup_fixture
+    DOTNET_UPDATE_EXIT=1 DOTNET_INSTALL_EXIT=0 run_fixture install-fallback storage --skip-deps
+
+    assert_file_contains "$TEST_ROOT/dotnet.log" "tool update --global azure.mcp --version 3.0.0-beta.15"
+    assert_file_contains "$TEST_ROOT/dotnet.log" "tool install --global azure.mcp --version 3.0.0-beta.15"
+
+    cat > "$TEST_ROOT/expected-start-args.log" <<'EOF'
+storage
+--skip-npm-update
+--skip-deps
+EOF
+    cmp -s "$TEST_ROOT/start-args.log" "$TEST_ROOT/expected-start-args.log" || fail "Unexpected start.sh args for install fallback"
+}
+
+test_update_path
+test_install_fallback_path
+
+rm -rf "$TEST_ROOT"
+echo "PASS: run-focus version pin tests"


### PR DESCRIPTION
## Summary

Fixes cosmos namespace regeneration failure where BootstrapStep's
`dotnet tool update azure.mcp --global` tried to downgrade from
prerelease `3.0.0-beta.13` to stable `2.0.2`, causing:

> The requested version 2.0.2 is lower than existing version 3.0.0-beta.13.

## Changes

- Added `MCP_VERSION="3.0.0-beta.15"` constant
- Added `ensure_mcp_version()` to pre-install the correct version
- Always pass `--skip-npm-update` to skip BootstrapStep's conflicting update

## Related

Enables `run-focus.sh cosmos` to run successfully for cosmos namespace regeneration.