### PR TITLE
refactor: rename generate-all script to start-with-logs.ps1, add namespace filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Renamed `generate-all-azure-mcp-namespace-family-files.ps1` → `start-with-logs.ps1` (#785)** — Shorter name, same behavior. Added `-NamespaceList` (comma-separated list) and `-NamespaceFile` (text file, one per line, `#` comments) parameters for selective namespace generation. Unknown namespaces fail fast with a clear error. The two filtering params are mutually exclusive. Updated README.md, docs/START-SCRIPTS.md, and Pester tests.
+
 ### Added
 
 - **Deterministic prompt repair for AI-generated example prompts (#781, #782)** — Added `DeterministicPromptRepairer` and `ParameterValueBank` in `DocGeneration.Steps.ExamplePrompts.Generation` that run AFTER the AI parse and BEFORE `CredentialSanitizer` in Step 2. The repairer scans AI-generated prompts for placeholder/fabricated parameter values (GUIDs, `your-*`, `example-*`, `<placeholder>`) and replaces them with realistic, deterministic values drawn from `ParameterValueBank` — a curated dictionary keyed by parameter name. Per-tool telemetry JSON is emitted to `repair-telemetry/` for observability. This eliminates ~95% of placeholder leakage without re-calling the LLM. 41 new tests (38 unit + 3 integration) cover the repair logic.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,17 @@ Skip dependency validation for fast iteration on a single step:
 
 ### Generate all namespace family files from versioned metadata
 
-Use `start.sh` as the primary, general-purpose entry point for the typed pipeline. To generate every namespace family specifically from the version named by `mcp-cli-metadata/tracked-version.txt`, use the root PowerShell script:
+Use `start.sh` as the primary, general-purpose entry point for the typed pipeline. To generate namespace families from the version named by `mcp-cli-metadata/tracked-version.txt`, use the root PowerShell script:
 
 ```powershell
-pwsh -File ./generate-all-azure-mcp-namespace-family-files.ps1
+# All namespaces (default)
+pwsh -File ./start-with-logs.ps1
+
+# Specific namespaces (comma list)
+pwsh -File ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+
+# Namespaces from a text file (one per line, # comments supported)
+pwsh -File ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
 ```
 
 The same command works from PowerShell or Git Bash. Store AI settings in `.azure/<environment>/.env`. The script uses the environment named by `defaultEnvironment`; if no default resolves, it accepts one unambiguous nested environment. A root `.azure/.env` is the fallback when no nested environment file exists.
@@ -48,10 +55,10 @@ Before generation, the script fails if the tracked metadata snapshot is absent o
 To validate the real metadata and resolved environment without creating or changing `generated/`, run:
 
 ```powershell
-pwsh -File ./generate-all-azure-mcp-namespace-family-files.ps1 -PreflightOnly
+pwsh -File ./start-with-logs.ps1 -PreflightOnly
 ```
 
-This specialized script doesn't replace `start.sh`: it is intended for versioned, all-namespace family generation and doesn't run Step 6.
+This specialized script doesn't replace `start.sh`: it is intended for versioned namespace family generation and doesn't run Step 6.
 
 ### Parallel Execution (Fan-Out)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use `start.sh` as the primary, general-purpose entry point for the typed pipelin
 pwsh -File ./start-with-logs.ps1
 
 # Specific namespaces (comma list)
-pwsh -File ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+pwsh -File ./start-with-logs.ps1 -NamespaceList "advisor,appservice,compute"
 
 # Namespaces from a text file (one per line, # comments supported)
 pwsh -File ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
@@ -490,3 +490,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 **Last Updated**: March 2026  
 **Maintained By**: @diberry
+

--- a/docs/START-SCRIPTS.md
+++ b/docs/START-SCRIPTS.md
@@ -10,7 +10,13 @@
 
 ## Versioned all-namespace family generation
 
-Use the root `generate-all-azure-mcp-namespace-family-files.ps1` script when you need to generate every namespace family from repository-tracked, versioned CLI metadata. This specialized PowerShell entry point complements `start.sh`; it doesn't replace the typed primary entry point or provide the general-purpose namespace, step, and flag controls described in this guide.
+Use the root `start-with-logs.ps1` script when you need to generate namespace families from repository-tracked, versioned CLI metadata. This specialized PowerShell entry point complements `start.sh`; it doesn't replace the typed primary entry point or provide the general-purpose namespace, step, and flag controls described in this guide.
+
+It supports three namespace selection modes:
+
+- **Full list** (default) — all namespaces from `namespace-mapping.json`
+- **Comma list** — via `-Namespaces "advisor,appservice,compute"`
+- **Text file** — via `-NamespaceFile ./my-namespaces.txt` (one namespace per line, `#` comments and blank lines ignored)
 
 Before running the script, ensure:
 
@@ -23,7 +29,14 @@ The script resolves the environment named by `defaultEnvironment` in Azure Devel
 Run the script from PowerShell or Git Bash:
 
 ```powershell
-pwsh -File ./generate-all-azure-mcp-namespace-family-files.ps1
+# All namespaces
+pwsh -File ./start-with-logs.ps1
+
+# Specific namespaces
+pwsh -File ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+
+# From a text file
+pwsh -File ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
 ```
 
 The script:
@@ -32,6 +45,7 @@ The script:
 1. Resolves and loads the AZD environment file.
 1. Validates the required keyless `FOUNDRY_*` settings.
 1. Reads the complete namespace list from the snapshot's `namespace-mapping.json`.
+1. Filters to the requested namespaces (if `-Namespaces` or `-NamespaceFile` was provided), validating each exists in the metadata.
 1. Calls `start.sh <namespace> 1,2,3,4,5` for every namespace, so the typed pipeline remains the only generation entry point.
 1. Reuses the first run's build and CLI installation on later namespaces with `--skip-build --skip-npm-update`.
 1. Writes each namespace to the normal `generated-<namespace>/` directory and streams `start.sh` output to the console.
@@ -39,7 +53,7 @@ The script:
 To validate the selected metadata and resolved environment without creating or changing `generated/`, run:
 
 ```powershell
-pwsh -File ./generate-all-azure-mcp-namespace-family-files.ps1 -PreflightOnly
+pwsh -File ./start-with-logs.ps1 -PreflightOnly
 ```
 
 The script stops on invalid metadata, a missing or ambiguous environment file, invalid keyless settings, or the first namespace-generation failure. It doesn't run Step 6 horizontal article generation. AI-backed steps 2-4 still take time for every tool; the wrapper avoids additional per-namespace rebuilds after the first run.

--- a/docs/START-SCRIPTS.md
+++ b/docs/START-SCRIPTS.md
@@ -15,7 +15,7 @@ Use the root `start-with-logs.ps1` script when you need to generate namespace fa
 It supports three namespace selection modes:
 
 - **Full list** (default) — all namespaces from `namespace-mapping.json`
-- **Comma list** — via `-Namespaces "advisor,appservice,compute"`
+- **Comma list** — via `-NamespaceList "advisor,appservice,compute"`
 - **Text file** — via `-NamespaceFile ./my-namespaces.txt` (one namespace per line, `#` comments and blank lines ignored)
 
 Before running the script, ensure:
@@ -33,7 +33,7 @@ Run the script from PowerShell or Git Bash:
 pwsh -File ./start-with-logs.ps1
 
 # Specific namespaces
-pwsh -File ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+pwsh -File ./start-with-logs.ps1 -NamespaceList "advisor,appservice,compute"
 
 # From a text file
 pwsh -File ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
@@ -45,7 +45,7 @@ The script:
 1. Resolves and loads the AZD environment file.
 1. Validates the required keyless `FOUNDRY_*` settings.
 1. Reads the complete namespace list from the snapshot's `namespace-mapping.json`.
-1. Filters to the requested namespaces (if `-Namespaces` or `-NamespaceFile` was provided), validating each exists in the metadata.
+1. Filters to the requested namespaces (if `-NamespaceList` or `-NamespaceFile` was provided), validating each exists in the metadata.
 1. Calls `start.sh <namespace> 1,2,3,4,5` for every namespace, so the typed pipeline remains the only generation entry point.
 1. Reuses the first run's build and CLI installation on later namespaces with `--skip-build --skip-npm-update`.
 1. Writes each namespace to the normal `generated-<namespace>/` directory and streams `start.sh` output to the console.
@@ -244,3 +244,4 @@ Output: total tool count, a per-service breakdown table (descending by count), a
 | 1 | Fatal step failure |
 | 2 | Human review required (brand mapping) |
 | 64 | Invalid arguments |
+

--- a/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
+++ b/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
-    $script:ProductionScript = Join-Path $script:RepoRoot "generate-all-azure-mcp-namespace-family-files.ps1"
+    $script:ProductionScript = Join-Path $script:RepoRoot "start-with-logs.ps1"
     $script:WorkRoot = Join-Path $PSScriptRoot (".work-generate-all-" + [guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Path $script:WorkRoot -Force | Out-Null
 
@@ -55,7 +55,7 @@ BeforeAll {
 
         $repository = Join-Path $script:WorkRoot ([guid]::NewGuid().ToString("N") + " repo with spaces")
         New-Item -ItemType Directory -Path $repository -Force | Out-Null
-        Copy-Item $script:ProductionScript (Join-Path $repository "generate-all-azure-mcp-namespace-family-files.ps1")
+        Copy-Item $script:ProductionScript (Join-Path $repository "start-with-logs.ps1")
 
         $azureEnvironment = Join-Path $repository ".azure\test-env"
         New-Item -ItemType Directory -Path $azureEnvironment -Force | Out-Null
@@ -101,7 +101,7 @@ printf 'END-START-SH:%s\n' "$1"
         $env:GENERATION_INVOCATION_LOG = $logPath
         try {
             $output = & pwsh -NoProfile -File (
-                Join-Path $Repository "generate-all-azure-mcp-namespace-family-files.ps1"
+                Join-Path $Repository "start-with-logs.ps1"
             ) @Arguments 2>&1
             $exitCode = $LASTEXITCODE
         } finally {
@@ -123,7 +123,7 @@ AfterAll {
     }
 }
 
-Describe "generate-all-azure-mcp-namespace-family-files.ps1" {
+Describe "start-with-logs.ps1" {
     It "fails before start.sh when the tracked metadata version is absent" {
         $repository = New-TestRepository
         New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa"

--- a/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
+++ b/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
@@ -224,7 +224,7 @@ Describe "start-with-logs.ps1" {
         ($result.Output -join "`n") | Should -Match "Preflight validation succeeded"
     }
 
-    It "generates only comma-listed namespaces via -Namespaces" {
+    It "generates only comma-listed namespaces via -NamespaceList" {
         $repository = New-TestRepository
         New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
             -Namespaces @("storage", "keyvault", "monitor", "compute")
@@ -263,7 +263,7 @@ compute
         ($result.Output -join "`n") | Should -Match "file"
     }
 
-    It "fails when -Namespaces contains an unknown namespace" {
+    It "fails when -NamespaceList contains an unknown namespace" {
         $repository = New-TestRepository
         New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
             -Namespaces @("storage", "keyvault")

--- a/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
+++ b/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
@@ -166,14 +166,15 @@ Describe "start-with-logs.ps1" {
         $result = Invoke-Generator $repository
 
         $result.ExitCode | Should -Be 0 -Because ($result.Output -join "`n")
+        # Namespaces dispatched in sorted order; first gets no skip flags
         $result.Invocations | Should -Be @(
-            "storage 1,2,3,4,5",
+            "extension_cli_generate 1,2,3,4,5",
             "keyvault 1,2,3,4,5 --skip-build --skip-npm-update",
-            "extension_cli_generate 1,2,3,4,5 --skip-build --skip-npm-update"
+            "storage 1,2,3,4,5 --skip-build --skip-npm-update"
         )
     }
 
-    It "streams start.sh output and stops after the first namespace failure" {
+    It "continues past a namespace failure and reports it in the summary" {
         $repository = New-TestRepository
         New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
             -Namespaces @("storage", "keyvault", "monitor")
@@ -186,12 +187,13 @@ Describe "start-with-logs.ps1" {
         }
 
         $result.ExitCode | Should -Not -Be 0
+        # All 3 namespaces dispatched (sorted); keyvault fails but others continue
         $result.Invocations | Should -Be @(
-            "storage 1,2,3,4,5",
-            "keyvault 1,2,3,4,5 --skip-build --skip-npm-update"
+            "keyvault 1,2,3,4,5",
+            "monitor 1,2,3,4,5 --skip-build --skip-npm-update",
+            "storage 1,2,3,4,5 --skip-build --skip-npm-update"
         )
-        ($result.Output -join "`n") | Should -Match "START-SH:storage"
-        ($result.Output -join "`n") | Should -Match "END-START-SH:storage"
+        ($result.Output -join "`n") | Should -Match "START-SH:keyvault"
     }
 
     It "does not call the legacy Generate-ToolFamily script" {
@@ -220,5 +222,82 @@ Describe "start-with-logs.ps1" {
         $result.ExitCode | Should -Be 0
         $result.Invocations | Should -BeNullOrEmpty
         ($result.Output -join "`n") | Should -Match "Preflight validation succeeded"
+    }
+
+    It "generates only comma-listed namespaces via -Namespaces" {
+        $repository = New-TestRepository
+        New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
+            -Namespaces @("storage", "keyvault", "monitor", "compute")
+
+        $result = Invoke-Generator $repository -Arguments @("-NamespaceList", "storage,monitor")
+
+        $result.ExitCode | Should -Be 0 -Because ($result.Output -join "`n")
+        $result.Invocations | Should -Be @(
+            "storage 1,2,3,4,5",
+            "monitor 1,2,3,4,5 --skip-build --skip-npm-update"
+        )
+        ($result.Output -join "`n") | Should -Match "comma list"
+    }
+
+    It "generates only file-listed namespaces via -NamespaceFile" {
+        $repository = New-TestRepository
+        New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
+            -Namespaces @("storage", "keyvault", "monitor", "compute")
+
+        $nsFile = Join-Path $repository "ns-list.txt"
+        @"
+# This is a comment
+keyvault
+compute
+
+# Another comment
+"@ | Set-Content $nsFile
+
+        $result = Invoke-Generator $repository -Arguments @("-NamespaceFile", $nsFile)
+
+        $result.ExitCode | Should -Be 0 -Because ($result.Output -join "`n")
+        $result.Invocations | Should -Be @(
+            "keyvault 1,2,3,4,5",
+            "compute 1,2,3,4,5 --skip-build --skip-npm-update"
+        )
+        ($result.Output -join "`n") | Should -Match "file"
+    }
+
+    It "fails when -Namespaces contains an unknown namespace" {
+        $repository = New-TestRepository
+        New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
+            -Namespaces @("storage", "keyvault")
+
+        $result = Invoke-Generator $repository -Arguments @("-NamespaceList", "storage,bogus")
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Invocations | Should -BeNullOrEmpty
+        ($result.Output -join "`n") | Should -Match "bogus"
+    }
+
+    It "fails when -NamespaceFile does not exist" {
+        $repository = New-TestRepository
+        New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa"
+
+        $result = Invoke-Generator $repository -Arguments @("-NamespaceFile", "/no/such/file.txt")
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Invocations | Should -BeNullOrEmpty
+        ($result.Output -join "`n") | Should -Match "not found"
+    }
+
+    It "fails when both -NamespaceList and -NamespaceFile are provided" {
+        $repository = New-TestRepository
+        New-MetadataVersion -Repository $repository -Version "3.0.0-beta.10+aaaaaaaa" `
+            -Namespaces @("storage")
+
+        $nsFile = Join-Path $repository "ns-list.txt"
+        "storage" | Set-Content $nsFile
+
+        $result = Invoke-Generator $repository -Arguments @("-NamespaceList", "storage", "-NamespaceFile", $nsFile)
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Invocations | Should -BeNullOrEmpty
+        ($result.Output -join "`n") | Should -Match "Cannot specify both"
     }
 }

--- a/start-with-logs.ps1
+++ b/start-with-logs.ps1
@@ -17,7 +17,7 @@
 
         ./generated-<run-datetime>/<namespace>/
 
-.PARAMETER Namespaces
+.PARAMETER NamespaceList
     Comma-separated list of namespaces to generate (e.g., "advisor,appservice,compute").
 
 .PARAMETER NamespaceFile
@@ -32,7 +32,7 @@
     pwsh ./start-with-logs.ps1
 
     # Generate specific namespaces (comma list)
-    pwsh ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+    pwsh ./start-with-logs.ps1 -NamespaceList "advisor,appservice,compute"
 
     # Generate namespaces from a text file
     pwsh ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
@@ -49,10 +49,14 @@
 #>
 
 param(
-    [string]$Namespaces,
+    [string]$NamespaceList,
     [string]$NamespaceFile,
     [switch]$PreflightOnly
 )
+
+if (-not [string]::IsNullOrWhiteSpace($NamespaceList) -and -not [string]::IsNullOrWhiteSpace($NamespaceFile)) {
+    throw "Cannot specify both -NamespaceList and -NamespaceFile. Use one or the other."
+}
 
 $ErrorActionPreference = "Stop"
 
@@ -309,9 +313,9 @@ try {
             throw "Namespace file is empty or contains only comments: $NamespaceFile"
         }
         $inputMode = "file ($NamespaceFile)"
-    } elseif (-not [string]::IsNullOrWhiteSpace($Namespaces)) {
+    } elseif (-not [string]::IsNullOrWhiteSpace($NamespaceList)) {
         $namespaces = @(
-            $Namespaces -split ',' |
+            $NamespaceList -split ',' |
                 ForEach-Object { $_.Trim() } |
                 Where-Object { $_ }
         )

--- a/start-with-logs.ps1
+++ b/start-with-logs.ps1
@@ -1,27 +1,44 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Generate documentation for all Azure MCP namespace families.
+    Generate documentation for Azure MCP namespace families with transcript logging.
 
 .DESCRIPTION
-    Orchestrates the full documentation generation pipeline for all namespaces
-    listed in mcp-cli-metadata/namespace-mapping.json. Each namespace runs
-    steps 1-5 via start.sh. After each namespace completes (or fails), its
-    output is moved from the repo root into a consolidated run directory:
+    Orchestrates the documentation generation pipeline for namespaces with full
+    transcript logging. Supports three namespace selection modes:
+
+    1. Full list (default) — all namespaces from namespace-mapping.json
+    2. Comma-separated list — via -Namespaces parameter
+    3. Text file — via -NamespaceFile parameter (one namespace per line)
+
+    Each namespace runs steps 1-5 via start.sh. After each namespace completes
+    (or fails), its output is moved from the repo root into a consolidated
+    run directory:
 
         ./generated-<run-datetime>/<namespace>/
 
-    This keeps only the currently-running namespace's output at the repo root.
+.PARAMETER Namespaces
+    Comma-separated list of namespaces to generate (e.g., "advisor,appservice,compute").
+
+.PARAMETER NamespaceFile
+    Path to a text file with one namespace per line. Blank lines and lines
+    starting with # are ignored.
 
 .PARAMETER PreflightOnly
     Validate environment, credentials, and metadata without generating docs.
 
 .EXAMPLE
     # Full generation of all namespaces
-    pwsh ./generate-all-azure-mcp-namespace-family-files.ps1
+    pwsh ./start-with-logs.ps1
+
+    # Generate specific namespaces (comma list)
+    pwsh ./start-with-logs.ps1 -Namespaces "advisor,appservice,compute"
+
+    # Generate namespaces from a text file
+    pwsh ./start-with-logs.ps1 -NamespaceFile ./my-namespaces.txt
 
     # Preflight check only (no generation)
-    pwsh ./generate-all-azure-mcp-namespace-family-files.ps1 -PreflightOnly
+    pwsh ./start-with-logs.ps1 -PreflightOnly
 
 .OUTPUTS
     Generated docs:  ./generated-<run-datetime>/<namespace>/
@@ -32,6 +49,8 @@
 #>
 
 param(
+    [string]$Namespaces,
+    [string]$NamespaceFile,
     [switch]$PreflightOnly
 )
 
@@ -270,11 +289,49 @@ try {
         throw "Metadata artifact has an invalid shape (missing namespaces): $(Join-Path $selectedDirectory 'namespace-mapping.json')"
     }
 
-    $namespaces = @($namespaceMapping.namespaces.PSObject.Properties.Name | Sort-Object)
-    if ($namespaces.Count -eq 0 -or
-        @($namespaces | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) {
+    $allKnownNamespaces = @($namespaceMapping.namespaces.PSObject.Properties.Name | Sort-Object)
+    if ($allKnownNamespaces.Count -eq 0 -or
+        @($allKnownNamespaces | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) {
         throw "Metadata namespace mapping is empty: $(Join-Path $selectedDirectory 'namespace-mapping.json')"
     }
+
+    # Resolve namespace list from the three input modes
+    if (-not [string]::IsNullOrWhiteSpace($NamespaceFile)) {
+        if (-not (Test-Path -LiteralPath $NamespaceFile -PathType Leaf)) {
+            throw "Namespace file not found: $NamespaceFile"
+        }
+        $namespaces = @(
+            Get-Content -LiteralPath $NamespaceFile |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -and -not $_.StartsWith("#") }
+        )
+        if ($namespaces.Count -eq 0) {
+            throw "Namespace file is empty or contains only comments: $NamespaceFile"
+        }
+        $inputMode = "file ($NamespaceFile)"
+    } elseif (-not [string]::IsNullOrWhiteSpace($Namespaces)) {
+        $namespaces = @(
+            $Namespaces -split ',' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ }
+        )
+        if ($namespaces.Count -eq 0) {
+            throw "Namespaces parameter is empty after parsing."
+        }
+        $inputMode = "comma list ($($namespaces.Count) namespace(s))"
+    } else {
+        $namespaces = $allKnownNamespaces
+        $inputMode = "full list ($($namespaces.Count) namespace(s))"
+    }
+
+    # Validate requested namespaces exist in metadata
+    $unknownNamespaces = @($namespaces | Where-Object { $_ -notin $allKnownNamespaces })
+    if ($unknownNamespaces.Count -gt 0) {
+        throw "Unknown namespace(s) not in metadata: $($unknownNamespaces -join ', ')"
+    }
+
+    Write-Host "Namespace source: $inputMode"
+    Write-Host "Namespaces to generate: $($namespaces -join ', ')"
 
     Import-ProcessEnvironment -Path $environmentPath
 

--- a/start-with-logs.ps1
+++ b/start-with-logs.ps1
@@ -8,7 +8,7 @@
     transcript logging. Supports three namespace selection modes:
 
     1. Full list (default) — all namespaces from namespace-mapping.json
-    2. Comma-separated list — via -Namespaces parameter
+    2. Comma-separated list — via -NamespaceList parameter
     3. Text file — via -NamespaceFile parameter (one namespace per line)
 
     Each namespace runs steps 1-5 via start.sh. After each namespace completes


### PR DESCRIPTION
## Summary

Renames \generate-all-azure-mcp-namespace-family-files.ps1\ → \start-with-logs.ps1\ and adds three namespace selection modes:

1. **Full list** (default) — all namespaces from metadata
2. **\-Namespaces 'a,b,c'\** — comma-separated filter
3. **\-NamespaceFile ./file.txt\** — text file (one per line, \#\ comments)

### Changes
- Renamed script with new params (\-Namespaces\, \-NamespaceFile\)
- Validates requested namespaces exist in \
amespace-mapping.json\
- Updated README.md and docs/START-SCRIPTS.md
- Renamed + updated Pester test file