### PR TITLE
(ignore) fix tool-family example prompt header recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Step 4 preserves rewritten example prompt blocks** — `DuplicateExampleStripper` now canonicalizes a tool section's only bare `Examples` / `Examples:` / `Example prompts:` bullet block back to `Example prompts include:` instead of deleting it as a duplicate. This prevents `ToolFamilyPostAssemblyValidator` failures such as `instrumentation-get-learning-resource: no example prompt header found` when Step 3 rewrites the generated example-prompt header. Regression coverage uses the real Azure Monitor instrumentation learning-resource shape and keeps duplicate removal unchanged when the canonical block is already present.
+
 - **Keyless verification follow-up** — Renamed new keyless test files to the repository `ValidateAIOptionsKeylessTests` convention, added constructor-level horizontal article auth regression coverage, and made `verify-keyless` print per-suite plus overall PASS/FAIL labels.
 
 - **Horizontal article generation no longer rejects keyless auth** — `HorizontalArticleGenerator` now requires `FOUNDRY_API_KEY` only when `FOUNDRY_USE_DEFAULT_CREDENTIAL` is not enabled, matching the Step 6 program validation and the shared `GenerativeAIClient` keyless path. A regression test fails with the previous `FOUNDRY_API_KEY not set` constructor exception.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Multi-namespace merge now honors mapped article filenames** — `merge-namespaces.sh` now reads each merge member's `fileName` from `brand-to-server-mapping.json` when loading and writing canonical and `-cli` tool-family articles, instead of assuming article filenames match MCP namespace names. This lets merge groups such as `monitor` + `workbooks` merge `azure-monitor.md` + `azure-workbooks.md` into the combined `azure-monitor.md`. The shipping merge smoke test now uses mapped filenames that differ from namespace names so the regression is covered.
+
 - **Step 4 preserves rewritten example prompt blocks** — `DuplicateExampleStripper` now canonicalizes a tool section's only bare `Examples` / `Examples:` / `Example prompts:` bullet block back to `Example prompts include:` instead of deleting it as a duplicate. This prevents `ToolFamilyPostAssemblyValidator` failures such as `instrumentation-get-learning-resource: no example prompt header found` when Step 3 rewrites the generated example-prompt header. Regression coverage uses the real Azure Monitor instrumentation learning-resource shape and keeps duplicate removal unchanged when the canonical block is already present.
 
 - **Keyless verification follow-up** — Renamed new keyless test files to the repository `ValidateAIOptionsKeylessTests` convention, added constructor-level horizontal article auth regression coverage, and made `verify-keyless` print per-suite plus overall PASS/FAIL labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Example-prompt validation now recognizes singular placeholders for plural ID parameters** — `ParameterCoverageChecker` now treats singular word variants such as `id` as matching plural required-parameter words such as `ids` when validating placeholders. This allows prompts like `<workbook_resource_id>` to satisfy the required `workbook-ids` parameter while still treating placeholder use separately from concrete-value coverage. A shared regression test covers the Azure Workbooks delete shape.
+
 - **Multi-namespace merge now honors mapped article filenames** — `merge-namespaces.sh` now reads each merge member's `fileName` from `brand-to-server-mapping.json` when loading and writing canonical and `-cli` tool-family articles, instead of assuming article filenames match MCP namespace names. This lets merge groups such as `monitor` + `workbooks` merge `azure-monitor.md` + `azure-workbooks.md` into the combined `azure-monitor.md`. The shipping merge smoke test now uses mapped filenames that differ from namespace names so the regression is covered.
 
 - **Step 4 preserves rewritten example prompt blocks** — `DuplicateExampleStripper` now canonicalizes a tool section's only bare `Examples` / `Examples:` / `Example prompts:` bullet block back to `Example prompts include:` instead of deleting it as a duplicate. This prevents `ToolFamilyPostAssemblyValidator` failures such as `instrumentation-get-learning-resource: no example prompt header found` when Step 3 rewrites the generated example-prompt header. Regression coverage uses the real Azure Monitor instrumentation learning-resource shape and keeps duplicate removal unchanged when the canonical block is already present.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,6 +263,8 @@ These are reliable, testable fixes that compensate for AI inconsistency.
 
 Some Azure services span multiple MCP namespaces but publish as a single article (e.g., `monitor` + `workbooks` → `monitor.md`). Rather than threading multi-namespace awareness through all 6 pipeline steps, a **post-assembly merge** runs after all namespaces complete:
 
