### PR TITLE
(ignore) Fix McpCliMetadata duplicate entry point build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **McpCliMetadata build no longer fails when the local mapping backfill scratch file is present** — The project file now excludes the stray `GenerateMapping.cs` helper from compilation, preserving `Program.cs` as the only executable top-level entry point and eliminating CS8802 during local generator builds.
+
 - **Parameter requiredness now strictly follows CLI metadata booleans (#732)** — Step 1 parameter table generation now preserves default wording in descriptions as descriptive text only while deriving the `Required or optional` column exclusively from each option's `required` boolean. This prevents required parameters whose descriptions mention defaults from being treated as optional.
 - **Validation Gate Article Health smoke tests no longer sweep negative or coverage fixtures (#739)** — Code/metadata-only PRs now run Article Health against an explicit healthy smoke-fixture allowlist instead of recursively checking every committed fixture under `mcp-tools/validation/tests/fixtures`. Intentional negative health fixtures and coverage-auditor fixtures remain covered by their dedicated Pester tests, but they no longer create baseline Article Health failures that prevent the warn-mode gate decision from running. The workflow validates the selected smoke fixture paths instead of relying on helper-script exit-code plumbing, captures Article Health's per-file exit code, and relies on the verdict outputs plus warn/block gate decision step while still failing if the health script does not produce its expected JSON output.
 

--- a/mcp-tools/McpCliMetadata/McpCliMetadata.csproj
+++ b/mcp-tools/McpCliMetadata/McpCliMetadata.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>DocGeneration.McpCliMetadata</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="GenerateMapping.cs" />
     <InternalsVisibleTo Include="DocGeneration.McpCliMetadata.Tests" />
   </ItemGroup>
   <ItemGroup>

--- a/mcp-tools/McpCliMetadata/README.md
+++ b/mcp-tools/McpCliMetadata/README.md
@@ -27,6 +27,8 @@ The `azmcp` binary must be available on `PATH` as a prerequisite.
 - **`IProcessRunner`** — abstraction over `Process.Start` (enables unit testing with fakes)
 - **`Program.cs`** — entry point; accepts output directory as argument
 
+`Program.cs` is the only compiled executable entry point. Local backfill or scratch helpers must not add additional top-level statements to this project.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- Excludes the local `mcp-tools/McpCliMetadata/GenerateMapping.cs` scratch helper from `McpCliMetadata` compilation.
- Documents that `Program.cs` is the only executable entry point for `McpCliMetadata`.
- Adds a changelog entry for the CS8802 build fix.

## Root cause
A stray local `GenerateMapping.cs` file in `mcp-tools/McpCliMetadata` contains top-level statements. SDK-style projects compile all `*.cs` files by default, so it was compiled alongside `Program.cs`, producing CS8802: "Only one compilation unit can have top-level statements."

## Validation
- `dotnet build mcp-tools\McpCliMetadata\McpCliMetadata.csproj --configuration Release --no-restore` — passed, 0 warnings, 0 errors.
- `dotnet test mcp-tools\McpCliMetadata.Tests\McpCliMetadata.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"` — passed, 19/19.
- `dotnet run --project mcp-tools\DocGeneration.PipelineRunner\DocGeneration.PipelineRunner.csproj --configuration Release -- --steps 1 --namespace advisor --output generated-walter-cs8802-proof --skip-npm-update --skip-env-validation` — passed; bootstrap emitted CLI metadata and Step 1 generated advisor output.

## Notes
The first proof run without `--skip-npm-update` stopped because `mcp-tool-version.txt` requests `azure.mcp` 3.0.0-beta.25 while the machine already has 3.0.0-beta.26 installed. Re-running with the existing tool proved the generator path without the CS8802 build error.
