### PR TITLE
fix: add dotnet PATH resolution for Git Bash on Windows

### DIFF
--- a/run-focus.sh
+++ b/run-focus.sh
@@ -16,6 +16,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Resolve dotnet on PATH for Git Bash on Windows (no-op on Linux/macOS/CI)
+if ! command -v dotnet &>/dev/null; then
+    for _dotnet_dir in "/c/Program Files/dotnet" "${LOCALAPPDATA:-}/Microsoft/dotnet"; do
+        if [[ -x "$_dotnet_dir/dotnet" ]]; then
+            export PATH="$_dotnet_dir:$PATH"
+            break
+        fi
+    done
+    if ! command -v dotnet &>/dev/null; then
+        echo "WARNING: dotnet not found on PATH — commands may fail" >&2
+    fi
+fi
+
 # Colors
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
When run-focus.sh is executed from Git Bash on Windows, \dotnet\ isn't on PATH because it's a Windows binary installed to \C:\Program Files\dotnet\. This adds PATH discovery at the top of run-focus.sh that checks common install locations if \dotnet\ isn't already available. No-op on Linux/macOS/CI where dotnet is already on PATH.