### PR TITLE
feat: PR-aware skills content audit (-IncludePRs)

### DIFF
--- a/skills-generation/scripts/audit-content-architecture.ps1
+++ b/skills-generation/scripts/audit-content-architecture.ps1
@@ -1,4 +1,4 @@
-# Usage: .\skills-generation\scripts\audit-content-architecture.ps1 [-InventoryPath <path>] [-ArticlesDir <path>] [-SourceDir <path>] [-ReportPath <path>] [-CI]
+# Usage: .\skills-generation\scripts\audit-content-architecture.ps1 [-InventoryPath <path>] [-ArticlesDir <path>] [-SourceDir <path>] [-ReportPath <path>] [-ContentRepo <owner/repo>] [-CI]
 <#
 .SYNOPSIS
     Audits generated skills content against the Skills Content Architecture model.
@@ -14,6 +14,8 @@ param(
     [string]$ArticlesDir,
     [string]$SourceDir,
     [string]$ReportPath,
+    [string]$ContentRepo = 'MicrosoftDocs/azure-dev-docs-pr',
+    [switch]$IncludePRs,
     [switch]$CI
 )
 
@@ -658,6 +660,64 @@ function Test-SourceSufficiency {
     }
 }
 
+# --- PR Content Fetching ---
+
+function Get-OpenSkillsPRs {
+    param([string]$Repo)
+
+    $prData = @{}
+    try {
+        $json = gh pr list --repo $Repo --search "skill" --state open --json number,title,headRefName,files --limit 50 2>$null
+        if (-not $json) { return $prData }
+        $prs = $json | ConvertFrom-Json
+        foreach ($pr in $prs) {
+            foreach ($f in $pr.files) {
+                if ($f.path -match 'articles/azure-skills/skills/(.+)\.md$') {
+                    $slug = $Matches[1]
+                    $prData[$slug] = [PSCustomObject]@{
+                        Number      = $pr.number
+                        Title       = $pr.title
+                        HeadRef     = $pr.headRefName
+                        FilePath    = $f.path
+                    }
+                    break
+                }
+            }
+        }
+    }
+    catch {
+        Write-Warning "Failed to fetch open PRs from $Repo : $_"
+    }
+    return $prData
+}
+
+function Get-PRArticleContent {
+    param(
+        [string]$Repo,
+        [int]$PRNumber,
+        [string]$FilePath
+    )
+
+    try {
+        # Get PR head branch info
+        $prJson = gh pr view $PRNumber --repo $Repo --json headRefName,headRepository,headRepositoryOwner 2>$null | ConvertFrom-Json
+        $headRef = $prJson.headRefName
+        $headOwner = $prJson.headRepositoryOwner.login
+        $headRepoName = $prJson.headRepository.name
+        # Fetch raw file content using the media type for raw content
+        $content = gh api "repos/$headOwner/$headRepoName/contents/$FilePath" --header "Accept: application/vnd.github.raw+json" --method GET --field "ref=$headRef" 2>$null
+        if ($content) {
+            return $content
+        }
+    }
+    catch {
+        Write-Warning "Failed to fetch PR #$PRNumber content: $_"
+    }
+    return $null
+}
+
+# --- Main Execution ---
+
 $resolvedInventoryPath = Resolve-ScriptRelativePath -Path $InventoryPath -DefaultRelativePath '..\data\skills-inventory.json'
 $resolvedArticlesDir = Resolve-ScriptRelativePath -Path $ArticlesDir -DefaultRelativePath '.\published-cache'
 $resolvedSourceDir = Resolve-ScriptRelativePath -Path $SourceDir -DefaultRelativePath '..\..\mcp-tools\skills-source'
