### PR TITLE
fix: start.sh copies root .env to mcp-tools/ or errors if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`start.sh` now copies the repo-root `.env` into `mcp-tools/.env` before running the pipeline** — the script now fails immediately with a clear message when `.env` is missing at the repo root, instead of letting credential validation fail later in bootstrap.
+
 - **BootstrapStep no longer fails when a newer prerelease of `azure.mcp` is already installed** — `mcp-tool-version.txt` at repo root is now the single source of truth for the azure.mcp version. `BootstrapStep` reads this file and passes `--version` to `dotnet tool update`, preventing a downgrade from `3.0.0-beta.15` to the latest stable `2.0.2`. "Already at this version" exit codes are treated as success. `run-focus.sh` also reads from the same file. When the file is absent, the previous behaviour (update to latest) is preserved with a warning.
 
 - **Cosmos regeneration no longer downgrades `azure.mcp` from prerelease to stable** — `run-focus.sh` now pre-installs `azure.mcp@3.0.0-beta.15` before dispatching any namespace and always forwards `--skip-npm-update` to `start.sh`, preventing `BootstrapStep` from attempting a conflicting stable-tool downgrade during focus runs.

--- a/start.sh
+++ b/start.sh
@@ -25,9 +25,21 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$ROOT_DIR"
 NAMESPACE_ARG=""
 STEPS_ARG="1,2,3,4,5,6"
 EXTRA_ARGS=()
+
+ENV_SOURCE="$SCRIPT_DIR/.env"
+ENV_TARGET="$SCRIPT_DIR/mcp-tools/.env"
+
+if [[ -f "$ENV_SOURCE" ]]; then
+    cp "$ENV_SOURCE" "$ENV_TARGET"
+    echo "[start] Copied .env → mcp-tools/.env"
+else
+    echo "[start] ERROR: .env not found at repo root. Create .env with FOUNDRY_API_KEY, FOUNDRY_ENDPOINT, FOUNDRY_MODEL_NAME." >&2
+    exit 1
+fi
 
 # If first arg starts with -, pass all args through directly to DocGeneration.PipelineRunner
 if [[ $# -gt 0 && "$1" =~ ^- ]]; then


### PR DESCRIPTION
## Summary

The pipeline requires \.env\ with FOUNDRY credentials in \mcp-tools/\, but the file lives at the repo root. Previously, if the file was missing from \mcp-tools/\, the pipeline would fail deep in Step 0 with an opaque error.

## Fix

- At the start of \start.sh\, check for \.env\ at repo root
- If found: copy to \mcp-tools/.env\ (ensures pipeline always has credentials)
- If not found: exit immediately with a clear error message listing required variables

This makes the failure mode obvious and self-documenting.