### PR TITLE
Fix required-first Azure MCP parameter ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Azure MCP CLI examples and parameter tables now share required-first parameter ordering (#740)** — Step 1 now uses one stable required-first parameter ordering rule for generated CLI example command flags and parameter table rows: all required parameters appear before optional parameters, while preserving source metadata order within each group. This prevents optional flags from appearing before required flags and keeps the CLI example order aligned with the parameter table order.
+
 - **Example-prompt validation now recognizes singular placeholders for plural ID parameters** — `ParameterCoverageChecker` now treats singular word variants such as `id` as matching plural required-parameter words such as `ids` when validating placeholders. This allows prompts like `<workbook_resource_id>` to satisfy the required `workbook-ids` parameter while still treating placeholder use separately from concrete-value coverage. A shared regression test covers the Azure Workbooks delete shape.
 
 - **Multi-namespace merge now honors mapped article filenames** — `merge-namespaces.sh` now reads each merge member's `fileName` from `brand-to-server-mapping.json` when loading and writing canonical and `-cli` tool-family articles, instead of assuming article filenames match MCP namespace names. This lets merge groups such as `monitor` + `workbooks` merge `azure-monitor.md` + `azure-workbooks.md` into the combined `azure-monitor.md`. The shipping merge smoke test now uses mapped filenames that differ from namespace names so the regression is covered.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,6 +56,9 @@ Step 1: Annotations + Parameters + Raw Tools ───────────�
   │  • cli-output.json → annotations/*.md (tool metadata flags)
   │  • cli-output.json → parameters/*.md (parameter tables)
   │  • cli-output.json → tools-raw/*.md (raw tool markdown)
+  │  • Parameter tables and CLI example command flags use the same
+  │    stable required-first order: required parameters first, then
+  │    optional parameters, preserving source order within each group
   │  Uses: Handlebars templates, static-text-replacement.json
   │
   ▼

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/Generators/CliExampleCommandGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/Generators/CliExampleCommandGeneratorTests.cs
@@ -87,6 +87,22 @@ public class CliExampleCommandGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void BuildExampleCommandContent_RequiredFirst_PreservesRelativeOrderWithinGroups()
+    {
+        var tool = MakeTool("storage account create",
+            new CliSwitch("--optional-b", "Optional B", "string"),
+            new CliSwitch("--required-b", "Required B", "string", IsRequired: true),
+            new CliSwitch("--optional-a", "Optional A", "string"),
+            new CliSwitch("--required-a", "Required A", "string", IsRequired: true));
+
+        var content = CliExampleCommandGenerator.BuildExampleCommandContent("storage account create", tool);
+
+        Assert.True(content.IndexOf("--required-b", StringComparison.Ordinal) < content.IndexOf("--required-a", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("--required-a", StringComparison.Ordinal) < content.IndexOf("[--optional-b", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("[--optional-b", StringComparison.Ordinal) < content.IndexOf("[--optional-a", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void BuildExampleCommandContent_OnlyGlobalSwitches_ShowsBareCommand()
     {
         var tool = MakeTool("storage account list",

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/Generators/CliParameterGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/Generators/CliParameterGeneratorTests.cs
@@ -154,6 +154,26 @@ public class CliParameterGeneratorTests: IDisposable
     }
 
     [Fact]
+    public async Task GenerateParameterCliFiles_OrdersRequiredFirst_PreservingRelativeOrderWithinGroups()
+    {
+        var tools = MakeSingleTool("storage account create",
+            new CliSwitch("--optional-b", "Optional B", "string"),
+            new CliSwitch("--required-b", "Required B", "string", IsRequired: true),
+            new CliSwitch("--optional-a", "Optional A", "string"),
+            new CliSwitch("--required-a", "Required A", "string", IsRequired: true));
+
+        await CliParameterGenerator
+            .GenerateParameterCliFilesAsync(tools, _templateFile, _outputDir, _ctx, "1.0.0", DateTime.UtcNow);
+
+        var file = Directory.GetFiles(_outputDir, "*.md").Single();
+        var content = await File.ReadAllTextAsync(file);
+
+        Assert.True(content.IndexOf("`required-b`", StringComparison.Ordinal) < content.IndexOf("`required-a`", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("`required-a`", StringComparison.Ordinal) < content.IndexOf("`optional-b`", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("`optional-b`", StringComparison.Ordinal) < content.IndexOf("`optional-a`", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GenerateParameterCliFiles_IncludesFrontmatter()
     {
         var genDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterSortingTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterSortingTests.cs
@@ -32,7 +32,7 @@ public class ParameterSortingTests
     }
 
     [Fact]
-    public void SortByRequiredThenName_AlphabeticalWithinGroup()
+    public void SortByRequiredThenName_PreservesRelativeOrderWithinOptionalGroup()
     {
         var options = new List<Option>
         {
@@ -43,13 +43,13 @@ public class ParameterSortingTests
 
         var sorted = ParameterSorting.SortByRequiredThenName(options).ToList();
 
-        Assert.Equal("--alpha", sorted[0].Name);
-        Assert.Equal("--charlie", sorted[1].Name);
-        Assert.Equal("--delta", sorted[2].Name);
+        Assert.Equal("--delta", sorted[0].Name);
+        Assert.Equal("--alpha", sorted[1].Name);
+        Assert.Equal("--charlie", sorted[2].Name);
     }
 
     [Fact]
-    public void SortByRequiredThenName_MultipleRequired_AlphabeticalByName()
+    public void SortByRequiredThenName_PreservesRelativeOrderWithinRequiredGroup()
     {
         var options = new List<Option>
         {
@@ -60,8 +60,8 @@ public class ParameterSortingTests
 
         var sorted = ParameterSorting.SortByRequiredThenName(options).ToList();
 
-        Assert.Equal("--alpha", sorted[0].Name);
-        Assert.Equal("--zoo", sorted[1].Name);
+        Assert.Equal("--zoo", sorted[0].Name);
+        Assert.Equal("--alpha", sorted[1].Name);
         Assert.Equal("--middle", sorted[2].Name);
     }
 
@@ -83,19 +83,17 @@ public class ParameterSortingTests
     }
 
     [Fact]
-    public void SortByRequiredThenName_CaseInsensitiveOrdering()
+    public void SortByRequiredThenName_DoesNotAlphabetizeWithinGroup()
     {
         var options = new List<Option>
         {
             TestHelpers.CreateOption("--Beta", required: false),
             TestHelpers.CreateOption("--alpha", required: false),
         };
-
         var sorted = ParameterSorting.SortByRequiredThenName(options).ToList();
 
-        // "alpha" should come before "Beta" case-insensitively
-        Assert.Equal("--alpha", sorted[0].Name);
-        Assert.Equal("--Beta", sorted[1].Name);
+        Assert.Equal("--Beta", sorted[0].Name);
+        Assert.Equal("--alpha", sorted[1].Name);
     }
 
     [Fact]
@@ -112,7 +110,7 @@ public class ParameterSortingTests
     }
 
     [Fact]
-    public void SortByRequiredThenName_AllRequired_SortedAlphabetically()
+    public void SortByRequiredThenName_AllRequired_PreservesRelativeOrder()
     {
         var options = new List<Option>
         {
@@ -123,9 +121,30 @@ public class ParameterSortingTests
 
         var sorted = ParameterSorting.SortByRequiredThenName(options).ToList();
 
-        Assert.Equal("--alpha", sorted[0].Name);
-        Assert.Equal("--bravo", sorted[1].Name);
-        Assert.Equal("--charlie", sorted[2].Name);
+        Assert.Equal("--charlie", sorted[0].Name);
+        Assert.Equal("--alpha", sorted[1].Name);
+        Assert.Equal("--bravo", sorted[2].Name);
         Assert.All(sorted, o => Assert.True(o.Required));
+    }
+
+    [Fact]
+    public void SortByRequiredThenName_PreservesRelativeOrderWithinBothGroups()
+    {
+        var options = new List<Option>
+        {
+            TestHelpers.CreateOption("--optional-b", required: false),
+            TestHelpers.CreateOption("--required-b", required: true),
+            TestHelpers.CreateOption("--optional-a", required: false),
+            TestHelpers.CreateOption("--required-a", required: true),
+        };
+
+        var sorted = ParameterSorting.SortByRequiredThenName(options).ToList();
+
+        Assert.Collection(
+            sorted,
+            p => Assert.Equal("--required-b", p.Name),
+            p => Assert.Equal("--required-a", p.Name),
+            p => Assert.Equal("--optional-b", p.Name),
+            p => Assert.Equal("--optional-a", p.Name));
     }
 }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
@@ -294,7 +294,7 @@ public static class DocumentationGenerator
                 // Add area property to tool for compatibility
                 tool.Area = area;
 
-                // Sort parameters once: required first, then alphabetical by name.
+                // Sort parameters once: required first, preserving source order within each group.
                 // All downstream generators inherit this order.
                 if (tool.Option != null)
                 {

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/CliExampleCommandGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/CliExampleCommandGenerator.cs
@@ -55,10 +55,9 @@ public static class CliExampleCommandGenerator
         sb.AppendLine();
         sb.AppendLine("```console");
 
-        // Get non-global switches, required first then optional
-        var toolSwitches = tool.Switches
-            .Where(s => !IsGlobalSwitch(s.Name))
-            .OrderByDescending(s => s.IsRequired == true)
+        // Get non-global switches, required first then optional.
+        var toolSwitches = ParameterSorting
+            .SortByRequiredThenName(tool.Switches.Where(s => !IsGlobalSwitch(s.Name)))
             .ToList();
 
         if (toolSwitches.Count > 0)

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/CliParameterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/CliParameterGenerator.cs
@@ -31,7 +31,7 @@ public class CliParameterGenerator
             var outputFile = Path.Combine(outputDir, fileName);
 
             var filtered = GlobalSwitchFilter.FilterOutGlobal(tool.Switches);
-            var switches = filtered
+            var switches = ParameterSorting.SortByRequiredThenName(filtered)
                 .Select(sw => new
                 {
                     sw.Name,

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterSorting.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterSorting.cs
@@ -6,24 +6,34 @@ namespace CSharpGenerator.Generators;
 
 /// <summary>
 /// Centralized parameter sorting logic. Ensures all generated documentation
-/// lists required parameters before optional ones, with alphabetical
-/// secondary ordering by normalized (human-readable) name.
+/// lists required parameters before optional ones while preserving the
+/// source metadata order within each group.
 /// </summary>
 public static class ParameterSorting
 {
     /// <summary>
-    /// Sorts parameters so that required parameters appear first, then optional.
-    /// Within each group, parameters are sorted alphabetically by their
-    /// normalized (human-readable) name, using case-insensitive comparison.
+    /// Sorts parameters so that required parameters appear first, then optional,
+    /// preserving source metadata order within each group.
     /// </summary>
     /// <param name="parameters">The parameters to sort.</param>
-    /// <returns>Sorted parameter sequence (required first, then alphabetical).</returns>
+    /// <returns>Sorted parameter sequence (required first, stable within each group).</returns>
     public static IOrderedEnumerable<Option> SortByRequiredThenName(
         IEnumerable<Option> parameters)
     {
         return parameters
-            .OrderByDescending(p => p.Required)
-            .ThenBy(p => Config.TextNormalizer.NormalizeParameter(p.Name ?? ""),
-                    StringComparer.OrdinalIgnoreCase);
+            .OrderByDescending(p => p.Required);
+    }
+
+    /// <summary>
+    /// Sorts CLI switches so that required switches appear first, then optional,
+    /// preserving source metadata order within each group.
+    /// </summary>
+    /// <param name="switches">The CLI switches to sort.</param>
+    /// <returns>Sorted switch sequence (required first, stable within each group).</returns>
+    public static IOrderedEnumerable<Shared.CliSwitch> SortByRequiredThenName(
+        IEnumerable<Shared.CliSwitch> switches)
+    {
+        return switches
+            .OrderByDescending(s => s.IsRequired == true);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #740 (parameter-ordering defect surfaced during beta.22 doc verification).

- Centralizes Azure MCP parameter ordering in `ParameterSorting` for both tool-table options and CLI switches.
- Emits required parameters first, then optional parameters.
- Preserves source metadata order within each required/optional group so generated CLI example flags and parameter table rows can stay aligned.
- Applies the shared order to CLI example command generation and CLI parameter-table generation.

## Root cause

The generator used multiple parameter-ordering paths:

- `DocumentationGenerator.cs` sorted `tool.Option` before downstream table generation.
- `CliExampleCommandGenerator.cs` independently ordered CLI flags.
- `CliParameterGenerator.cs` rendered CLI parameter rows from filtered switches without using the same sorter.

That allowed CLI examples and parameter tables to diverge and did not preserve the requested stable order within required/optional groups.

## Validation

- `dotnet test mcp-tools\DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests\DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests.csproj --configuration Release --filter "FullyQualifiedName~ParameterSortingTests|FullyQualifiedName~CliExampleCommandGeneratorTests|FullyQualifiedName~CliParameterGeneratorTests" --no-restore --verbosity minimal`

Result: Passed — 30 tests.

## Docs

- Updated `CHANGELOG.md`.
- Updated `docs/ARCHITECTURE.md` to document the stable required-first ordering rule.