### PR TITLE
(ignore) test(#582): dedicated validator namespace-mapping consumption test

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -1463,6 +1463,49 @@ public class ToolFamilyPostAssemblyValidatorTests
         }
     }
 
+    [Fact]
+    public async Task ValidateAsync_ConsumesNamespaceMappingJson_MatchesToolsByMappedPrefix()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var context = CreateContext(testRoot);
+
+            // Stage config/namespace-mapping.json with a distinctive entry that fallback heuristics
+            // (ai-compute, azure-compute) would NOT produce: "compute" → "custom-distinctive-name.md"
+            var configDir = Path.Combine(testRoot, "config");
+            Directory.CreateDirectory(configDir);
+            var namespaceMappingPath = Path.Combine(configDir, "namespace-mapping.json");
+            File.WriteAllText(namespaceMappingPath, """
+                {
+                  "compute": "custom-distinctive-name.md"
+                }
+                """);
+
+            // Seed tool files using the JSON-mapped prefix (custom-distinctive-name-*)
+            // NOT the fallback prefixes (compute-*, ai-compute-*, azure-compute-*)
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "custom-distinctive-name-list.md"), "compute list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "custom-distinctive-name-show.md"), "compute show");
+
+            // Seed the tool-family article with matching @mcpcli markers
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "compute.md"), ValidArticleContent());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            // Assert: If the validator consumed namespace-mapping.json, it found the tools
+            // with "custom-distinctive-name-*" prefix and validation passed.
+            // If it only used fallback heuristics (compute, ai-compute, azure-compute),
+            // it would NOT find the tools and validation would fail with "No tool files found".
+            Assert.True(result.Success, $"Validation failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("No tool files found", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
     private static CliMetadataSnapshot BuildCliOutput(
         params (string Command, bool Destructive, bool Idempotent, bool OpenWorld, bool ReadOnly, bool Secret, bool LocalRequired)[] tools)
     {


### PR DESCRIPTION
Closes the **Scooter (Completeness)** review nit from the PR #729 8-agent review.

## Context

In PR #729, `NamespaceMappingLoader` was wired into `ToolFamilyPostAssemblyValidator.GetNamespaceFilePrefixesAsync()` to read `config/namespace-mapping.json` and derive namespace→file prefixes from it.

The 8-agent review (Scooter, Completeness) noted this new C# production call site is exercised only **transitively** by the existing 32 validator tests — there is **NO DEDICATED test** proving the validator actually consumes `config/namespace-mapping.json`.

## This PR

Adds a focused unit test:

**Test**: `ValidateAsync_ConsumesNamespaceMappingJson_MatchesToolsByMappedPrefix`

**Setup**:
- Stages a temp repoRoot with `config/namespace-mapping.json` mapping `compute` → `custom-distinctive-name.md`
- Seeds tool files using the JSON-mapped prefix (`custom-distinctive-name-list.md`, `custom-distinctive-name-show.md`)
- **NOT** the fallback prefixes (`compute-*`, `ai-compute-*`, `azure-compute-*`)

**Assertion**:
- Invokes the validator's public `ValidateAsync()` entry point
- If the validator consumed `namespace-mapping.json`, it finds the tools with `custom-distinctive-name-*` prefix → validation **passes**
- If it only used fallback heuristics, it would **NOT** find the tools → validation would fail with 'No tool files found'

**Proof**: Test passes, proving JSON consumption.

## Test-Only Change

- ✅ No production code changes
- ✅ Follows established `ToolFamilyPostAssemblyValidatorTests` pattern (`CreateTestRoot`, `CreateContext`, `SeedToolFile`, `DeleteTestRoot`)
- ✅ Service-agnostic, self-contained
- ✅ Zero warnings, zero errors (Release build)
- ✅ 30/30 tests pass (`ToolFamilyPostAssemblyValidatorTests`)

## Build & Test Results

- **Build**: `dotnet build mcp-doc-generation.sln --configuration Release` → **0 warnings, 0 errors**
- **Tests**: `dotnet test --filter FullyQualifiedName~ToolFamilyPostAssemblyValidatorTests` → **30/30 passed**
  - New test: `ValidateAsync_ConsumesNamespaceMappingJson_MatchesToolsByMappedPrefix` (71 ms) ✅

## Known Pre-Existing Baseline Failures (Ignored)

- `ToolFamilyCleanup.Tests`: `R_CG2_AllNamespacesHaveGeneratedOutput`
- `PipelineRunner.Tests`: 2x `CliTabPilotTests` (corrupt CLI JSON 0x1A)