+Merge member articles are resolved by each mapping's `fileName` value, not by the raw MCP namespace. For example, the `monitor` namespace writes `azure-monitor.md` and the `workbooks` namespace writes `azure-workbooks.md`; the merge writes the combined article back to the primary mapped filename, `azure-monitor.md`.
+
 1. Each namespace generates independently through Steps 1-6
 2. `merge-namespaces.sh` reads merge group config from `brand-to-server-mapping.json`
 3. Grouped namespaces are combined using three optional fields:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,7 +252,7 @@ The `FamilyFileStitcher.Stitch()` method chains 9 deterministic fixes after AI a
 3. Related content assembly (append related content section)
 4. `PostProcessor.ExpandMcpAcronym()` — expand "MCP" on first body mention
 5. `FrontmatterEnricher.Enrich()` — inject required Microsoft Learn fields
-6. `DuplicateExampleStripper.Strip()` — remove non-canonical example blocks
+6. `DuplicateExampleStripper.Strip()` — remove duplicate non-canonical example blocks, or canonicalize a section's only example-prompt block back to `Example prompts include:`
 7. `AnnotationSpaceFixer.Fix()` — blank line between annotation link and values
 8. `ContractionFixer.Fix()` — "does not" → "doesn't", etc. (backtick-aware)
 9. `ExampleValueBackticker.Fix()` — wrap bare values in `(for example, VALUE)` with backticks

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -4,6 +4,7 @@ using PipelineRunner.Contracts;
 using PipelineRunner.Services;
 using PipelineRunner.Validation;
 using PipelineRunner.Tests.Fixtures;
+using ToolFamilyCleanup.Services;
 using Xunit;
 
 namespace PipelineRunner.Tests.Unit;
@@ -313,6 +314,57 @@ public class ToolFamilyPostAssemblyValidatorTests
             Assert.Contains(result.Warnings, warning =>
                 warning.Contains("list", StringComparison.OrdinalIgnoreCase)
                 && warning.Contains("no example prompt header", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BareExamplesBlock_AfterDuplicateExampleStripper_NoExampleHeaderWarning()
+    {
+        // Regression test (reviewer: Sam — PR #725):
+        // Proves that after DuplicateExampleStripper.Strip() recovers the canonical header
+        // from a bare "Examples" block (the Step 3 AI-rewrite failure shape), the
+        // post-assembly validator does NOT report "no example prompt header found".
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "compute-list.md"), "compute list");
+
+            // Raw content: Step 3 AI downgraded "Example prompts include:" to bare "Examples"
+            // (no colon, no heading marker). Validator would emit "no example prompt header
+            // found" on this raw content. Strip() must recover it first.
+            var rawContent = """
+                ---
+                title: Compute tools
+                tool_count: 1
+                ---
+                # Compute tools
+
+                ## List virtual machines
+                <!-- @mcpcli compute list -->
+                Lists virtual machines in the subscription.
+
+                Examples
+
+                - "List all virtual machines in resource group 'rg-prod'."
+                - "Show all virtual machines in location 'eastus'."
+
+                ## Related content
+                - Link
+                """;
+
+            var strippedContent = DuplicateExampleStripper.Strip(rawContent);
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), strippedContent);
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Contains("no example prompt header found", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/mcp-tools/DocGeneration.PromptRegression.Tests/Tests/MetricsComparisonTests.cs
+++ b/mcp-tools/DocGeneration.PromptRegression.Tests/Tests/MetricsComparisonTests.cs
@@ -135,10 +135,8 @@ public class MetricsComparisonTests
         Assert.True(comparison.SectionDelta < 0);
     }
 
