### PR TITLE
chore(squad): add ceremonies and decisions from PR #784/#785 session

### DIFF
--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -39,3 +39,54 @@
 2. Root cause analysis
 3. What should change?
 4. Action items for next iteration
+
+---
+
+## Blocker Resolution Re-Review
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | after |
+| **Condition** | team review returns blockers and all blockers are fixed |
+| **Facilitator** | coordinator |
+| **Participants** | all-relevant (same reviewers as initial review) |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. Verify each blocker is resolved (not just acknowledged)
+2. Check that fixes didn't introduce new issues
+3. Confirm non-blocking nits from initial review are addressed or explicitly deferred
+4. Post consolidated re-review verdict on the PR
+
+**Process:**
+- Fix all blockers in a single commit (or minimal commits)
+- Push to the same PR branch
+- Re-run the full team review with the same reviewers
+- If new blockers emerge, repeat the cycle
+- Cosmetic nits found in re-review may be fixed in a follow-up commit without another full re-review
+
+**Why this works:** PR #785 demonstrated the value — initial review caught 3 blockers (missing CHANGELOG, missing tests, missing mutual-exclusion guard). All were fixed in one pass, re-review found only 2 cosmetic nits. The cycle prevents both premature merges and infinite review loops.
+
+---
+
+## Pre-Existing Test Baseline Check
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | manual |
+| **When** | during |
+| **Condition** | test failures appear during implementation and it's unclear whether they are pre-existing or newly introduced |
+| **Facilitator** | implementer |
+| **Participants** | implementer + Cameron (test lead) |
+| **Time budget** | quick |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. Stash current changes
+2. Run the failing tests against main (or the base branch)
+3. If tests fail on main too, they are pre-existing — fix or update test expectations as part of the current work
+4. If tests pass on main, the failure is introduced — investigate the change
+
+**Why this works:** PR #785 had 2 pre-existing Pester test failures (namespace sort order) that were initially conflated with new failures caused by a variable collision. Running the baseline check separated the two classes of failures and avoided a false root cause analysis.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,11 @@
 
 ## Active Decisions
 
+### 2026-08-01: AD-027 — PowerShell parameter-variable collision check
+**By:** Coordinator (learned from PR #785)
+**What:** When reviewing PowerShell scripts (`.ps1`), Quinn and reviewers must check that `param()` parameter names do not collide (case-insensitive) with local variables used in the script body. PowerShell's type-constrained parameters silently coerce reassigned values (e.g., `[string]$Namespaces` converts an array assignment to a space-joined string), causing subtle bugs that only surface at runtime.
+**Why:** PR #785 had `[string]$Namespaces` as a parameter and `$namespaces` as a local variable. PowerShell treated them as the same variable, coercing array→string and breaking namespace iteration. Fix was to rename the parameter to `$NamespaceList`. This class of bug is invisible to static analysis and easy to introduce.
+
 ### 2026-05-31: AD-026 — PR CHANGELOG requirement (summary reference)
 **By:** Dina Berry (via Copilot)
 **What:** Every PR must update `CHANGELOG.md` under `## [Unreleased]` with a user-facing description before team review. Full definition in `.squad/decisions-archive.md` under AD-026.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -10,6 +10,7 @@ How to decide who handles what.
 | Pipeline orchestrator / step contracts | Riley | PipelineRunner, step registration, dependencies, workspace isolation, retry logic, merge orchestration |
 | C# generator code (`mcp-tools/**/*.cs`) | Morgan | Generator bug fixes, new generators, template changes, config file updates |
 | Scripts / CI / Docker (`.ps1`, `.sh`, `.yml`, `Dockerfile`) | Quinn | Script fixes, Docker builds, CI pipeline, preflight validation |
+| PowerShell param safety (`.ps1` reviews) | Quinn | Check param names don't collide with locals (AD-027), verify `[switch]` not `[bool]`, validate bash interop |
 | AI prompts / Azure OpenAI (`prompts/`, `GenerativeAI/`) | Sage | Prompt design, AI output validation, fabrication detection, content transformation |
 | Test projects (`*.Tests/`, `verify-quantity/`) | Parker | New tests, test data, content validation, regression detection |
 | Code review | Avery + domain specialist | Avery coordinates review; domain owner reviews implementation |


### PR DESCRIPTION
## Summary

Captures process improvements that proved effective during the PR #784 (display-name fix) and PR #785 (start-with-logs rename) session.

### Changes

**\.squad/ceremonies.md\**
- **Blocker Resolution Re-Review** — Formalizes the fix-all-blockers→re-review cycle that caught 3 real issues in PR #785 (missing CHANGELOG, missing tests, missing mutual-exclusion guard)
- **Pre-Existing Test Baseline Check** — Documents the stash→run-on-main pattern that separated 2 pre-existing Pester failures from 3 newly-introduced ones during PR #785

**\.squad/decisions.md\**
- **AD-027: PowerShell parameter-variable collision check** — PowerShell is case-insensitive for variables, so \[string]\\ (param) silently shadows \\\ (local) and coerces array→string. Requires reviewers to check for collisions.

**\.squad/routing.md\**
- Added Quinn routing for PowerShell param safety reviews (AD-027 + switch/bool + bash interop)

### Exemptions
Squad-only config changes — no CHANGELOG needed per AD-026 (internal refactor with no behavior change).