### PR TITLE
fix: remove first-word truncation in ResolveSourceToolsForArticle (#787)

### DIFF
--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilySourceVerificationTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Integration/ToolFamilySourceVerificationTests.cs
@@ -42,8 +42,9 @@ public sealed class ToolFamilySourceVerificationTests : IDisposable
         var result = await ValidateAsync(context);
 
         Assert.False(result.Success);
-        Assert.Contains(result.Warnings, warning => warning.Contains("article marker(s) are not present in source CLI JSON", StringComparison.Ordinal));
-        Assert.Contains(result.Warnings, warning => warning.Contains("storage account delete", StringComparison.Ordinal));
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("No tools found matching", StringComparison.Ordinal)
+            && warning.Contains("storage account delete", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -234,7 +235,7 @@ public sealed class ToolFamilySourceVerificationTests : IDisposable
         var result = await ValidateAsync(context);
 
         Assert.False(result.Success);
-        Assert.Contains(result.Warnings, warning => warning.Contains("No tools found matching 'emptyservice'", StringComparison.Ordinal));
+        Assert.Contains(result.Warnings, warning => warning.Contains("No tools found matching 'emptyservice resource list'", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/ToolFamilyPostAssemblyValidatorTests.cs
@@ -1609,6 +1609,305 @@ public class ToolFamilyPostAssemblyValidatorTests
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Issue #787: Shared-prefix namespace tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ValidateAsync_SharedPrefix_OnlyMatchesOwnNamespace_ExtensionCliGenerate()
+    {
+        // Reproduces #787: extension_cli_generate should resolve 1 tool, not 3.
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var snapshot = BuildCliOutputSimple("extension azqr", "extension cli generate", "extension cli install");
+            var context = CreateContextForNamespace(testRoot, "extension_cli_generate", snapshot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "extension_cli_generate.md"), "extension cli generate");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "extension_cli_generate.md"),
+                SharedPrefixArticle("extension cli generate", "Extension CLI Generate"));
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success, $"Validation failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("Source tool count check failed", StringComparison.Ordinal));
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("extra article command", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("missing from article", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("extension_azqr", "extension azqr", "Extension AzQR")]
+    [InlineData("extension_cli_generate", "extension cli generate", "Extension CLI Generate")]
+    [InlineData("extension_cli_install", "extension cli install", "Extension CLI Install")]
+    public async Task ValidateAsync_SharedPrefix_EachNamespaceGetsOnlyOwnTool(
+        string namespaceName, string command, string heading)
+    {
+        // Each of the 3 extension namespaces should resolve exactly 1 tool.
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var snapshot = BuildCliOutputSimple("extension azqr", "extension cli generate", "extension cli install");
+            var context = CreateContextForNamespace(testRoot, namespaceName, snapshot);
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", $"{namespaceName}.md"), command);
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", $"{namespaceName}.md"),
+                SharedPrefixArticle(command, heading));
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success, $"Namespace '{namespaceName}' failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("Source tool count check failed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MultiToolNamespace_StillWorksCorrectly()
+    {
+        // Regression guard: acr namespace with multiple sub-tools still resolves all of them.
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var snapshot = BuildCliOutputSimple("acr repository list", "acr repository show", "acr repository delete");
+            var context = CreateContextForNamespace(testRoot, "acr", snapshot);
+
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "acr-repository-list.md"), "acr repository list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "acr-repository-show.md"), "acr repository show");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "acr-repository-delete.md"), "acr repository delete");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "acr.md"), MultiToolArticle());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success, $"Validation failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("Source tool count check failed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SingleToolNamespace_NoSubcommands()
+    {
+        // Single-tool namespace where command = namespace name resolves to exactly 1 tool.
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var snapshot = BuildCliOutputSimple("version");
+            var context = CreateContextForNamespace(testRoot, "version", snapshot);
+
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "version.md"), "version");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "version.md"), SingleToolArticle());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success, $"Validation failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("Source tool count check failed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MixedDepthCommands_ResolvesCorrectly()
+    {
+        // Cameron amendment: namespace with commands at different depth levels.
+        // "network" has both "network list" and "network vnet show" — both should resolve.
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var snapshot = BuildCliOutputSimple("network list", "network vnet show", "network vnet delete");
+            var context = CreateContextForNamespace(testRoot, "network", snapshot);
+
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "network-list.md"), "network list");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "network-vnet-show.md"), "network vnet show");
+            SeedToolFile(Path.Combine(context.OutputPath, "tools", "network-vnet-delete.md"), "network vnet delete");
+            SeedFile(Path.Combine(context.OutputPath, "tool-family", "network.md"), MixedDepthArticle());
+
+            var validator = new ToolFamilyPostAssemblyValidator();
+            var result = await validator.ValidateAsync(context, new FakeStep(), CancellationToken.None);
+
+            Assert.True(result.Success, $"Validation failed. Warnings: {string.Join("; ", result.Warnings)}");
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("Source tool count check failed", StringComparison.Ordinal));
+            Assert.DoesNotContain(result.Warnings, w => w.Contains("missing from article", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    private static PipelineContext CreateContextForNamespace(string testRoot, string namespaceName, CliMetadataSnapshot snapshot)
+    {
+        var outputPath = Path.Combine(testRoot, $"generated-{namespaceName}");
+        Directory.CreateDirectory(outputPath);
+
+        var context = new PipelineContext
+        {
+            Request = new PipelineRequest(namespaceName, [4], outputPath, SkipBuild: true, SkipValidation: false, DryRun: false),
+            RepoRoot = testRoot,
+            McpToolsRoot = Path.Combine(testRoot, "mcp-tools"),
+            OutputPath = outputPath,
+            ProcessRunner = new RecordingProcessRunner(),
+            Workspaces = new WorkspaceManager(),
+            CliMetadataLoader = new StubCliMetadataLoader(),
+            TargetMatcher = new TargetMatcher(),
+            FilteredCliWriter = new StubFilteredCliWriter(),
+            BuildCoordinator = new StubBuildCoordinator(),
+            AiCapabilityProbe = new StubAiCapabilityProbe(),
+            Reports = new BufferedReportWriter(),
+            CliVersion = "1.2.3",
+            SelectedNamespaces = [namespaceName],
+        };
+
+        context.Items[ToolFamilyPostAssemblyValidator.FamilyNameContextKey] = namespaceName;
+        context.Items["Namespace"] = namespaceName;
+        context.CliOutput = snapshot;
+        context.SourceCliOutput = snapshot;
+        return context;
+    }
+
+    private static CliMetadataSnapshot BuildCliOutputSimple(params string[] commands)
+    {
+        var cliTools = new List<CliTool>();
+        foreach (var cmd in commands)
+        {
+            var json = $$"""{ "command": "{{cmd}}", "name": "{{cmd}}" }""";
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            cliTools.Add(new CliTool(cmd, cmd, null, doc.RootElement.Clone()));
+        }
+
+        using var rootDoc = System.Text.Json.JsonDocument.Parse("{}");
+        return new CliMetadataSnapshot("cli-output.json", rootDoc.RootElement.Clone(), cliTools);
+    }
+
+    private static string SharedPrefixArticle(string command, string heading)
+        => $$"""
+        ---
+        title: {{heading}} tools
+        tool_count: 1
+        ---
+        # {{heading}} tools
+
+        ## {{heading}}
+        <!-- @mcpcli {{command}} -->
+        Example prompts include:
+        - Run the tool with name 'my-resource' in resource group 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | name | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string MultiToolArticle()
+        => """
+        ---
+        title: ACR tools
+        tool_count: 3
+        ---
+        # ACR tools
+
+        ## List repositories
+        <!-- @mcpcli acr repository list -->
+        Example prompts include:
+        - List repositories where registry name is 'myregistry'
+        | Parameter | Required |
+        | --- | --- |
+        | registry name | Yes |
+
+        ## Show repository
+        <!-- @mcpcli acr repository show -->
+        Example prompts include:
+        - Show details of repository name 'myrepo' in registry name 'myregistry'
+        | Parameter | Required |
+        | --- | --- |
+        | registry name | Yes |
+        | repository name | Yes |
+
+        ## Delete repository
+        <!-- @mcpcli acr repository delete -->
+        Example prompts include:
+        - Delete repository name 'myrepo' from registry name 'myregistry'
+        | Parameter | Required |
+        | --- | --- |
+        | registry name | Yes |
+        | repository name | Yes |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string SingleToolArticle()
+        => """
+        ---
+        title: Version tools
+        tool_count: 1
+        ---
+        # Version tools
+
+        ## Version
+        <!-- @mcpcli version -->
+        Example prompts include:
+        - Show the current version
+        | Parameter | Required |
+        | --- | --- |
+        | format | No |
+
+        ## Related content
+        - Link
+        """;
+
+    private static string MixedDepthArticle()
+        => """
+        ---
+        title: Network tools
+        tool_count: 3
+        ---
+        # Network tools
+
+        ## List networks
+        <!-- @mcpcli network list -->
+        Example prompts include:
+        - List all networks in resource group 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | resource group | No |
+
+        ## Show virtual network
+        <!-- @mcpcli network vnet show -->
+        Example prompts include:
+        - Show details of vnet name 'myvnet' in resource group 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vnet name | Yes |
+
+        ## Delete virtual network
+        <!-- @mcpcli network vnet delete -->
+        Example prompts include:
+        - Delete vnet name 'myvnet' from resource group 'rg-one'
+        | Parameter | Required |
+        | --- | --- |
+        | vnet name | Yes |
+
+        ## Related content
+        - Link
+        """;
+
     private static CliMetadataSnapshot BuildCliOutput(
         params (string Command, bool Destructive, bool Idempotent, bool OpenWorld, bool ReadOnly, bool Secret, bool LocalRequired)[] tools)
     {

--- a/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs
@@ -786,7 +786,6 @@ public sealed class ToolFamilyPostAssemblyValidator : IPostValidator
         var roots = article.Sections
                 .SelectMany(section => section.Commands)
                 .Select(NormalizeToolCommand)
-                .Select(command => command.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
                 .Append(sourceNamespace)
                 .Where(root => !string.IsNullOrWhiteSpace(root))
                 .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary

Fixes #787 — False-positive Step 4 validation failure for shared-prefix namespaces (`extension_cli_*`).

## Root Cause

`ResolveSourceToolsForArticle()` in `ToolFamilyPostAssemblyValidator.cs` extracted only the **first word** of each article command as the match root:

```csharp
.Select(command => command.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
```

For namespace `extension_cli_generate` (command: `extension cli generate`), this produced root `"extension"`. `TargetMatcher.FindMatches()` then prefix-matched against **all tools in the catalog**, returning 3 tools across 3 different namespaces instead of 1.

## Fix

Remove the `.Split(' ').FirstOrDefault()` truncation — use the full normalized command as the match root. `TargetMatcher.FindMatches` does `exact match || StartsWith(root + " ")`, so full commands like `"extension cli generate"` correctly match only that tool or its sub-commands.

## Changes

| File | Change |
|------|--------|
| `ToolFamilyPostAssemblyValidator.cs` ~line 789 | Remove `.Split(' ').FirstOrDefault()` — use full command |
| `ToolFamilyPostAssemblyValidatorTests.cs` | Add 6 new test methods (7 test cases) |
| `ToolFamilySourceVerificationTests.cs` | Update 2 integration test assertions for new error path |

## Tests Added (7 cases)

| Test | What it covers |
|------|---------------|
| `SharedPrefix_OnlyMatchesOwnNamespace_ExtensionCliGenerate` | Bug reproducer — validates exactly 1 tool resolved |
| `SharedPrefix_EachNamespaceGetsOnlyOwnTool` (Theory × 3) | All 3 extension namespaces resolve only their own tool |
| `MultiToolNamespace_StillWorksCorrectly` | Regression guard — `acr` with 3 sub-tools still works |
| `SingleToolNamespace_NoSubcommands` | Single-tool namespace resolves correctly |
| `MixedDepthCommands_ResolvesCorrectly` | Cameron amendment — mixed-depth commands in same namespace |

## Squad Review

[Review comment](https://github.com/diberry/microsoft-mcp-doc-generation/issues/787#issuecomment-5151700482) — 3 reviewers:
- **Riley** (Architect): Core fix correct; recommended follow-up namespace boundary filter
- **Cameron** (Test Lead): Test amendments incorporated (exact assertions, mixed-depth case, non-vacuous Test 3)
- **Morgan** (C# Generator): APPROVE — single call site confirmed, no regression risk

## Verification

- ✅ `dotnet build mcp-doc-generation.sln --configuration Release` — 0 warnings, 0 errors
- ✅ `dotnet test` — 618 PipelineRunner tests pass (611 existing + 7 new)
- ⚠️ 2 pre-existing E2E test failures (unrelated — require generated output directories)