-    [Theory]
-    [InlineData(0.06, true)]
-    [InlineData(0.04, false)]
-    public void HasImprovements_ContractionRateThreshold_RespectsBoundary(double delta, bool expected)
+    [Fact]
+    public void HasImprovements_ContractionRateThreshold_RespectsBoundary()
     {
         // Build metrics with controlled contraction rates to test the 0.05 threshold
         var baselineContent = "# Test\n\nYou do not need this. It is not required. They are not available. We do not support it.";

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/DocumentationGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/DocumentationGeneratorTests.cs
@@ -346,7 +346,7 @@ public class DocumentationGeneratorTests
         Assert.Equal(3, transformed.Tools.Count);
         Assert.Single(transformed.Areas); // only "storage"
         Assert.True(transformed.Areas.ContainsKey("storage"));
-        Assert.Single(transformed.Tools.Where(t => t.Area != null));
+        Assert.Single(transformed.Tools, t => t.Area != null);
     }
 
     [Fact]

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorValidationTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/ArticleContentProcessorValidationTests.cs
@@ -469,7 +469,7 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Partitioning Guide", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("fabricated URL pattern"));
     }
@@ -487,7 +487,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.Equal(2, data.AdditionalLinks.Count);
+        Assert.Collection(
+            data.AdditionalLinks,
+            link => Assert.Equal("Best Practices", link.Title),
+            link => Assert.Equal("Security Guide", link.Title));
     }
 
     [Fact]
@@ -517,7 +520,7 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Quickstart", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("Removed duplicate additional link"));
     }
@@ -535,7 +538,7 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Best Practices", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("Removed duplicate additional link"));
     }
@@ -552,7 +555,7 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
     }
 
     [Fact]
@@ -568,7 +571,10 @@ public class ArticleContentProcessorValidationTests
 
         _processor.Validate(data, "Test");
 
-        Assert.Equal(2, data.AdditionalLinks.Count);
+        Assert.Collection(
+            data.AdditionalLinks,
+            link => Assert.Equal("Partitioning Best Practices", link.Title),
+            link => Assert.Equal("Request Units", link.Title));
     }
 
     [Fact]
@@ -586,7 +592,7 @@ public class ArticleContentProcessorValidationTests
         var result = _processor.Validate(data, "Test");
 
         // The fabricated /docs link should be removed
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Voice Gallery", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("fabricated URL pattern") || c.Contains("Removed duplicate"));
     }
@@ -667,7 +673,7 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Metrics Overview", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("Removed link with empty URL"));
     }
@@ -685,7 +691,7 @@ public class ArticleContentProcessorValidationTests
 
         var result = _processor.Validate(data, "Test");
 
-        Assert.Equal(1, data.AdditionalLinks.Count);
+        Assert.Single(data.AdditionalLinks);
         Assert.Equal("Cluster Security", data.AdditionalLinks[0].Title);
         Assert.Contains(result.Corrections, c => c.Contains("Removed link with empty URL"));
     }

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/DeterministicHorizontalHelpersTests.cs
@@ -278,7 +278,7 @@ public class DeterministicHorizontalHelpersTests
         };
 
         var caps = DeterministicHorizontalHelpers.PreComputeCapabilities(tools);
-        Assert.Equal(1, caps.Count);
+        Assert.Single(caps);
         Assert.Equal("First description", caps["storage list"]);
     }
 

--- a/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/HorizontalArticleGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.HorizontalArticles.Tests/HorizontalArticleGeneratorTests.cs
@@ -53,7 +53,7 @@ public class HorizontalArticleGeneratorTests : IDisposable
 
         var staticData = await InvokeExtractStaticDataAsync(generator);
 
-        Assert.Equal(1, staticData.Count);
+        Assert.Single(staticData);
         Assert.Equal("../tool-family/compute.md", staticData[0].ToolsReferenceLink);
     }
 
