### PR TITLE
(ignore) Fix resource group demonstrative wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Resource-group parameter boilerplate now follows demonstrative-noun style guidance (#733)** — The shared `--resource-group` description now says "This name is a logical container for Azure resources" instead of "This is a logical container...", and the static text replacement fallback applies the same correction during generation.
+
 - **Azure MCP CLI examples and parameter tables now share required-first parameter ordering (#740)** — Step 1 now uses one stable required-first parameter ordering rule for generated CLI example command flags and parameter table rows: all required parameters appear before optional parameters, while preserving source metadata order within each group. This prevents optional flags from appearing before required flags and keeps the CLI example order aligned with the parameter table order.
 
 - **Example-prompt validation now recognizes singular placeholders for plural ID parameters** — `ParameterCoverageChecker` now treats singular word variants such as `id` as matching plural required-parameter words such as `ids` when validating placeholders. This allows prompts like `<workbook_resource_id>` to satisfy the required `workbook-ids` parameter while still treating placeholder use separately from concrete-value coverage. A shared regression test covers the Azure Workbooks delete shape.

--- a/docs/PROJECT-GUIDE.md
+++ b/docs/PROJECT-GUIDE.md
@@ -860,7 +860,7 @@ pwsh ./mcp-tools/scripts/lint-vale.ps1 -TargetDir ./generated-advisor/
 
 **CI integration:** The `vale-lint` job in `.github/workflows/build-and-test.yml` runs Vale on PRs (non-blocking, `continue-on-error: true`).
 
-**Feeding findings back:** Common Vale findings should be added to `mcp-tools/data/static-text-replacement.json` so the pipeline auto-corrects them during generation.
+**Feeding findings back:** Common Vale findings should be added to `mcp-tools/data/static-text-replacement.json` so the pipeline auto-corrects them during generation. When a finding comes from shared parameter boilerplate, update the source description in `mcp-tools/data/common-parameters.json` too; for example, avoid bare demonstratives such as "This is..." by writing a noun phrase such as "This name is...".
 
 ### Future: Architecture Modernization
 

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterGeneratorTests.cs
@@ -138,6 +138,20 @@ public class ParameterGeneratorTests
     }
 
     [Fact]
+    public void CommonParameters_ResourceGroupDescriptionUsesDemonstrativeNoun()
+    {
+        var commonParamsPath = Path.Combine(
+            FindProjectRoot(), "mcp-tools", "data", "common-parameters.json");
+        var json = File.ReadAllText(commonParamsPath);
+        var commonParams = System.Text.Json.JsonSerializer.Deserialize<List<CommonParam>>(json,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var resourceGroup = Assert.Single(commonParams!, p => p.Name == "--resource-group");
+        Assert.DoesNotContain("This is a logical container", resourceGroup.Description);
+        Assert.Contains("This name is a logical container", resourceGroup.Description);
+    }
+
+    [Fact]
     public void CommonParameters_IncludeSubscription()
     {
         // subscription is a scoping parameter that must be in common-parameters.json

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/StaticTextReplacementTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/StaticTextReplacementTests.cs
@@ -104,17 +104,17 @@ public class StaticTextReplacementTests : IClassFixture<TransformationEngineFixt
         var result = _normalizer.ReplaceStaticText(input);
 
         // Assert — should add noun "resource group" after "This"
-        Assert.Contains("This resource group is a logical container", result);
+        Assert.Contains("This name is a logical container", result);
         Assert.DoesNotContain("This is a logical container", result);
     }
 
     [Theory]
     [InlineData(
         "The name of the Azure resource group. This is a logical container for Azure resources.",
-        "The name of the Azure resource group. This resource group is a logical container for Azure resources.")]
+        "The name of the Azure resource group. This name is a logical container for Azure resources.")]
     [InlineData(
         "This is a logical container for resources in your subscription.",
-        "This resource group is a logical container for resources in your subscription.")]
+        "This name is a logical container for resources in your subscription.")]
     public void ReplaceStaticText_DemonstrativePronoun_VariousContexts(string input, string expected)
     {
         // Act
@@ -128,13 +128,13 @@ public class StaticTextReplacementTests : IClassFixture<TransformationEngineFixt
     public void ReplaceStaticText_DemonstrativePronoun_NotReplacedWhenAlreadyFixed()
     {
         // Already-fixed text should pass through unchanged
-        var input = "This resource group is a logical container for Azure resources.";
+        var input = "This name is a logical container for Azure resources.";
 
         // Act
         var result = _normalizer.ReplaceStaticText(input);
 
         // Assert — no double-replacement
-        Assert.Equal("This resource group is a logical container for Azure resources.", result);
+        Assert.Equal("This name is a logical container for Azure resources.", result);
     }
 
     // ── Acrolinx Wordy/Informal Phrase Replacements (#215) ──────────

--- a/mcp-tools/data/common-parameters.json
+++ b/mcp-tools/data/common-parameters.json
@@ -50,7 +50,7 @@
   {
     "name": "--resource-group",
     "type": "string",
-    "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+    "description": "The name of the Azure resource group. This name is a logical container for Azure resources.",
     "isRequired": false
   },
   {

--- a/mcp-tools/data/static-text-replacement.json
+++ b/mcp-tools/data/static-text-replacement.json
@@ -37,7 +37,7 @@
     },
     {
         "Parameter": "This is a logical container",
-        "NaturalLanguage": "This resource group is a logical container"
+        "NaturalLanguage": "This name is a logical container"
     },
     {
         "Parameter": "etc.",


### PR DESCRIPTION
## Summary
- Update shared `--resource-group` boilerplate to use "This name is..." instead of the bare demonstrative "This is...".
- Update the static text replacement fallback to apply the same style fix.
- Document how shared boilerplate style findings should be fed back into config.

Fixes #733

## TDD evidence
Failing test added first and verified before the fix:

```text
Assert.DoesNotContain() Failure: Sub-string found
                                ↓ (pos 38)
String: ···"ure resource group. This is a logical con"···
Found:  "This is a logical container"
```

## Validation
- `dotnet test mcp-tools\\DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests\\DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests.csproj --configuration Release --no-restore`
- `dotnet build mcp-doc-generation.sln --configuration Release --no-restore`