@@ -685,6 +745,14 @@ if (-not (Test-Path -LiteralPath $reportDirectory)) {
 $inventory = Get-Content -Path $resolvedInventoryPath -Raw | ConvertFrom-Json
 $skills = @($inventory.skills)
 $sourceDirectories = @(Get-ChildItem -Path $resolvedSourceDir -Directory | Where-Object { $_.Name -ne 'sync-metadata.json' })
+
+# Fetch open PRs if requested
+$openPRs = @{}
+if ($IncludePRs) {
+    Write-Host "Fetching open skills PRs from $ContentRepo..." -ForegroundColor Cyan
+    $openPRs = Get-OpenSkillsPRs -Repo $ContentRepo
+    Write-Host "  Found $($openPRs.Count) skills with open PRs" -ForegroundColor Green
+}
 
 Write-Host "Running check A: Inventory Coverage" -ForegroundColor Cyan
 $inventoryCoverage = Test-InventoryCoverage -Skills $skills -ArticlesDirectory $resolvedArticlesDir -SourceDirectories $sourceDirectories
@@ -714,6 +782,27 @@ foreach ($skill in $skills) {
     $articlePath = Join-Path $resolvedArticlesDir ("{0}.md" -f $slug)
     $hasArticle = Test-Path -LiteralPath $articlePath
     $articleAnalysis = if ($hasArticle) { Get-ArticleAnalysis -Path $articlePath } else { $null }
+
+    # Check for PR content — overrides or supplements published article
+    $prInfo = $null
+    $articleSource = 'published'
+    if ($IncludePRs -and $openPRs.ContainsKey($slug)) {
+        $prInfo = $openPRs[$slug]
+        Write-Host ("  PR #{0} found: {1}" -f $prInfo.Number, $prInfo.Title) -ForegroundColor DarkYellow
+        $prContent = Get-PRArticleContent -Repo $ContentRepo -PRNumber $prInfo.Number -FilePath $prInfo.FilePath
+        if ($prContent) {
+            # PR content is clean markdown — use it for analysis (overrides published cache)
+            $prTempPath = Join-Path $env:TEMP ("audit-pr-{0}.md" -f $slug)
+            Set-Content -Path $prTempPath -Value $prContent -Encoding UTF8
+            $articleAnalysis = Get-ArticleAnalysis -Path $prTempPath
+            Remove-Item -Path $prTempPath -Force -ErrorAction SilentlyContinue
+            $hasArticle = $true
+            $articleSource = 'pr'
+        }
+        else {
+            Write-Warning "  Could not fetch PR content for $slug — falling back to published cache"
+        }
+    }
 
     $sourceResolution = Resolve-SourceDirectory -Skill $skill -SourceDirectories $sourceDirectories
     $sourceAnalysis = $null
@@ -796,7 +885,7 @@ foreach ($skill in $skills) {
         Skill         = $skillLabel
         Identity      = if ($identityResult.IsComplete) { '✓' } else { '✗' }
         Source        = if ($sourceSufficiency.Skipped) { '⏸️' } elseif ($sourceSufficiency.Passed) { '✓' } else { '⚠️' }
-        Article       = if ($hasArticle) { '✓' } else { '⏸️' }
+        Article       = if (-not $hasArticle) { '⏸️' } elseif ($articleSource -eq 'pr') { "✓ (PR #$($prInfo.Number))" } else { '✓' }
         Coverage      = if (-not $hasArticle) { '⏸️' } elseif ($coverageResult.Passed) { '✓' } else { '✗' }
         NoLeakage     = if (-not $hasArticle) { '⏸️' } elseif ($leakageResult.Passed) { '✓' } else { '⚠️' }
         Conditional   = if (-not $hasArticle) { '⏸️' } elseif ($conditionalResult.Passed) { '✓' } else { '✗' }
@@ -814,6 +903,10 @@ $reportLines = @()
 $reportLines += '# Skills Content Architecture Audit Report'
 $reportLines += ''
 $reportLines += ('Generated: {0}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss K'))
+if ($IncludePRs) {
+    $reportLines += ''
+    $reportLines += ('**Article sources:** Published cache + {0} open PRs from `{1}`' -f $openPRs.Count, $ContentRepo)
+}
 $reportLines += ''
 $reportLines += '## Summary'
 $reportLines += ''

--- a/skills-generation/scripts/audit-report-2026-06-04-pr-aware.md
+++ b/skills-generation/scripts/audit-report-2026-06-04-pr-aware.md
@@ -1,0 +1,111 @@
+# Skills Content Architecture Audit Report
+
+Generated: 2026-06-04 18:33:48 -07:00
+
+**Article sources:** Published cache + 22 open PRs from `MicrosoftDocs/azure-dev-docs-pr`
+
+## Summary
+
+| Check | Status | Details |
+|-------|--------|---------|
+| A. Inventory Coverage | ⚠️ | 24 generated, 1 pending, 190 source folders not in inventory |
+| B. Identity Completeness | ✅ | 25/25 fully complete, version coverage 8% |
+| C. User-Facing Coverage | ✅ | 24/24 pass all required sections |
+| D. Internal Leakage | ⚠️ | 5 leakage findings |
+| E. Conditional Rendering | ✅ | 1 conditional sections found, 0 mismatches (presence/absence only; Tier 1 assumed offline) |
+| F. Unmapped Headings | ⚠️ | 40 unmapped headings across 6 skills |
+| G. Source Sufficiency | ✅ | 6/6 sources sufficient, 6 prompt-source warnings |
+
+## Conformance Matrix
+
+| Skill | Identity ✓ | Source ✓ | Article ✓ | Coverage ✓ | No Leakage ✓ | Conditional ✓ | Unmapped |
+|-------|---|---|---|---|---|---|---|
+| azure-ai | ✓ | ✓ | ✓ (PR #9189) | ✓ | ✓ | ✓ | 8 |
+| azure-aigateway | ✓ | ⏸️ | ✓ (PR #9190) | ✓ | ✓ | ✓ | n/a |
+| azure-hosted-copilot-sdk | ✓ | ⏸️ | ✓ (PR #9192) | ✓ | ✓ | ✓ | n/a |
+| microsoft-foundry | ✓ | ⏸️ | ✓ (PR #9136) | ✓ | ✓ | ✓ | n/a |
+| azure-kusto | ✓ | ⏸️ | ✓ (PR #9196) | ✓ | ✓ | ✓ | n/a |
+| azure-messaging | ✓ | ⏸️ | ✓ (PR #9193) | ✓ | ✓ | ✓ | n/a |
+| azure-storage | ✓ | ⏸️ | ✓ (PR #9195) | ✓ | ✓ | ✓ | n/a |
+| azure-deploy | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 7 |
+| azure-prepare | ✓ | ⏸️ | ✓ (PR #9200) | ✓ | ✓ | ✓ | n/a |
+| azure-upgrade | ✓ | ⏸️ | ✓ (PR #9077) | ✓ | ✓ | ✓ | n/a |
+| azure-validate | ✓ | ⏸️ | ✓ (PR #9197) | ✓ | ✓ | ✓ | n/a |
+| airunway-aks-setup | ✓ | ⏸️ | ⏸️ | ⏸️ | ⏸️ | ⏸️ | n/a |
+| azure-compute | ✓ | ⏸️ | ✓ (PR #9204) | ✓ | ✓ | ✓ | n/a |
+| azure-enterprise-infra-planner | ✓ | ⏸️ | ✓ (PR #9194) | ✓ | ✓ | ✓ | n/a |
+| azure-kubernetes | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 9 |
+| azure-cloud-migrate | ✓ | ⏸️ | ✓ (PR #9203) | ✓ | ✓ | ✓ | n/a |
+| appinsights-instrumentation | ✓ | ⏸️ | ✓ (PR #9198) | ✓ | ✓ | ✓ | n/a |
+| azure-cost | ✓ | ✓ | ✓ (PR #9191) | ✓ | ⚠️ | ✓ | 8 |
+| azure-diagnostics | ✓ | ⏸️ | ✓ (PR #9135) | ✓ | ✓ | ✓ | n/a |
+| azure-quotas | ✓ | ✓ | ✓ (PR #9201) | ✓ | ✓ | ✓ | 1 |
+| azure-resource-lookup | ✓ | ⏸️ | ✓ (PR #9199) | ✓ | ✓ | ✓ | n/a |
+| azure-resource-visualizer | ✓ | ⏸️ | ✓ (PR #9202) | ✓ | ✓ | ✓ | n/a |
+| azure-compliance | ✓ | ⏸️ | ✓ (PR #9205) | ✓ | ✓ | ✓ | n/a |
+| azure-rbac | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 7 |
+| entra-app-registration | ✓ | ⏸️ | ✓ (PR #9206) | ✓ | ✓ | ✓ | n/a |
+
+## Detailed Findings
+
+### C. User-Facing Coverage (failures only)
+
+> No user-facing coverage failures detected.
+
+### D. Internal Leakage (findings only)
+
+- **azure-cost**
+  - MCP tool name: azure__documentation
+  - MCP tool name: azure__extension_cli_generate
+  - MCP tool name: azure__get_azure_bestpractices
+  - MCP tool name: azure__extension_azqr
+  - MCP tool name: azure__aks
+
+### E. Conditional Rendering (mismatches only)
+
+> No conditional rendering mismatches detected. Offline validation is limited to section presence/absence.
+
+### F. Unmapped Headings
+
+- **azure-ai**: Troubleshooting, Best Practices, Decision Making, Limits & Quotas, Security, Configuration, Integrations & Coding Patterns, Deployment
+- **azure-deploy**: Troubleshooting, Best Practices, Limits & Quotas, Security, Configuration, Integrations & Coding Patterns, Deployment
+- **azure-kubernetes**: Troubleshooting, Best Practices, Decision Making, Architecture & Design Patterns, Limits & Quotas, Security, Configuration, Integrations & Coding Patterns, Deployment
+- **azure-cost**: Troubleshooting, Best Practices, Decision Making, Limits & Quotas, Security, Configuration, Integrations & Coding Patterns, Deployment
+- **azure-quotas**: Limits & Quotas
+- **azure-rbac**: Troubleshooting, Best Practices, Decision Making, Limits & Quotas, Security, Configuration, Integrations & Coding Patterns
+
+**Mapping warnings**
+- No matching source folder found for 'azure-aigateway'
+- No matching source folder found for 'azure-hosted-copilot-sdk'
+- No matching source folder found for 'microsoft-foundry'
+- No matching source folder found for 'azure-kusto'
+- No matching source folder found for 'azure-messaging'
+- No matching source folder found for 'azure-storage'
+- No matching source folder found for 'azure-prepare'
+- No matching source folder found for 'azure-upgrade'
+- No matching source folder found for 'azure-validate'
+- No matching source folder found for 'airunway-aks-setup'
+- No matching source folder found for 'azure-compute'
+- No matching source folder found for 'azure-enterprise-infra-planner'
+- No matching source folder found for 'azure-cloud-migrate'
+- No matching source folder found for 'appinsights-instrumentation'
+- No matching source folder found for 'azure-diagnostics'
+- No matching source folder found for 'azure-resource-lookup'
+- No matching source folder found for 'azure-resource-visualizer'
+- No matching source folder found for 'azure-compliance'
+- No matching source folder found for 'entra-app-registration'
+
+### G. Source Sufficiency (warnings only)
+
+- **azure-ai**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)
+- **azure-deploy**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)
+- **azure-kubernetes**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)
+- **azure-cost**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)
+- **azure-quotas**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)
+- **azure-rbac**
+  - No example-prompt source reference detected (expected triggers.test.ts or curated JSON reference)


### PR DESCRIPTION
Extends the skills content architecture audit tool to fetch article content from open PRs on MicrosoftDocs/azure-dev-docs-pr, giving a more accurate picture of content coverage.

New params: -IncludePRs (enable PR fetching), -ContentRepo (target repo).

Results: Category C passes 24/24 with PR content (was 22/24 published-only). azure-cost leakage persists in PR. airunway-aks-setup needs slug field fix.

Usage: .\skills-generation\scripts\audit-content-architecture.ps1 -IncludePRs