@@ -79,7 +79,7 @@ public class HorizontalArticleGeneratorTests : IDisposable
         var staticData = await InvokeExtractStaticDataAsync(generator);
 
         // Assert: management plane first (alphabetical by command), then data plane (alphabetical).
-        Assert.Equal(1, staticData.Count);
+        Assert.Single(staticData);
         var commands = staticData[0].Tools.Select(t => t.Command).ToList();
         Assert.Equal(
             new[]

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DuplicateExampleStripperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/DuplicateExampleStripperTests.cs
@@ -198,6 +198,34 @@ Example prompts include:
         Assert.Contains("Example prompts include:", result);
     }
 
+    [Fact]
+    public void Strip_CanonicalizesBareExamplesBlockWhenCanonicalHeaderIsMissing()
+    {
+        // Real Step 3 failure shape for monitor instrumentation get-learning-resource:
+        // the AI rewrote the canonical "Example prompts include:" heading to bare "Examples".
+        var content = @"## Instrumentation: Get learning resource
+
+<!-- @mcpcli monitor instrumentation get-learning-resource -->
+
+Lists all available learning resources for Azure Monitor instrumentation, or retrieves the content of a specific resource by `path`.
+
+Examples
+
+- ""List all learning resource paths for Azure Monitor.""
+- ""Get the content for learning resource with path 'docs/instrumentation/aspnetcore'.""
+
+| Parameter |  Required or optional | Description |
+|-----------------------|----------------------|-------------|
+| **Path** |  Optional | Learning resource path. |";
+
+        var result = DuplicateExampleStripper.Strip(content);
+
+        Assert.Contains("Example prompts include:", result);
+        Assert.Contains("List all learning resource paths for Azure Monitor.", result);
+        Assert.Contains("docs/instrumentation/aspnetcore", result);
+        Assert.DoesNotContain("Examples\n", result);
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────
 
     [Fact]

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
@@ -61,18 +61,62 @@ public static class DuplicateExampleStripper
         // Remove blockquote examples ("> Example: ...")
         result = BlockquoteExamplePattern.Replace(result, "");
 
-        // Remove raw "Examples:" bullet lists
-        result = RawExamplesBlockPattern.Replace(result, "");
+        // Remove raw "Examples:" bullet lists when they duplicate the canonical block.
+        // If an AI step rewrote the canonical heading, restore it instead of dropping
+        // the only example prompts for the tool section.
+        result = RawExamplesBlockPattern.Replace(
+            result,
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples:\s*", "Example prompts include:"));
 
-        // Remove bare "Examples" (no colon) bullet lists (#709)
-        result = BareExamplesBlockPattern.Replace(result, "");
+        // Remove bare "Examples" (no colon) bullet lists (#709), unless this is the
+        // section's only example-prompt block.
+        result = BareExamplesBlockPattern.Replace(
+            result,
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples[ \t]*", "Example prompts include:"));
 
-        // Remove "Example prompts:" (without "include") bullet lists
-        result = ExamplePromptsNoIncludePattern.Replace(result, "");
+        // Remove "Example prompts:" (without "include") bullet lists when duplicate;
+        // otherwise normalize to the canonical label.
+        result = ExamplePromptsNoIncludePattern.Replace(
+            result,
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Example prompts:(?! include)\s*", "Example prompts include:"));
 
         // Clean up excessive blank lines left by removals (3+ → 2)
         result = Regex.Replace(result, @"\n{3,}", "\n\n");
 
         return result;
     }
+
+    private static string CanonicalizeOrRemoveExampleBlock(
+        string fullContent,
+        Match match,
+        string headingPattern,
+        string canonicalHeading)
+    {
+        return SectionContainsCanonicalExampleHeader(fullContent, match.Index)
+            ? string.Empty
+            : Regex.Replace(
+                match.Value,
+                headingPattern,
+                canonicalHeading + Environment.NewLine,
+                RegexOptions.IgnoreCase);
+    }
+
+    private static bool SectionContainsCanonicalExampleHeader(string content, int matchIndex)
+    {
+        var sectionStart = FindPreviousH2Start(content, matchIndex);
+        var sectionEnd = FindNextH2Start(content, matchIndex);
+        var sectionLength = sectionEnd < 0 ? content.Length - sectionStart : sectionEnd - sectionStart;
+        var section = content.Substring(sectionStart, sectionLength);
+
+        return section.Contains("Example prompts include:", StringComparison.Ordinal);
+    }
+
+    private static int FindPreviousH2Start(string content, int index)
+    {
+        var previous = content.LastIndexOf("\n## ", Math.Max(0, index), StringComparison.Ordinal);
+        return previous < 0 ? 0 : previous + 1;
+    }
+
+    private static int FindNextH2Start(string content, int index)
+        => content.IndexOf("\n## ", index + 1, StringComparison.Ordinal);
 }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/DuplicateExampleStripper.cs
@@ -61,24 +61,24 @@ public static class DuplicateExampleStripper
         // Remove blockquote examples ("> Example: ...")
         result = BlockquoteExamplePattern.Replace(result, "");
 
-        // Remove raw "Examples:" bullet lists when they duplicate the canonical block.
-        // If an AI step rewrote the canonical heading, restore it instead of dropping
-        // the only example prompts for the tool section.
+        // Root cause: Step 3 (AI rewrite) can downgrade "Example prompts include:" to a
+        // bare "Examples" or variant header. The replacements below are an intentional
+        // DEFENSIVE canonicalization in Step 4, not the primary fix.
         result = RawExamplesBlockPattern.Replace(
             result,
-            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples:\s*", "Example prompts include:"));
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples:\s*", MetadataConstants.CanonicalExampleHeader));
 
         // Remove bare "Examples" (no colon) bullet lists (#709), unless this is the
         // section's only example-prompt block.
         result = BareExamplesBlockPattern.Replace(
             result,
-            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples[ \t]*", "Example prompts include:"));
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Examples[ \t]*", MetadataConstants.CanonicalExampleHeader));
 
         // Remove "Example prompts:" (without "include") bullet lists when duplicate;
         // otherwise normalize to the canonical label.
         result = ExamplePromptsNoIncludePattern.Replace(
             result,
-            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Example prompts:(?! include)\s*", "Example prompts include:"));
+            match => CanonicalizeOrRemoveExampleBlock(result, match, @"^Example prompts:(?! include)\s*", MetadataConstants.CanonicalExampleHeader));
 
         // Clean up excessive blank lines left by removals (3+ → 2)
         result = Regex.Replace(result, @"\n{3,}", "\n\n");
@@ -108,7 +108,7 @@ public static class DuplicateExampleStripper
         var sectionLength = sectionEnd < 0 ? content.Length - sectionStart : sectionEnd - sectionStart;
         var section = content.Substring(sectionStart, sectionLength);
 
-        return section.Contains("Example prompts include:", StringComparison.Ordinal);
+        return section.Contains(MetadataConstants.CanonicalExampleHeader, StringComparison.Ordinal);
     }
 
     private static int FindPreviousH2Start(string content, int index)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/MetadataConstants.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/MetadataConstants.cs
@@ -26,4 +26,8 @@ public static class MetadataConstants
 
     // Content paths
     public const string IncludeParameterConsideration = "[!INCLUDE [tip-about-params](../includes/tools/parameter-consideration.md)]";
+
+    // Step 4 canonical example-prompt header — single source of truth used by
+    // DuplicateExampleStripper and SectionContainsCanonicalExampleHeader.
+    public const string CanonicalExampleHeader = "Example prompts include:";
 }

--- a/mcp-tools/validation/tests/merge-namespaces-smoke.sh
+++ b/mcp-tools/validation/tests/merge-namespaces-smoke.sh
@@ -34,15 +34,15 @@ trap 'rm -rf "$TMP"' EXIT
 # ── Brand mapping with one merge group: alpha (primary) + beta (secondary) ──
 cat > "$TMP/brand-map.json" <<'JSON'
 [
-  { "mcpServerName": "alpha", "mergeGroup": "smoke-group", "mergeOrder": 1, "mergeRole": "primary" },
-  { "mcpServerName": "beta",  "mergeGroup": "smoke-group", "mergeOrder": 2, "mergeRole": "secondary" }
+  { "mcpServerName": "alpha", "fileName": "azure-alpha", "mergeGroup": "smoke-group", "mergeOrder": 1, "mergeRole": "primary" },
+  { "mcpServerName": "beta",  "fileName": "azure-beta",  "mergeGroup": "smoke-group", "mergeOrder": 2, "mergeRole": "secondary" }
 ]
 JSON
 
 mkdir -p "$TMP/generated-alpha/tool-family" "$TMP/generated-beta/tool-family"
 
 # ── Canonical (plain) variant fixtures ──
-cat > "$TMP/generated-alpha/tool-family/alpha.md" <<'MD'
+cat > "$TMP/generated-alpha/tool-family/azure-alpha.md" <<'MD'
 ---
 title: Alpha tools
 tool_count: 1
@@ -60,7 +60,7 @@ Alpha tool one body.
 - Alpha related link
 MD
 
-cat > "$TMP/generated-beta/tool-family/beta.md" <<'MD'
+cat > "$TMP/generated-beta/tool-family/azure-beta.md" <<'MD'
 ---
 title: Beta tools
 tool_count: 2
@@ -83,7 +83,7 @@ Beta tool two body.
 MD
 
 # ── CLI-tab variant fixtures (tab markers must survive the merge) ──
-cat > "$TMP/generated-alpha/tool-family/alpha-cli.md" <<'MD'
+cat > "$TMP/generated-alpha/tool-family/azure-alpha-cli.md" <<'MD'
 ---
 title: Alpha tools
 tool_count: 1
@@ -104,7 +104,7 @@ alpha mcp content
 - Alpha related link
 MD
 
-cat > "$TMP/generated-beta/tool-family/beta-cli.md" <<'MD'
+cat > "$TMP/generated-beta/tool-family/azure-beta-cli.md" <<'MD'
 ---
 title: Beta tools
 tool_count: 2
@@ -136,8 +136,8 @@ MD
 MERGE_ROOT_DIR="$TMP" MERGE_BRAND_MAP="$TMP/brand-map.json" bash "$MERGE_SCRIPT" \
     || fail "merge-namespaces.sh exited non-zero"
 
-CANON="$TMP/generated-alpha/tool-family/alpha.md"
-CLI="$TMP/generated-alpha/tool-family/alpha-cli.md"
+CANON="$TMP/generated-alpha/tool-family/azure-alpha.md"
+CLI="$TMP/generated-alpha/tool-family/azure-alpha-cli.md"
 
 [[ -f "$CANON" ]] || fail "merged canonical article not written: $CANON"
 [[ -f "$CLI" ]]   || fail "merged -cli article not written: $CLI"

--- a/merge-namespaces.sh
+++ b/merge-namespaces.sh
@@ -37,6 +37,7 @@ for (const m of mappings) {
     if (!grouped[m.mergeGroup]) grouped[m.mergeGroup] = [];
     grouped[m.mergeGroup].push({
         ns: m.mcpServerName,
+        fileName: m.fileName || m.mcpServerName,
         order: m.mergeOrder || 99,
         role: m.mergeRole || 'secondary'
     });
@@ -108,12 +109,12 @@ for (const [groupName, members] of groups) {
         const generatedDirs = {};
         for (const m of members) {
             const generatedDir = resolveGeneratedDir(m.ns);
-            const articlePath = generatedDir ? path.join(generatedDir, 'tool-family', m.ns + suffix + '.md') : null;
+            const articlePath = generatedDir ? path.join(generatedDir, 'tool-family', m.fileName + suffix + '.md') : null;
             if (articlePath && fs.existsSync(articlePath)) {
                 generatedDirs[m.ns] = generatedDir;
                 articles[m.ns] = fs.readFileSync(articlePath, 'utf8');
             } else {
-                return { missing: true, missingNs: m.ns };
+                return { missing: true, missingNs: m.ns, missingFile: (m.fileName + suffix + '.md') };
             }
         }
         return { missing: false, articles, generatedDirs };
@@ -142,14 +143,14 @@ for (const [groupName, members] of groups) {
         const loaded = loadVariant(suffix);
         if (loaded.missing) {
             const label = suffix === '' ? '' : ' ' + suffix.replace(/^-/, '') + ' variant for';
-            console.log('  Skipping' + label + ' group ' + groupName + ': ' + loaded.missingNs + suffix + '.md not found');
+            console.log('  Skipping' + label + ' group ' + groupName + ': ' + loaded.missingFile + ' not found for ' + loaded.missingNs);
             return required ? false : true;
         }
         const { merged, totalTools, toolCounts } = buildMerged(loaded.articles);
-        const outputPath = path.join(loaded.generatedDirs[primary.ns], 'tool-family', primary.ns + suffix + '.md');
-        const memberLabel = members.map(m => m.ns + suffix).join(' + ');
+        const outputPath = path.join(loaded.generatedDirs[primary.ns], 'tool-family', primary.fileName + suffix + '.md');
+        const memberLabel = members.map(m => m.fileName + suffix).join(' + ');
         if (dryRun) {
-            console.log('  DRY RUN: Would merge ' + memberLabel + ' -> ' + primary.ns + suffix + '.md');
+            console.log('  DRY RUN: Would merge ' + memberLabel + ' -> ' + primary.fileName + suffix + '.md');
             console.log('           ' + totalTools + ' tools (' + toolCounts + ')');
         } else {
             try {
@@ -159,7 +160,7 @@ for (const [groupName, members] of groups) {
                 console.log('  WARNING: Skipping ' + suffix.replace(/^-/, '') + ' variant for group ' + groupName + ': write failed (' + err.message + ')');
                 return true;
             }
-            console.log('  Merged: ' + memberLabel + ' -> ' + primary.ns + suffix + '.md');
+            console.log('  Merged: ' + memberLabel + ' -> ' + primary.fileName + suffix + '.md');
             console.log('          ' + totalTools + ' tools (' + toolCounts + ')');
         }
         return true;

--- a/shared/DocGeneration.Core.Shared.Tests/ParameterCoverageCheckerTests.cs
+++ b/shared/DocGeneration.Core.Shared.Tests/ParameterCoverageCheckerTests.cs
@@ -102,6 +102,16 @@ public class ParameterCoverageCheckerTests
     }
 
     [Fact]
+    public void SemanticFallback_PluralIdParameterMatchesSingularIdPlaceholder()
+    {
+        var prompts = new[] { "Delete workbook with resource ID <workbook_resource_id>." };
+        var result = ParameterCoverageChecker.GetConcretePromptCoverage(prompts, "workbook-ids", 1);
+
+        Assert.False(result.Covered);
+        Assert.True(result.PlaceholderDetected);
+    }
+
+    [Fact]
     public void NoMatch_ReturnsCoveredFalse()
     {
         var prompts = new[] { "List all virtual machines in the region" };

--- a/shared/DocGeneration.Core.Shared.Tests/ParameterCoverageCheckerTests.cs
+++ b/shared/DocGeneration.Core.Shared.Tests/ParameterCoverageCheckerTests.cs
@@ -112,6 +112,19 @@ public class ParameterCoverageCheckerTests
     }
 
     [Fact]
+    public void PluralIdParameter_WithConcreteValue_ReturnsCovered()
+    {
+        // Complementary positive case (reviewer: Statler — PR #725):
+        // workbook-ids with real quoted values must be Covered=true, PlaceholderDetected=false.
+        // Proves the plural-ID/singular-placeholder fix did not over-suppress real coverage.
+        var prompts = new[] { "Get workbook 'my-workbook-001' from the workspace." };
+        var result = ParameterCoverageChecker.GetConcretePromptCoverage(prompts, "workbook-ids", 1);
+
+        Assert.True(result.Covered);
+        Assert.False(result.PlaceholderDetected);
+    }
+
+    [Fact]
     public void NoMatch_ReturnsCoveredFalse()
     {
         var prompts = new[] { "List all virtual machines in the region" };

--- a/shared/DocGeneration.Core.Shared/ParameterCoverageChecker.cs
+++ b/shared/DocGeneration.Core.Shared/ParameterCoverageChecker.cs
@@ -129,7 +129,7 @@ public static class ParameterCoverageChecker
                 var requiredWordMatches = Math.Min(Math.Max(words.Length, 1), 2);
                 if (placeholderSlug == slug
                     || placeholderSlug.Contains(slug, StringComparison.Ordinal)
-                    || words.Count(word => placeholderSlug.Contains(word, StringComparison.Ordinal)) >= requiredWordMatches)
+                    || CountRequiredWordMatches(words, word => placeholderSlug.Contains(word, StringComparison.Ordinal)) >= requiredWordMatches)
                 {
                     placeholderDetected = true;
                 }
@@ -142,7 +142,7 @@ public static class ParameterCoverageChecker
                     var innerTokens = Regex.Split(inner.ToLowerInvariant(), "[^a-z0-9]+")
                         .Where(t => t.Length > 0)
                         .ToArray();
-                    if (words.Count(word => innerTokens.Contains(word, StringComparer.Ordinal))
+                    if (CountRequiredWordMatches(words, word => innerTokens.Contains(word, StringComparer.Ordinal))
                         >= requiredWordMatches)
                     {
                         placeholderDetected = true;
@@ -267,6 +267,23 @@ public static class ParameterCoverageChecker
         clean = Regex.Replace(clean, "<[^>]+>", string.Empty);
         clean = Regex.Replace(clean, "\\s+", " ");
         return clean.Trim();
+    }
+
+    private static int CountRequiredWordMatches(IReadOnlyList<string> requiredWords, Func<string, bool> matches)
+        => requiredWords.Count(word => GetWordVariants(word).Any(matches));
+
+    private static IEnumerable<string> GetWordVariants(string word)
+    {
+        yield return word;
+
+        if (string.Equals(word, "ids", StringComparison.Ordinal))
+        {
+            yield return "id";
+        }
+        else if (word.Length > 3 && word.EndsWith('s'))
+        {
+            yield return word[..^1];
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Preserve rewritten bare example prompt blocks by canonicalizing a section's only non-canonical examples header back to `Example prompts include:`.
- Add regression coverage for the Azure Monitor instrumentation get-learning-resource failure shape.
- Update CHANGELOG and architecture docs.

## Validation
- Failing test before fix: `DuplicateExampleStripperTests.Strip_CanonicalizesBareExamplesBlockWhenCanonicalHeaderIsMissing` failed with `Assert.Contains() Failure: Sub-string not found ... Not found: "Example prompts include:"`.
- `dotnet test .\mcp-tools\DocGeneration.Steps.ToolFamilyCleanup.Tests\DocGeneration.Steps.ToolFamilyCleanup.Tests.csproj --configuration Release --filter "FullyQualifiedName~DuplicateExampleStripperTests" --no-restore`
- `dotnet build .\mcp-doc-generation.sln --configuration Release --no-restore --verbosity quiet` (0 warnings)
- `dotnet build .\skills-generation\skills-generation.slnx --configuration Release --no-restore --verbosity quiet` (0 warnings)
- `.\verify-keyless.ps1 -SkipBuild`
- Re-ran Step 4 against the previously failing monitor output with keyless auth and `--skip-npm-update --skip-build --skip-deps`; validator passed with warn-only low-parameter-count warnings.