### PR TITLE
fix: Beta.31 generation failures (F1-F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Beta.31 generation failures — 20/65 namespace failures resolved** — Four fixes addressing cold-start timeouts, stale namespace config, parameter filtering, and output contamination:
+  - **F1: CLI metadata retry with exponential backoff** — BootstrapStep now retries CLI metadata extraction up to 3 times (2s→4s→8s backoff) before failing with a clear diagnostic message. Applies to all runs, not just cold-start.
+  - **F2: Removed stale `foundry` namespace + drift detection** — Removed the obsolete `foundry` entry from `brand-to-server-mapping.json` (replaced by `foundryextensions` in beta.31). Added namespace drift detection that hard-errors when a configured namespace is missing from CLI output, with guidance to check `config/namespace-mapping.json`.
+  - **F3: Include ALL parameters in generated output** — Stopped filtering common parameters (tenant, auth-method, retry-*, subscription) from tool parameter tables. All params now appear; Dina strips them manually during content PR creation for consistency between CLI and NLP tabs.
+  - **F4: Archive previous output to `generated-old/`** — Previous generation output is now moved to `generated-old/{timestamp}/` instead of deleted, preventing cross-version contamination while preserving history. Clear logging distinguishes clean vs incremental runs.
+
 ### Changed
 
 - **Renamed `generate-all-azure-mcp-namespace-family-files.ps1` → `start-with-logs.ps1` (#785)** — Shorter name, same behavior. Added `-NamespaceList` (comma-separated list) and `-NamespaceFile` (text file, one per line, `#` comments) parameters for selective namespace generation. Unknown namespaces fail fast with a clear error. The two filtering params are mutually exclusive. Updated README.md, docs/START-SCRIPTS.md, and Pester tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Pipeline generation hardening for Step 2, Step 4, and Step 5 failures (#791)** — Three pipeline fixes now prevent the 2026-08-02 catalog run regressions from recurring:
+  - **Step 2: Actionable example-prompt retry feedback + deterministic last resort** — retry feedback now appends an actionable section that names the missing required parameters, identifies prompt slots that can absorb them, and shows a concrete rewrite example. `DeterministicPromptRepairer` also adds a last-resort display-name-based fallback prompt when canonical-name injection still leaves coverage gaps after sanitization.
+  - **Step 4: Pre-assembly phantom-parameter stripping** — `FamilyStructureBuilder` now runs a `ParameterCrossCheckService` against Step 1 parameter manifest JSON before assembly and removes parameter-table rows that are not present in the CLI source manifest, logging each stripped hallucinated parameter instead of letting the post-assembly validator fail later.
+  - **Step 5: Skills relevance filename alignment + zero-skill grace path** — `SkillsRelevanceStep` now resolves report filenames with the same sanitization used by the writer and treats zero relevant skills as a warning-only success instead of a missing-artifact failure.
+
 - **Beta.31 generation failures — 20/65 namespace failures resolved** — Four fixes addressing cold-start timeouts, stale namespace config, parameter filtering, and output contamination:
   - **F1: CLI metadata retry with exponential backoff** — BootstrapStep now retries CLI metadata extraction up to 3 times (2s→4s→8s backoff) before failing with a clear diagnostic message. Applies to all runs, not just cold-start.
   - **F2: Removed stale `foundry` namespace + drift detection** — Removed the obsolete `foundry` entry from `brand-to-server-mapping.json` (replaced by `foundryextensions` in beta.31). Added namespace drift detection that hard-errors when a configured namespace is missing from CLI output, with guidance to check `config/namespace-mapping.json`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,7 +171,7 @@ Steps declare their dependencies, failure policy, and whether they need AI confi
 
 | Step | Class | AI? | Failure | Retries | Key Outputs |
 |------|-------|-----|---------|---------|-------------|
-| 0 | `BootstrapStep` | No | Fatal | 0 | `cli/`, `h2-headings/`, `e2e-test-prompts/`, `namespace-mapping.json` |
+| 0 | `BootstrapStep` | No | Fatal | 3 | `cli/`, `h2-headings/`, `e2e-test-prompts/`, `namespace-mapping.json` |
 | 1 | `AnnotationsParametersRawStep` | No | Fatal | 0 | `annotations/`, `parameters/`, `tools-raw/` |
 | 2 | `ExamplePromptsStep` | Yes | Fatal | 0 | `example-prompts/` |
 | 3 | `ToolGenerationStep` | Yes | Fatal | 0 | `tools-composed/`, `tools/` |
@@ -392,6 +392,51 @@ Before processing namespace-scoped steps, `PipelineRunner.RunAsync()` applies an
 1. `--mcp-branch` CLI flag
 2. `MCP_BRANCH` environment variable
 3. Default: `main`
+
+### CLI Metadata Retry Logic
+
+BootstrapStep retries CLI metadata extraction with exponential backoff to handle cold-start timeouts (e.g., first invocation after `dotnet tool install`):
+
+- **Attempts**: Initial + 3 retries (4 total)
+- **Backoff**: 2s → 4s → 8s between retries
+- **Scope**: All CLI metadata extractions (not just cold-start)
+- **On exhaustion**: Pipeline fails with diagnostic message listing all attempt errors
+- **Testability**: Delay function is injected (overridable in tests)
+
+### Namespace Drift Detection
+
+After loading CLI metadata, BootstrapStep validates that every `mcpServerName` in `brand-to-server-mapping.json` exists in the live CLI namespace list. Mismatches produce a **hard error** that stops the pipeline:
+
+```
+Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI output.
+Check config/namespace-mapping.json and merge-namespaces.sh for planned namespace changes.
+HUMAN action required.
+```
+
+This prevents silent failures when Microsoft renames or removes namespaces between beta versions. Configuration files that track planned changes:
+- `config/namespace-mapping.json` — namespace lifecycle tracking
+- `merge-namespaces.sh` — namespace merge/join configuration
+
+### Output Archival (generated-old)
+
+When running a **clean run** (full pipeline), previous output is moved to `generated-old/{timestamp}/` instead of being deleted. This:
+- Preserves prior generation results for debugging cross-version issues
+- Prevents stale content from contaminating fresh runs
+- Provides clear logging: "Clean run: archiving previous output" vs "Incremental run: preserving existing output"
+
+## Parameter Taxonomy (3-Tier Model)
+
+Parameters in Azure MCP tools fall into three categories:
+
+| Tier | Parameters | Behavior in Generated Output |
+|------|-----------|------------------------------|
+| **Global** | `--tenant`, `--auth-method`, `--retry-delay`, `--retry-max-delay`, `--retry-max-retries`, `--retry-mode`, `--retry-network-timeout` | Included in all tool parameter tables (Dina strips during content PR) |
+| **Resource-group** | `--resource-group` | Included in all tool parameter tables (Dina strips during content PR when not required) |
+| **Tool-specific** | All other parameters | Always included; must never be lost or dropped |
+
+**Historical note**: Prior to beta.31 fixes, common/global parameters were filtered from generated output automatically. This was changed to include all parameters for consistency between CLI and NLP tabs, with manual stripping during content PR creation.
+
+The `common-parameters.json` file is retained for documentation purposes but is no longer used for filtering.
 
 ### Parallel Execution
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,6 +56,9 @@ Step 1: Annotations + Parameters + Raw Tools ───────────�
   │  • cli-output.json → annotations/*.md (tool metadata flags)
   │  • cli-output.json → parameters/*.md (parameter tables)
   │  • cli-output.json → tools-raw/*.md (raw tool markdown)
+  │  • Parameter tables now keep ALL CLI parameters, including common
+  │    infrastructure/scoping flags such as tenant, auth-method,
+  │    retry-*, and subscription
   │  • Parameter tables and CLI example command flags use the same
   │    stable required-first order: required parameters first, then
   │    optional parameters, preserving source order within each group
@@ -71,6 +74,12 @@ Step 2: Example Prompts (AI + Deterministic Repair) ─────────�
   │  • DeterministicPromptRepairer replaces placeholder/fabricated
   │    parameter values with realistic deterministic values (runs
   │    AFTER AI parse, BEFORE CredentialSanitizer)
+  │  • Retry feedback now adds actionable repair guidance: missing
+  │    parameter names, prompt-slot suggestions, and a concrete rewrite
+  │    example for the next AI attempt
+  │  • If canonical-name injection still misses a required parameter
+  │    after sanitization, DeterministicPromptRepairer injects a
+  │    display-name-based last-resort fallback prompt
   │  • Per-tool repair telemetry → repair-telemetry/*.json
   │  • Validation checks parameter coverage in generated prompts
   │
@@ -86,6 +95,9 @@ Step 4: Tool Family Assembly (AI + Retry + Validation) ────────�
   │  • `FamilyStructureBuilder` deterministically emits
   │    `FamilyStructureContext` (family name, section order, headings,
   │    source content, schema version) before AI metadata generation
+  │  • Pre-assembly `ParameterCrossCheckService` compares each tool's
+  │    parameter table to the Step 1 parameter manifest and strips any
+  │    hallucinated parameter rows before the family article is stitched
   │  • H2 headings come from bootstrap `h2-headings/*.json`
   │  • AI generates: frontmatter, intro, related content
   │  • Post-processing: MCP acronym expansion, frontmatter enrichment,
@@ -104,6 +116,10 @@ Step 4: Tool Family Assembly (AI + Retry + Validation) ────────�
   ▼
 Step 5: Skills Relevance (non-blocking) ───────────────────────────
   │  • tools/ → skills-relevance/*.md (GitHub Copilot skills mapping)
+  │  • Output lookup uses the same sanitized filename strategy as the
+  │    writer, so multi-token/extension namespaces resolve correctly
+  │  • Zero relevant skills is treated as warning-only success rather
+  │    than a missing-artifact failure
   │  • Warning-only — failures don't stop the pipeline
   │
   ▼
@@ -405,17 +421,31 @@ BootstrapStep retries CLI metadata extraction with exponential backoff to handle
 
 ### Namespace Drift Detection
 
-After loading CLI metadata, BootstrapStep validates that every `mcpServerName` in `brand-to-server-mapping.json` exists in the live CLI namespace list. Mismatches produce a **hard error** that stops the pipeline:
+After loading CLI metadata, BootstrapStep checks whether every `mcpServerName` in `brand-to-server-mapping.json` exists in the live CLI namespace list. Mismatches produce a **warning** (non-fatal) logged to the console:
 
 ```
-Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI output.
-Check config/namespace-mapping.json and merge-namespaces.sh for planned namespace changes.
-HUMAN action required.
+WARNING: Namespace 'get' exists in brand-to-server-mapping.json but was not found in CLI output.
 ```
 
-This prevents silent failures when Microsoft renames or removes namespaces between beta versions. Configuration files that track planned changes:
+This alerts operators to namespace lifecycle changes but does **not** stop the pipeline — Steps 1–3 do not require brand-mapping data and can proceed for any namespace present in the CLI output.
+
+Configuration files that track planned changes:
 - `config/namespace-mapping.json` — namespace lifecycle tracking
 - `merge-namespaces.sh` — namespace merge/join configuration
+
+### Brand-to-Server Mapping: When It Matters
+
+`brand-to-server-mapping.json` is consumed only at **Step 4** (tool-family assembly) and **Step 5** (merge-namespaces). Its purpose is to:
+
+1. Resolve the user-facing brand name and output filename for the tool-family article
+2. Determine whether multiple namespaces merge into a single tool-family file (`mergeGroup`)
+
+**If a namespace is NOT in brand-mapping**, Steps 4 and 5 still complete successfully — they use the raw namespace name as the fallback filename and skip multi-namespace merge logic. The only features that require a brand-mapping entry are:
+
+- Custom brand display names (e.g., "Azure Container Registry" instead of "acr")
+- Multi-namespace merge groups (combining related namespaces into one article)
+
+Namespaces missing from brand-mapping produce identical tool-family output to those with an entry whose `fileName` matches the namespace — i.e., no alterations are needed for single-namespace families.
 
 ### Output Archival (generated-old)
 

--- a/docs/PROJECT-GUIDE.md
+++ b/docs/PROJECT-GUIDE.md
@@ -125,7 +125,7 @@ When iterating on a single step whose prerequisites already exist from a prior r
 | 2 | Example Prompts | Per-namespace | Yes | `example-prompts/`, `example-prompts-prompts/`, `repair-telemetry/` |
 | 3 | Tool Generation | Per-namespace | Yes | `tools/` (AI-improved markdown) |
 | 4 | Tool-Family Assembly | Per-namespace | Yes | `tool-family/{namespace}.md` |
-| 5 | Skills Relevance | Per-namespace | No | `skills-relevance/{namespace}-skills-relevance.md` |
+| 5 | Skills Relevance | Per-namespace | No | `skills-relevance/{sanitized-namespace}-skills-relevance.md` |
 | 6 | Horizontal Articles | Per-namespace | Yes | `horizontal-articles/` |
 
 ### Pipeline Observability
@@ -302,10 +302,25 @@ tail -f generated/logs/step2.log
 ./start.sh advisor 2 --verbose
 ```
 
+#### Step 2 keeps retrying the same missing required parameters
+
+**Cause:** The validation report found missing required parameters in generated example prompts  
+**Solution:** Retry feedback now appends actionable guidance naming the missing parameters, suggesting which prompt slots to rewrite, and giving a concrete rewrite example. If retries still fail, inspect `example-prompts-validation/` and `repair-telemetry/` for the exact uncovered parameter names.
+
 #### Step 4 tool-count mismatch in validation report
 
 **Cause:** Phantom `## ` sections injected by AI heading replacement or assembly, inflating the detected tool count  
 **Solution:** The pipeline now strips phantom H2 sections during Phase 1.5 (heading replacement) and Step 4 (post-assembly). If validation still fails, inspect the tool-family article for stray `## ` headings with no body content.
+
+#### Step 4 reports parameters that do not exist in CLI source
+
+**Cause:** Step 3 can hallucinate plausible parameter names when it rewrites tool prose  
+**Solution:** `FamilyStructureBuilder` now cross-checks each tool parameter table against the Step 1 parameter manifest and strips hallucinated rows before assembly. If one still appears, inspect `parameters/*-params.json` for the source-of-truth parameter list and compare it to the corresponding `tools/*.md` file.
+
+#### Step 5 warns about missing skills relevance output for extension namespaces
+
+**Cause:** Skills relevance filenames are sanitized from the normalized namespace, so multi-token namespaces such as `extension azqr` produce `extension-azqr-skills-relevance.md`  
+**Solution:** The pipeline now uses the same sanitization for lookup and treats zero relevant skills as a warning-only success. Check the `skills-relevance/` directory for the sanitized filename if you need to inspect the raw output manually.
 
 #### ParameterCoverageChecker false positives freezing sections
 
@@ -810,7 +825,7 @@ The pipeline operates in **6 sequential steps per namespace**, taking a canonica
 3. **Example Prompts (Step 2)** → Use AI to generate realistic usage examples for each tool
 4. **Tool Generation (Step 3)** → Use AI to compose markdown for each tool, referencing examples and annotations
 5. **Tool-Family Assembly (Step 4)** → Use AI to assemble per-namespace articles, validate structural integrity
-6. **Skills Relevance (Step 5)** → Generate Copilot skills relevance metadata (supplementary)
+6. **Skills Relevance (Step 5)** → Generate Copilot skills relevance metadata (supplementary, warning-only, sanitized filenames)
 7. **Horizontal Articles (Step 6)** → Generate cross-service feature articles using AI
 
 **Key design principles:**

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -53,6 +53,54 @@ public class BootstrapStepTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_NamespaceDriftDetected_FailsWithHumanActionMessage()
+    {
+        using var harness = CreateHarness(
+            brandMappingJson: """[{"mcpServerName":"foundry","brandName":"Azure AI Foundry","shortName":"Foundry","fileName":"azure-ai-foundry"}]""");
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(
+                "Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI output. Check config/namespace-mapping.json and merge-namespaces.sh for planned namespace changes. HUMAN action required.",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CliMetadataExtractionRetriesThreeTimesAndFailsWithClearMessage()
+    {
+        using var harness = CreateHarness(metadataFailuresBeforeSuccess: 4);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(4, harness.ProcessRunner.MetadataInvocationCount);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains("CLI metadata extraction failed after 4 attempts", StringComparison.Ordinal));
+        Assert.Contains(
+            ((BufferedReportWriter)harness.Context.Reports).Messages,
+            message => message.Contains("Retrying CLI metadata extraction (attempt 2 of 4)", StringComparison.Ordinal));
+        Assert.Contains(
+            ((BufferedReportWriter)harness.Context.Reports).Messages,
+            message => message.Contains("Retrying CLI metadata extraction (attempt 4 of 4)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CliMetadataExtractionSucceedsOnThirdAttempt()
+    {
+        using var harness = CreateHarness(metadataFailuresBeforeSuccess: 2);
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal(3, harness.ProcessRunner.MetadataInvocationCount);
+        Assert.Equal("1.2.3", harness.Context.CliVersion);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_CliVersionMetadataMissing_Fails()
     {
         using var harness = CreateHarness(cliMetadataLoader: new DelegatingCliMetadataLoader(versionExists: false));
@@ -72,6 +120,40 @@ public class BootstrapStepTests
 
         Assert.True(result.Success);
         Assert.True(harness.BuildCoordinator.SkipBuildObserved);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FullRunMovesExistingOutputToGeneratedOld()
+    {
+        using var harness = CreateHarness(requestSteps: [1, 2, 3, 4, 5, 6]);
+        Directory.CreateDirectory(harness.Context.OutputPath);
+        File.WriteAllText(Path.Combine(harness.Context.OutputPath, "existing.txt"), "keep me");
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        var archiveRoot = Path.Combine(harness.Context.RepoRoot, "generated-old");
+        Assert.True(Directory.Exists(archiveRoot));
+        var archivedDirectories = Directory.GetDirectories(archiveRoot);
+        Assert.Single(archivedDirectories);
+        Assert.True(File.Exists(Path.Combine(archivedDirectories[0], "existing.txt")));
+        Assert.False(File.Exists(Path.Combine(harness.Context.OutputPath, "existing.txt")));
+        Assert.Contains(
+            ((BufferedReportWriter)harness.Context.Reports).Messages,
+            message => message.Contains("Clean run: moving previous output to generated-old/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IncrementalRunLogsPreservationMessage()
+    {
+        using var harness = CreateHarness();
+
+        var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Contains(
+            ((BufferedReportWriter)harness.Context.Reports).Messages,
+            message => message.Contains("Incremental run: preserving existing output", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -104,6 +186,7 @@ public class BootstrapStepTests
         // Brand mapping lists azurebackup; SelectedNamespaces echoes it
         using var harness = CreateHarness(
             selectedNamespaces: ["azurebackup"],
+            namespaceNames: ["azurebackup"],
             brandMappingJson: """[{"mcpServerName":"azurebackup","fileName":"azure-backup"}]""");
 
         var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
@@ -123,6 +206,7 @@ public class BootstrapStepTests
         // Running only "monitor" should also include "workbooks" (same mergeGroup)
         using var harness = CreateHarness(
             selectedNamespaces: ["monitor"],
+            namespaceNames: ["monitor", "workbooks"],
             brandMappingJson: """
                 [
                   {"mcpServerName":"monitor","fileName":"azure-monitor","mergeGroup":"azure-monitor","mergeRole":"primary"},
@@ -146,6 +230,7 @@ public class BootstrapStepTests
     {
         // No selected namespaces (all-namespace run) — should pull all from brand mapping
         using var harness = CreateHarness(
+            namespaceNames: ["compute", "storage"],
             brandMappingJson: """
                 [
                   {"mcpServerName":"compute","fileName":"azure-compute"},
@@ -437,9 +522,12 @@ public class BootstrapStepTests
         bool skipEnvValidation = false,
         bool skipNpmUpdate = false,
         bool failNpmLatestInstall = false,
+        int metadataFailuresBeforeSuccess = 0,
         bool requiresAiConfiguration = false,
         bool aiConfigured = true,
         ICliMetadataLoader? cliMetadataLoader = null,
+        IReadOnlyList<string>? namespaceNames = null,
+        IReadOnlyList<int>? requestSteps = null,
         IReadOnlyList<string>? selectedNamespaces = null,
         string? brandMappingJson = null,
         string? mcpToolVersionFileContent = "3.0.0-beta.15",
@@ -464,10 +552,12 @@ public class BootstrapStepTests
         {
             FailNpmLatestInstall = failNpmLatestInstall,
             AlreadyInstalledVersion = alreadyInstalledVersion,
+            MetadataFailuresBeforeSuccess = metadataFailuresBeforeSuccess,
+            NamespaceNames = namespaceNames ?? ["compute"],
         };
         var buildCoordinator = new RecordingBuildCoordinator();
         var aiCapabilityProbe = new RecordingAiCapabilityProbe(aiConfigured);
-        var step = new BootstrapStep();
+        var step = new BootstrapStep(delayAsync: static (_, _) => Task.CompletedTask);
         var plannedSteps = requiresAiConfiguration
             ? new IPipelineStep[] { step, new ExamplePromptsStep() }
             : new IPipelineStep[] { step, new AnnotationsParametersRawStep() };
@@ -476,7 +566,7 @@ public class BootstrapStepTests
         {
             Request = new PipelineRequest(
                 "compute",
-                [1],
+                requestSteps ?? [1],
                 ".\\generated-compute",
                 SkipBuild: skipBuild,
                 SkipValidation: skipValidation,
@@ -604,17 +694,6 @@ public class BootstrapStepTests
             },
         });
 
-        private static readonly string NamespaceJson = JsonSerializer.Serialize(new
-        {
-            results = new[]
-            {
-                new
-                {
-                    name = "compute",
-                },
-            },
-        });
-
         public bool FailNpmLatestInstall { get; init; }
 
         /// <summary>
@@ -622,6 +701,12 @@ public class BootstrapStepTests
         /// with "already installed" in stderr — simulating the tool already being at that version.
         /// </summary>
         public string? AlreadyInstalledVersion { get; init; }
+
+        public int MetadataFailuresBeforeSuccess { get; init; }
+
+        public int MetadataInvocationCount { get; private set; }
+
+        public IReadOnlyList<string> NamespaceNames { get; init; } = ["compute"];
 
         public List<ProcessSpec> Invocations { get; } = new();
 
@@ -660,12 +745,28 @@ public class BootstrapStepTests
 
             if (spec.FileName == "dotnet" && spec.Arguments.Any(arg => arg.EndsWith("McpCliMetadata.csproj", StringComparison.OrdinalIgnoreCase)))
             {
+                MetadataInvocationCount++;
+                if (MetadataInvocationCount <= MetadataFailuresBeforeSuccess)
+                {
+                    return ValueTask.FromResult(new ProcessExecutionResult(
+                        spec.FileName,
+                        spec.Arguments,
+                        spec.WorkingDirectory,
+                        124,
+                        string.Empty,
+                        "timed out waiting for azmcp cold start",
+                        TimeSpan.Zero));
+                }
+
                 var outputPath = spec.Arguments.Last();
                 var cliDir = Path.Combine(outputPath, "cli");
                 Directory.CreateDirectory(cliDir);
                 File.WriteAllText(Path.Combine(cliDir, "cli-version.json"), "{\"version\":\"1.2.3\"}");
                 File.WriteAllText(Path.Combine(cliDir, "cli-output.json"), CliOutputJson);
-                File.WriteAllText(Path.Combine(cliDir, "cli-namespace.json"), NamespaceJson);
+                File.WriteAllText(Path.Combine(cliDir, "cli-namespace.json"), JsonSerializer.Serialize(new
+                {
+                    results = NamespaceNames.Select(name => new { name }).ToArray(),
+                }));
                 return ValueTask.FromResult(Success(spec));
             }
 

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/BootstrapStepTests.cs
@@ -53,18 +53,18 @@ public class BootstrapStepTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_NamespaceDriftDetected_FailsWithHumanActionMessage()
+    public async Task ExecuteAsync_NamespaceDriftDetected_SucceedsWithWarning()
     {
         using var harness = CreateHarness(
             brandMappingJson: """[{"mcpServerName":"foundry","brandName":"Azure AI Foundry","shortName":"Foundry","fileName":"azure-ai-foundry"}]""");
 
         var result = await harness.Step.ExecuteAsync(harness.Context, CancellationToken.None);
 
-        Assert.False(result.Success);
+        Assert.True(result.Success, "Namespace drift should be a warning, not a fatal error");
         Assert.Contains(
             result.Warnings,
             warning => warning.Contains(
-                "Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI output. Check config/namespace-mapping.json and merge-namespaces.sh for planned namespace changes. HUMAN action required.",
+                "Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI output",
                 StringComparison.Ordinal));
     }
 

--- a/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner.Tests/Unit/NamespaceStepTests.cs
@@ -571,6 +571,105 @@ public class NamespaceStepTests
     }
 
     [Fact]
+    public async Task Step5_SkillsRelevance_UsesSanitizedNamespaceForOutputLookup()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new SkillsRelevanceOutputRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["extension azqr list"]);
+            context.Items["Namespace"] = "extension_azqr";
+
+            var step = new SkillsRelevanceStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Warnings));
+            Assert.Empty(result.ArtifactFailures);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step5_SkillsRelevance_ZeroSkillsWithoutOutput_SucceedsWithWarning()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            var runner = new SkillsRelevanceZeroSkillsRunner();
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: ["compute list"]);
+            context.Items["Namespace"] = "compute";
+
+            var step = new SkillsRelevanceStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Empty(result.ArtifactFailures);
+            Assert.Contains(result.Warnings, warning => warning.Contains("zero relevant skills", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Step2_ExamplePrompts_RetryFeedbackFileIncludesActionableRepairGuidance()
+    {
+        var testRoot = CreateTestRoot();
+        try
+        {
+            const string command = "compute list";
+            var runner = new ExamplePromptRetryRunner(command, validationFailuresBeforeSuccess: 1);
+            var context = CreateContext(testRoot, runner, skipValidation: false, toolCommands: [command]);
+            context.Items["Namespace"] = command;
+
+            var artifacts = await GetExamplePromptArtifactsAsync(context.OutputPath, command);
+            SeedFile(
+                artifacts.ExamplePromptPath,
+                """
+                - "List all compute resources."
+                - "Show me the current compute resources."
+                - "Display the compute inventory."
+                """);
+            SeedFile(artifacts.InputPromptPath, "initial input prompt");
+            SeedFile(artifacts.RawOutputPath, "initial raw output");
+            await SeedParameterManifestAsync(
+                context.OutputPath,
+                command,
+                """
+                [
+                  {
+                    "name": "--subscription",
+                    "displayName": "Subscription name",
+                    "required": true,
+                    "requiredText": "Required",
+                    "description": "Subscription name."
+                  }
+                ]
+                """);
+
+            var step = new ExamplePromptsStep();
+            var result = await step.ExecuteAsync(context, CancellationToken.None);
+            var feedbackPath = GetArgumentValue(runner.Invocations[2].Arguments, "--validation-feedback-file");
+
+            Assert.True(result.Success);
+            Assert.NotNull(feedbackPath);
+            var feedback = await File.ReadAllTextAsync(feedbackPath!);
+            Assert.Contains("Missing required parameters by name", feedback, StringComparison.Ordinal);
+            Assert.Contains("Subscription name", feedback, StringComparison.Ordinal);
+            Assert.Contains("Prompt #1", feedback, StringComparison.Ordinal);
+            Assert.Contains("Rewrite example", feedback, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteTestRoot(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task Step6_HorizontalArticles_UsesReducerOverride_AndWritesOutput()
     {
         var testRoot = CreateTestRoot();
@@ -716,6 +815,16 @@ public class NamespaceStepTests
             SeedFile(artifacts.RawOutputPath);
             SeedFile(artifacts.ValidationPath);
         }
+    }
+
+    private static async Task SeedParameterManifestAsync(string outputPath, string command, string content)
+    {
+        var nameContext = await FileNameContext.CreateAsync();
+        var manifestPath = Path.Combine(
+            outputPath,
+            "parameters",
+            ToolFileNameBuilder.BuildParameterManifestFileName(command, nameContext));
+        SeedFile(manifestPath, content);
     }
 
     private static async Task SeedToolGenerationFilesAsync(string outputPath, IReadOnlyList<string> commands, bool includeComposed, bool includeImproved)
@@ -914,6 +1023,89 @@ public class NamespaceStepTests
         }
     }
 
+    private sealed class SkillsRelevanceOutputRunner : IProcessRunner
+    {
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
+        {
+            Invocations.Add(spec);
+            var outputPath = GetFlagValue(spec.Arguments, "--output-path");
+            if (!string.IsNullOrWhiteSpace(outputPath))
+            {
+                SeedFile(Path.Combine(outputPath, "extension-azqr-skills-relevance.md"), "skills report");
+            }
+
+            return ValueTask.FromResult(new ProcessExecutionResult(spec.FileName, spec.Arguments, spec.WorkingDirectory, 0, string.Empty, string.Empty, TimeSpan.Zero));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken cancellationToken)
+            => RunAsync(
+                new ProcessSpec(
+                    "dotnet",
+                    ["build", solutionPath, "--configuration", "Release", "--verbosity", "quiet"],
+                    Path.GetDirectoryName(solutionPath) ?? Environment.CurrentDirectory),
+                cancellationToken);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken cancellationToken)
+        {
+            var invocation = new List<string> { "run", "--project", projectPath, "--configuration", "Release" };
+            if (noBuild)
+            {
+                invocation.Add("--no-build");
+            }
+
+            invocation.Add("--");
+            invocation.AddRange(arguments);
+            return RunAsync(new ProcessSpec("dotnet", invocation, workingDirectory), cancellationToken);
+        }
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);
+    }
+
+    private sealed class SkillsRelevanceZeroSkillsRunner : IProcessRunner
+    {
+        public List<ProcessSpec> Invocations { get; } = new();
+
+        public ValueTask<ProcessExecutionResult> RunAsync(ProcessSpec spec, CancellationToken cancellationToken)
+        {
+            Invocations.Add(spec);
+            return ValueTask.FromResult(new ProcessExecutionResult(
+                spec.FileName,
+                spec.Arguments,
+                spec.WorkingDirectory,
+                0,
+                "Relevant skills:      0 (min score: 0.10)",
+                string.Empty,
+                TimeSpan.Zero));
+        }
+
+        public ValueTask<ProcessExecutionResult> RunDotNetBuildAsync(string solutionPath, CancellationToken cancellationToken)
+            => RunAsync(
+                new ProcessSpec(
+                    "dotnet",
+                    ["build", solutionPath, "--configuration", "Release", "--verbosity", "quiet"],
+                    Path.GetDirectoryName(solutionPath) ?? Environment.CurrentDirectory),
+                cancellationToken);
+
+        public ValueTask<ProcessExecutionResult> RunDotNetProjectAsync(string projectPath, IEnumerable<string> arguments, bool noBuild, string workingDirectory, CancellationToken cancellationToken)
+        {
+            var invocation = new List<string> { "run", "--project", projectPath, "--configuration", "Release" };
+            if (noBuild)
+            {
+                invocation.Add("--no-build");
+            }
+
+            invocation.Add("--");
+            invocation.AddRange(arguments);
+            return RunAsync(new ProcessSpec("dotnet", invocation, workingDirectory), cancellationToken);
+        }
+
+        public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
+            => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);
+    }
+
     private sealed class FailingProcessRunner : IProcessRunner
     {
         private readonly int _exitCode;
@@ -967,4 +1159,7 @@ public class NamespaceStepTests
         public ValueTask<ProcessExecutionResult> RunPowerShellScriptAsync(string scriptPath, IEnumerable<string> arguments, string workingDirectory, CancellationToken cancellationToken)
             => RunAsync(new ProcessSpec("pwsh", ["-File", scriptPath, .. arguments], workingDirectory), cancellationToken);
     }
+
+    private static string? GetFlagValue(IReadOnlyList<string> arguments, string flag)
+        => GetArgumentValue(arguments, flag);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
+++ b/mcp-tools/DocGeneration.PipelineRunner/DocGeneration.PipelineRunner.csproj
@@ -11,6 +11,7 @@
     <InternalsVisibleTo Include="DocGeneration.PipelineRunner.Tests" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DocGeneration.Steps.ExamplePrompts.Generation\DocGeneration.Steps.ExamplePrompts.Generation.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Shared\DocGeneration.Core.Shared.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.GenerativeAI\DocGeneration.Core.GenerativeAI.csproj" />
     <ProjectReference Include="..\..\shared\DocGeneration.Core.Tracing\DocGeneration.Core.Tracing.csproj" />

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -10,6 +10,13 @@ namespace PipelineRunner.Steps;
 
 public sealed class BootstrapStep : StepDefinition
 {
+    private static readonly TimeSpan[] CliMetadataRetryDelays =
+    [
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(4),
+        TimeSpan.FromSeconds(8),
+    ];
+
     /// <summary>
     /// Base path within the microsoft/mcp repo where upstream doc files live.
     /// </summary>
@@ -42,8 +49,11 @@ public sealed class BootstrapStep : StepDefinition
     ];
 
     private readonly INamespaceMappingEmitter _namespaceMappingEmitter;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
 
-    public BootstrapStep(INamespaceMappingEmitter? namespaceMappingEmitter = null)
+    public BootstrapStep(
+        INamespaceMappingEmitter? namespaceMappingEmitter = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
         : base(
             0,
             "Bootstrap pipeline",
@@ -65,6 +75,7 @@ public sealed class BootstrapStep : StepDefinition
             ])
     {
         _namespaceMappingEmitter = namespaceMappingEmitter ?? new NamespaceMappingEmitter();
+        _delayAsync = delayAsync ?? Task.Delay;
     }
 
     public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
@@ -97,11 +108,12 @@ public sealed class BootstrapStep : StepDefinition
 
             if (IsFullPipelineRun(context))
             {
+                context.Reports.Info("Clean run: moving previous output to generated-old/");
                 ResetOutputDirectory(context.OutputPath);
             }
             else
             {
-                // Incremental run — preserve existing output, just ensure directories exist
+                context.Reports.Info("Incremental run: preserving existing output");
                 Directory.CreateDirectory(context.OutputPath);
             }
             CreateDirectories(context.OutputPath, ["cli"]);
@@ -165,16 +177,18 @@ public sealed class BootstrapStep : StepDefinition
                 context.Reports.Info("Skipping azure.mcp dotnet tool update (--skip-npm-update).");
             }
 
-            var metadataGenerationResult = await context.ProcessRunner.RunDotNetProjectAsync(
+            var metadataGenerationAttempts = await RunCliMetadataExtractionWithRetryAsync(
+                context,
                 mcpCliMetadataProject,
-                [context.OutputPath],
-                noBuild: true,
-                context.RepoRoot,
                 cancellationToken);
-            processResults.Add(metadataGenerationResult);
+            processResults.AddRange(metadataGenerationAttempts);
+            var metadataGenerationResult = metadataGenerationAttempts[^1];
             if (!metadataGenerationResult.Succeeded)
             {
-                AddProcessIssue(metadataGenerationResult, warnings, "CLI metadata extraction failed");
+                AddProcessIssue(
+                    metadataGenerationResult,
+                    warnings,
+                    $"CLI metadata extraction failed after {metadataGenerationAttempts.Count} attempts (3 retries). This usually means the azure.mcp CLI cold-start timed out or the CLI remained unavailable.");
                 return BuildResult(context, processResults, success: false, warnings);
             }
 
@@ -198,7 +212,7 @@ public sealed class BootstrapStep : StepDefinition
 
             context.CliOutput = await context.CliMetadataLoader.LoadCliOutputAsync(context.OutputPath, cancellationToken);
             context.CliVersion = await context.CliMetadataLoader.LoadCliVersionAsync(context.OutputPath, cancellationToken);
-            await context.CliMetadataLoader.LoadNamespacesAsync(context.OutputPath, cancellationToken);
+            var availableNamespaces = await context.CliMetadataLoader.LoadNamespacesAsync(context.OutputPath, cancellationToken);
 
             // Generate deterministic H2 headings from CLI metadata (once, for all namespaces)
             await GenerateH2HeadingsAsync(context);
@@ -336,6 +350,13 @@ public sealed class BootstrapStep : StepDefinition
                 context.Reports.Warning("brand-to-server-mapping.json is empty or missing — namespace-mapping.json will contain no namespaces.");
             }
 
+            var namespaceDriftWarnings = ValidateNamespaceDrift(brandEntries, availableNamespaces);
+            if (namespaceDriftWarnings.Count > 0)
+            {
+                warnings.AddRange(namespaceDriftWarnings);
+                return BuildResult(context, processResults, success: false, warnings);
+            }
+
             var namespacesForConfig = await ResolveCliTabNamespacesAsync(brandMappingPath, context.SelectedNamespaces, cancellationToken);
             var cliTabConfig = CliTabConfig.ForNamespaces([.. namespacesForConfig]);
             var cliTabConfigPath = Path.Combine(context.OutputPath, "cli-tab-config.json");
@@ -406,10 +427,28 @@ public sealed class BootstrapStep : StepDefinition
     {
         if (Directory.Exists(outputPath))
         {
-            Directory.Delete(outputPath, recursive: true);
+            var archiveRoot = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? outputPath, "generated-old");
+            Directory.CreateDirectory(archiveRoot);
+            var archivePath = GetArchivePath(outputPath, archiveRoot);
+            Directory.Move(outputPath, archivePath);
         }
 
         Directory.CreateDirectory(outputPath);
+    }
+
+    private static string GetArchivePath(string outputPath, string archiveRoot)
+    {
+        var directoryName = Path.GetFileName(Path.GetFullPath(outputPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmssfff");
+        var candidate = Path.Combine(archiveRoot, $"{directoryName}-{timestamp}");
+        var suffix = 1;
+
+        while (Directory.Exists(candidate) || File.Exists(candidate))
+        {
+            candidate = Path.Combine(archiveRoot, $"{directoryName}-{timestamp}-{suffix++}");
+        }
+
+        return candidate;
     }
 
     private static void CreateDirectories(string outputPath, IEnumerable<string> directories)
@@ -418,6 +457,66 @@ public sealed class BootstrapStep : StepDefinition
         {
             Directory.CreateDirectory(Path.Combine(outputPath, directory));
         }
+    }
+
+    private static IReadOnlyList<string> ValidateNamespaceDrift(
+        IReadOnlyList<BrandMappingEntry> brandEntries,
+        IReadOnlyList<string> availableNamespaces)
+    {
+        var availableNamespaceSet = new HashSet<string>(
+            availableNamespaces.Where(static ns => !string.IsNullOrWhiteSpace(ns)),
+            StringComparer.OrdinalIgnoreCase);
+
+        return brandEntries
+            .Select(entry => entry.McpServerName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(name => !availableNamespaceSet.Contains(name))
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(name => $"Namespace '{name}' exists in brand-to-server-mapping.json but was not found in CLI output. Check config/namespace-mapping.json and merge-namespaces.sh for planned namespace changes. HUMAN action required.")
+            .ToArray();
+    }
+
+    private async Task<IReadOnlyList<ProcessExecutionResult>> RunCliMetadataExtractionWithRetryAsync(
+        PipelineContext context,
+        string mcpCliMetadataProject,
+        CancellationToken cancellationToken)
+    {
+        var attempts = new List<ProcessExecutionResult>();
+        var totalAttempts = CliMetadataRetryDelays.Length + 1;
+
+        for (var attempt = 1; attempt <= totalAttempts; attempt++)
+        {
+            var result = await context.ProcessRunner.RunDotNetProjectAsync(
+                mcpCliMetadataProject,
+                [context.OutputPath],
+                noBuild: true,
+                context.RepoRoot,
+                cancellationToken);
+            attempts.Add(result);
+
+            if (result.Succeeded)
+            {
+                if (attempt > 1)
+                {
+                    context.Reports.Info($"CLI metadata extraction succeeded on attempt {attempt} of {totalAttempts}.");
+                }
+
+                return attempts;
+            }
+
+            if (attempt == totalAttempts)
+            {
+                break;
+            }
+
+            var delay = CliMetadataRetryDelays[attempt - 1];
+            context.Reports.Warning(
+                $"CLI metadata extraction attempt {attempt} of {totalAttempts} failed with exit code {result.ExitCode}. Retrying CLI metadata extraction (attempt {attempt + 1} of {totalAttempts}) after {delay.TotalSeconds:0}s.");
+            await _delayAsync(delay, cancellationToken);
+        }
+
+        return attempts;
     }
 
     /// <summary>

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs
@@ -353,8 +353,10 @@ public sealed class BootstrapStep : StepDefinition
             var namespaceDriftWarnings = ValidateNamespaceDrift(brandEntries, availableNamespaces);
             if (namespaceDriftWarnings.Count > 0)
             {
+                // Brand-mapping drift is non-fatal — the mapping is only consumed at Step 4/5
+                // for tool-family assembly. Namespaces missing from the CLI can still be skipped
+                // gracefully at that stage. Log warnings but allow the pipeline to continue.
                 warnings.AddRange(namespaceDriftWarnings);
-                return BuildResult(context, processResults, success: false, warnings);
             }
 
             var namespacesForConfig = await ResolveCliTabNamespacesAsync(brandMappingPath, context.SelectedNamespaces, cancellationToken);

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
@@ -13,6 +13,11 @@ public sealed class ExamplePromptsStep : NamespaceStepBase
 {
     private const int MaxValidationRetries = 2;
 
+    private static readonly JsonSerializerOptions CaseInsensitiveJson = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private static readonly Regex FailedToolRegex = new(
         @"^\s*❌\s+(?<command>.+?)(?:\s+\(.*\))?$",
         RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -495,7 +500,7 @@ public sealed class ExamplePromptsStep : NamespaceStepBase
         {
             var manifest = JsonSerializer.Deserialize<List<ParameterManifestOption>>(
                 await File.ReadAllTextAsync(manifestPath, cancellationToken),
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+                CaseInsensitiveJson) ?? [];
 
             return manifest
                 .Where(static param => param.Required || (param.RequiredText?.StartsWith("Required", StringComparison.OrdinalIgnoreCase) ?? false))

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs
@@ -1,4 +1,7 @@
 using System.Text.RegularExpressions;
+using System.Text.Json;
+using ExamplePromptGeneratorStandalone.Generators;
+using ExamplePromptGeneratorStandalone.Models;
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
@@ -204,6 +207,12 @@ public sealed class ExamplePromptsStep : NamespaceStepBase
             {
                 var preservedArtifacts = PreserveAttemptArtifacts(artifact, attempt);
                 var reason = SummarizeValidationReport(preservedArtifacts.ValidationPath);
+                await EnrichValidationFeedbackAsync(
+                    preservedArtifacts.ValidationPath,
+                    artifact.ExamplePromptPath,
+                    Path.Combine(context.OutputPath, "parameters"),
+                    command,
+                    cancellationToken);
                 var retryMessage = $"Retrying example prompts for '{command}' (attempt {attempt}/{MaxValidationRetries}) because {reason}";
                 context.Reports.Warning($"    {retryMessage}");
                 retryWarnings.Add(retryMessage);
@@ -417,6 +426,95 @@ public sealed class ExamplePromptsStep : NamespaceStepBase
             .ToList();
     }
 
+    private static async Task EnrichValidationFeedbackAsync(
+        string validationPath,
+        string examplePromptPath,
+        string parameterManifestDirectory,
+        string command,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(validationPath) || !File.Exists(examplePromptPath))
+        {
+            return;
+        }
+
+        var prompts = File.ReadLines(examplePromptPath)
+            .Select(static line => line.Trim())
+            .Where(static line => line.StartsWith("- ", StringComparison.Ordinal))
+            .Select(static line => line[2..].Trim().Trim('"'))
+            .Where(static prompt => !string.IsNullOrWhiteSpace(prompt))
+            .ToArray();
+
+        if (prompts.Length == 0)
+        {
+            return;
+        }
+
+        var requiredOptions = await LoadRequiredOptionsAsync(parameterManifestDirectory, command, cancellationToken);
+        if (requiredOptions.Count == 0)
+        {
+            return;
+        }
+
+        var guidance = DeterministicPromptRepairer.BuildRetryFeedback(prompts, requiredOptions);
+        if (string.IsNullOrWhiteSpace(guidance))
+        {
+            return;
+        }
+
+        var currentContent = await File.ReadAllTextAsync(validationPath, cancellationToken);
+        if (currentContent.Contains(guidance, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var augmentedContent = $"{currentContent.TrimEnd()}{Environment.NewLine}{Environment.NewLine}{guidance}{Environment.NewLine}";
+        await File.WriteAllTextAsync(validationPath, augmentedContent, cancellationToken);
+    }
+
+    private static async Task<IReadOnlyList<Option>> LoadRequiredOptionsAsync(
+        string parameterManifestDirectory,
+        string command,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(parameterManifestDirectory))
+        {
+            return Array.Empty<Option>();
+        }
+
+        var nameContext = await FileNameContext.CreateAsync();
+        var manifestPath = Path.Combine(
+            parameterManifestDirectory,
+            ToolFileNameBuilder.BuildParameterManifestFileName(command, nameContext));
+        if (!File.Exists(manifestPath))
+        {
+            return Array.Empty<Option>();
+        }
+
+        try
+        {
+            var manifest = JsonSerializer.Deserialize<List<ParameterManifestOption>>(
+                await File.ReadAllTextAsync(manifestPath, cancellationToken),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+            return manifest
+                .Where(static param => param.Required || (param.RequiredText?.StartsWith("Required", StringComparison.OrdinalIgnoreCase) ?? false))
+                .Where(static param => !string.IsNullOrWhiteSpace(param.Name))
+                .Select(param => new Option
+                {
+                    Name = param.Name,
+                    DisplayName = param.DisplayName,
+                    Required = param.Required,
+                    Description = param.Description
+                })
+                .ToArray();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<Option>();
+        }
+    }
+
     private static Dictionary<string, List<string>> GetPerToolOutputIssues(IEnumerable<ToolArtifacts> toolArtifacts)
     {
         var issues = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
@@ -573,4 +671,11 @@ public sealed class ExamplePromptsStep : NamespaceStepBase
         ValidatorResult ValidatorResult,
         IReadOnlyList<string> Warnings,
         IReadOnlyList<ArtifactFailure> ArtifactFailures);
+
+    private sealed record ParameterManifestOption(
+        string? Name,
+        string? DisplayName,
+        bool Required,
+        string? RequiredText,
+        string? Description);
 }

--- a/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/SkillsRelevanceStep.cs
+++ b/mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/SkillsRelevanceStep.cs
@@ -1,6 +1,7 @@
 using PipelineRunner.Context;
 using PipelineRunner.Contracts;
 using PipelineRunner.Services;
+using System.Text.RegularExpressions;
 
 namespace PipelineRunner.Steps;
 
@@ -21,7 +22,7 @@ public sealed class SkillsRelevanceStep : NamespaceStepBase
     public override async ValueTask<StepResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken)
     {
         var currentNamespace = GetCurrentNamespace(context);
-        var namespaceRoot = currentNamespace.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0].ToLowerInvariant();
+        var reportStem = SanitizeSkillsReportName(currentNamespace);
         var processResults = new List<ProcessExecutionResult>();
         var warnings = new List<string>();
         var artifactFailures = new List<ArtifactFailure>();
@@ -49,20 +50,26 @@ public sealed class SkillsRelevanceStep : NamespaceStepBase
             AddProcessIssue(processResult, warnings, "Skills relevance generation failed");
             artifactFailures.Add(CreateArtifactFailure(
                 "azure skill",
-                $"{namespaceRoot}-skills-relevance.md",
+                $"{reportStem}-skills-relevance.md",
                 "Azure skill relevance generation failed for this namespace.",
                 warnings,
-                [Path.Combine(skillsOutputDirectory, $"{namespaceRoot}-skills-relevance.md")]));
+                [Path.Combine(skillsOutputDirectory, $"{reportStem}-skills-relevance.md")]));
             return BuildResult(context, processResults, false, warnings, artifactFailures: artifactFailures);
         }
 
-        var reportPath = Path.Combine(skillsOutputDirectory, $"{namespaceRoot}-skills-relevance.md");
+        var reportPath = Path.Combine(skillsOutputDirectory, $"{reportStem}-skills-relevance.md");
         if (!File.Exists(reportPath))
         {
+            if (HasZeroRelevantSkills(processResult.StandardOutput))
+            {
+                warnings.Add($"Skills relevance produced zero relevant skills for '{currentNamespace}'.");
+                return BuildResult(context, processResults, true, warnings, artifactFailures: artifactFailures);
+            }
+
             warnings.Add($"Expected skills relevance output at '{reportPath}'.");
             artifactFailures.Add(CreateArtifactFailure(
                 "azure skill",
-                $"{namespaceRoot}-skills-relevance.md",
+                $"{reportStem}-skills-relevance.md",
                 "Azure skill relevance output is missing for this namespace.",
                 warnings,
                 [reportPath]));
@@ -71,4 +78,10 @@ public sealed class SkillsRelevanceStep : NamespaceStepBase
 
         return BuildResult(context, processResults, true, warnings, artifactFailures: artifactFailures);
     }
+
+    private static string SanitizeSkillsReportName(string value)
+        => Regex.Replace(value.ToLowerInvariant().Replace(' ', '-'), @"[^a-z0-9\-]", string.Empty);
+
+    private static bool HasZeroRelevantSkills(string output)
+        => Regex.IsMatch(output ?? string.Empty, @"(?mi)^\s*Relevant skills:\s*0\b");
 }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterFilterHelperTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ParameterFilterHelperTests.cs
@@ -26,7 +26,7 @@ public class ParameterFilterHelperTests
     {
         var common = MakeCommonSet("--resource-group", "--subscription", "--tenant");
         var opt = MakeOption("--resource-group", required: false);
-        Assert.False(ParameterFilterHelper.ShouldInclude(opt, common));
+        Assert.True(ParameterFilterHelper.ShouldInclude(opt, common));
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class ParameterFilterHelperTests
     {
         var common = MakeCommonSet("--resource-group", "--subscription", "--tenant");
         var opt = MakeOption("--subscription", required: false);
-        Assert.False(ParameterFilterHelper.ShouldInclude(opt, common));
+        Assert.True(ParameterFilterHelper.ShouldInclude(opt, common));
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class ParameterFilterHelperTests
     {
         var common = MakeCommonSet("--tenant", "--auth-method", "--retry-delay");
         var opt = MakeOption("--tenant", required: false);
-        Assert.False(ParameterFilterHelper.ShouldInclude(opt, common));
+        Assert.True(ParameterFilterHelper.ShouldInclude(opt, common));
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class ParameterFilterHelperTests
     {
         var common = MakeCommonSet("--tenant", "--auth-method", "--retry-delay");
         var opt = MakeOption("--retry-delay", required: false);
-        Assert.False(ParameterFilterHelper.ShouldInclude(opt, common));
+        Assert.True(ParameterFilterHelper.ShouldInclude(opt, common));
     }
 
     [Fact]

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ScopingParamRequiredTests.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations.Tests/ScopingParamRequiredTests.cs
@@ -9,9 +9,7 @@ namespace CSharpGenerator.Tests;
 
 /// <summary>
 /// Tests that PageGenerator.FilterToolOptions and DocumentationGenerator.CountNonCommonParameters
-/// correctly include required common/scoping parameters in output.
-/// Bug: Both methods unconditionally excluded ALL common parameters, even when
-/// required for a specific tool (e.g., --resource-group on sql database list).
+/// now include all named parameters in output and summary counts.
 /// </summary>
 public class ScopingParamRequiredTests
 {
@@ -30,7 +28,7 @@ public class ScopingParamRequiredTests
 
         Assert.Contains(filtered, o => o.Name == "--resource-group");
         Assert.Contains(filtered, o => o.Name == "--server-name");
-        Assert.DoesNotContain(filtered, o => o.Name == "--tenant");
+        Assert.Contains(filtered, o => o.Name == "--tenant");
     }
 
     [Fact]
@@ -45,7 +43,7 @@ public class ScopingParamRequiredTests
 
         var filtered = PageGenerator.FilterToolOptions(options, common);
 
-        Assert.DoesNotContain(filtered, o => o.Name == "--resource-group");
+        Assert.Contains(filtered, o => o.Name == "--resource-group");
         Assert.Contains(filtered, o => o.Name == "--server-name");
     }
 
@@ -80,14 +78,16 @@ public class ScopingParamRequiredTests
 
         var filtered = PageGenerator.FilterToolOptions(options, common);
 
-        Assert.Equal(3, filtered.Count);
+        Assert.Equal(5, filtered.Count);
         Assert.Contains(filtered, o => o.Name == "--resource-group");
         Assert.Contains(filtered, o => o.Name == "--subscription");
         Assert.Contains(filtered, o => o.Name == "--server-name");
+        Assert.Contains(filtered, o => o.Name == "--tenant");
+        Assert.Contains(filtered, o => o.Name == "--retry-delay");
     }
 
     [Fact]
-    public void CountNonCommonParameters_RequiredScopingParams_AreCounted()
+    public void CountNonCommonParameters_ReturnsTotalNamedParameters()
     {
         var common = MakeCommonSet("--resource-group", "--subscription", "--tenant");
         var tool = new Tool
@@ -104,11 +104,11 @@ public class ScopingParamRequiredTests
 
         var count = DocumentationGenerator.CountNonCommonParameters(tool, common);
 
-        Assert.Equal(3, count);
+        Assert.Equal(4, count);
     }
 
     [Fact]
-    public void CountNonCommonParameters_AllOptionalCommon_ReturnsZero()
+    public void CountNonCommonParameters_AllOptionalCommon_ReturnsTotalCount()
     {
         var common = MakeCommonSet("--tenant", "--auth-method", "--retry-delay");
         var tool = new Tool
@@ -124,7 +124,7 @@ public class ScopingParamRequiredTests
 
         var count = DocumentationGenerator.CountNonCommonParameters(tool, common);
 
-        Assert.Equal(0, count);
+        Assert.Equal(3, count);
     }
 
     [Fact]

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/DocumentationGenerator.cs
@@ -203,12 +203,6 @@ public static class DocumentationGenerator
         Console.WriteLine($"    Tools requiring secrets: {secretsCount}");
         Console.WriteLine($"    Tools requiring local consent: {consentCount}");
         
-        // Get common parameter names for filtering
-        var commonParameters = transformedData.SourceDiscoveredCommonParams.Any() 
-            ? transformedData.SourceDiscoveredCommonParams 
-            : ExtractCommonParameters(transformedData.Tools);
-        var commonParameterNames = new HashSet<string>(commonParameters.Select(p => p.Name ?? ""), StringComparer.OrdinalIgnoreCase);
-        
         // Log detailed area breakdown to file
         foreach (var area in transformedData.Areas.OrderBy(a => a.Key))
         {
@@ -223,6 +217,7 @@ public static class DocumentationGenerator
         LogFileHelper.WriteDebug("");
         LogFileHelper.WriteDebug("Legend: [A] = Annotation file, [P] = Parameter file, [E] = Example prompts file");
         LogFileHelper.WriteDebug("");
+        var ignoredCommonParameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         
         foreach (var area in transformedData.Areas.OrderBy(a => a.Key))
         {
@@ -232,8 +227,7 @@ public static class DocumentationGenerator
             
             foreach (var tool in area.Value.Tools.OrderBy(t => t.Command))
             {
-                // Calculate non-common parameter count (matches what's shown in parameter tables)
-                var nonCommonParamCount = CountNonCommonParameters(tool, commonParameterNames);
+                var parameterCount = CountNonCommonParameters(tool, ignoredCommonParameterNames);
                 
                 // Build indicators for generated files
                 var indicators = new List<string>();
@@ -242,7 +236,7 @@ public static class DocumentationGenerator
                 if (tool.HasExamplePrompts) indicators.Add("E");
                 var indicatorStr = indicators.Count > 0 ? $" [{string.Join(",", indicators)}]" : "";
                 
-                LogFileHelper.WriteDebug($"  • {tool.Command,-50} - {tool.Name,-20} [{nonCommonParamCount,2} params]{indicatorStr}");
+                LogFileHelper.WriteDebug($"  • {tool.Command,-50} - {tool.Name,-20} [{parameterCount,2} params]{indicatorStr}");
             }
         }
 
@@ -529,8 +523,8 @@ public static class DocumentationGenerator
     }
 
     /// <summary>
-    /// Counts non-common parameters for a tool, excluding common parameters that are optional.
-    /// Required common parameters are counted because they appear in parameter tables.
+    /// Counts named parameters for a tool. Common parameters are no longer filtered
+    /// from generated tables or summary counts.
     /// </summary>
     internal static int CountNonCommonParameters(Tool tool, HashSet<string> commonParameterNames)
     {

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/PageGenerator.cs
@@ -42,12 +42,6 @@ public class PageGenerator
             var fileName = $"{areaNameForFile}.md";
             var outputFile = Path.Combine(outputDir, fileName);
 
-            // Get common parameter names to filter them out
-            var commonParameters = data.SourceDiscoveredCommonParams.Any() 
-                ? data.SourceDiscoveredCommonParams 
-                : _extractCommonParameters(data.Tools);
-            var commonParameterNames = new HashSet<string>(commonParameters.Select(p => p.Name ?? ""), StringComparer.OrdinalIgnoreCase);
-
             // Annotations directory path (at parent level)
             var parentDirCandidate = Path.GetDirectoryName(outputDir);
             var parentDir = string.IsNullOrWhiteSpace(parentDirCandidate) ? outputDir : parentDirCandidate;
@@ -55,6 +49,7 @@ public class PageGenerator
             
             // Load shared data files for filename generation
             var nameContext = await FileNameContext.CreateAsync();
+            var ignoredCommonParameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Filter out common parameters from tools for area pages and add annotation content
             var toolsWithFilteredParamsTasks = areaData.Tools.Select(async tool => 
@@ -100,7 +95,7 @@ public class PageGenerator
                         StringComparer.OrdinalIgnoreCase);
 
                     var filteredOptions = tool.Option
-                        .Where(opt => ParameterFilterHelper.ShouldInclude(opt, commonParameterNames));
+                        .Where(opt => ParameterFilterHelper.ShouldInclude(opt, ignoredCommonParameterNames));
 
                     filteredTool.Option = filteredOptions
                         .Select(opt => new Option
@@ -121,13 +116,13 @@ public class PageGenerator
                 return filteredTool;
             });
 
-            var toolsWithFilteredParams = (await Task.WhenAll(toolsWithFilteredParamsTasks)).ToList();
+            var toolsWithIncludedParams = (await Task.WhenAll(toolsWithFilteredParamsTasks)).ToList();
 
             var areaPageData = new Dictionary<string, object>
             {
                 ["areaName"] = areaName,
                 ["areaData"] = areaData,
-                ["tools"] = toolsWithFilteredParams,
+                ["tools"] = toolsWithIncludedParams,
                 ["version"] = data.Version,
                 ["generatedAt"] = data.GeneratedAt,
                 ["generateAreaPage"] = true
@@ -236,8 +231,7 @@ public class PageGenerator
     }
 
     /// <summary>
-    /// Filters a tool's options to exclude common parameters that are optional.
-    /// Required common parameters are kept so they appear in the parameter table.
+    /// Filters a tool's options down to named parameters only.
     /// </summary>
     internal static List<Option> FilterToolOptions(
         IEnumerable<Option> options, HashSet<string> commonParameterNames)

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterFilterHelper.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterFilterHelper.cs
@@ -6,21 +6,18 @@ using CSharpGenerator.Models;
 namespace CSharpGenerator.Generators;
 
 /// <summary>
-/// Shared predicate for filtering common parameters from tool-specific output.
-/// Common (infrastructure) parameters are excluded unless they are required for
-/// a specific tool — in that case they must appear in the parameter table.
+/// Shared predicate for including parameters in tool-specific output.
+/// Common parameters are no longer filtered; every named parameter appears in
+/// the generated tables and counts.
 /// </summary>
 public static class ParameterFilterHelper
 {
     /// <summary>
     /// Determines whether a parameter should be included in tool-specific output.
-    /// A parameter is included when:
-    ///   1. It has a non-empty name, AND
-    ///   2. It is NOT a common parameter, OR it IS required for this tool.
+    /// A parameter is included when it has a non-empty name.
     /// </summary>
     public static bool ShouldInclude(Option opt, HashSet<string> commonParameterNames)
     {
-        return !string.IsNullOrEmpty(opt.Name)
-            && (!commonParameterNames.Contains(opt.Name) || opt.Required);
+        return !string.IsNullOrEmpty(opt.Name);
     }
 }

--- a/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
+++ b/mcp-tools/DocGeneration.Steps.AnnotationsParametersRaw.Annotations/Generators/ParameterGenerator.cs
@@ -35,9 +35,10 @@ public class ParameterGenerator
             // Load shared data files for filename generation
             var nameContext = await FileNameContext.CreateAsync();
             
-            // Get common parameters from CLI data only
+            // Keep common parameter metadata for canonical descriptions, but include
+            // every named parameter in generated tool output.
             var commonParameters = data.SourceDiscoveredCommonParams;
-            var commonParameterNames = new HashSet<string>(commonParameters.Select(p => p.Name ?? ""), StringComparer.OrdinalIgnoreCase);
+            var ignoredCommonParameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             
             // Build canonical description lookup for consistent parameter descriptions
             // GroupBy ensures no duplicate key exceptions if source has case-variant duplicates
@@ -59,16 +60,14 @@ public class ParameterGenerator
                 var outputFile = Path.Combine(outputDir, fileName);
                 var manifestOutputFile = Path.Combine(outputDir, manifestFileName);
 
-                // Filter out common parameters unless they are required for this specific tool
                 var allOptions = tool.Option ?? new List<Option>();
                 
-                // Filter to get only tool-specific parameters (non-common) or required common parameters
                 var conditionalParameters = new HashSet<string>(
                     tool.ConditionalRequiredParameters ?? new List<string>(),
                     StringComparer.OrdinalIgnoreCase);
 
                 var filteredOptions = allOptions
-                    .Where(opt => ParameterFilterHelper.ShouldInclude(opt, commonParameterNames))
+                    .Where(opt => ParameterFilterHelper.ShouldInclude(opt, ignoredCommonParameterNames))
                     .ToList();
 
                 var parameterManifest = BuildParameterManifest(filteredOptions, conditionalParameters, canonicalDescriptions);

--- a/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/StaleNamespaceRegressionTests.cs
+++ b/mcp-tools/DocGeneration.Steps.Bootstrap.BrandMappings.Tests/StaleNamespaceRegressionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+
+namespace BrandMapperValidator.Tests;
+
+/// <summary>
+/// Regression guards: stale namespaces that were removed from beta.31 CLI output
+/// must never reappear in brand-to-server-mapping.json. If they do, the drift
+/// detection in BootstrapStep will hard-error and block ALL namespace generation.
+/// </summary>
+public class StaleNamespaceRegressionTests
+{
+    /// <summary>
+    /// Resolves the real brand-to-server-mapping.json in the source tree.
+    /// </summary>
+    private static string GetRealBrandMappingPath()
+    {
+        // Walk up from bin/Release/net10.0 to mcp-tools/data/
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "mcp-tools", "data", "brand-to-server-mapping.json");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException(
+            "Could not locate brand-to-server-mapping.json from test bin directory.");
+    }
+
+    private static HashSet<string> LoadMcpServerNames()
+    {
+        var path = GetRealBrandMappingPath();
+        var json = File.ReadAllText(path);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.EnumerateArray()
+            .Select(e => e.GetProperty("mcpServerName").GetString()!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("foundry")]
+    [InlineData("get")]
+    public void BrandMapping_DoesNotContain_StaleNamespace(string staleNamespace)
+    {
+        var serverNames = LoadMcpServerNames();
+
+        Assert.DoesNotContain(staleNamespace, serverNames);
+    }
+
+    [Fact]
+    public void BrandMapping_Contains_FoundryExtensions_Replacement()
+    {
+        var serverNames = LoadMcpServerNames();
+
+        // foundryextensions replaced foundry in beta.31
+        Assert.Contains("foundryextensions", serverNames);
+    }
+}

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicPromptRepairerTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation.Tests/DeterministicPromptRepairerTests.cs
@@ -626,4 +626,55 @@ public class DeterministicPromptRepairerTests
         var option = new Option { Name = "--resource-group", Required = true };
         Assert.Equal("resource-group", DeterministicPromptRepairer.GetCoverageName(option));
     }
+
+    [Fact]
+    public void BuildRetryFeedback_IncludesMissingParamNamesPromptIndicesAndRewriteExample()
+    {
+        var prompts = new List<string>
+        {
+            "Scale the deployment.",
+            "Increase the instance count.",
+            "",
+            "Show me the current capacity."
+        };
+        var required = new List<Option>
+        {
+            new() { Name = "--resource-group", Required = true, DisplayName = "Resource group name", Description = "Resource group name" }
+        };
+
+        var feedback = DeterministicPromptRepairer.BuildRetryFeedback(prompts, required);
+
+        Assert.Contains("Resource group name", feedback, StringComparison.Ordinal);
+        Assert.Contains("Prompt #1", feedback, StringComparison.Ordinal);
+        Assert.Contains("Prompt #2", feedback, StringComparison.Ordinal);
+        Assert.Contains("Prompt #4", feedback, StringComparison.Ordinal);
+        Assert.Contains("Rewrite example", feedback, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Repair_WhenDisplayNameCoverageStillMissing_AddsLastResortPromptUsingDisplayName()
+    {
+        var prompts = new List<string>
+        {
+            "Scale the deployment.",
+            "Increase the instance count."
+        };
+        var required = new List<Option>
+        {
+            new()
+            {
+                Name = "--vmss",
+                Required = true,
+                DisplayName = "Virtual machine scale set name",
+                Description = "Virtual machine scale set name"
+            }
+        };
+
+        var result = DeterministicPromptRepairer.Repair(prompts, required);
+
+        Assert.Empty(result.StillUncovered);
+        Assert.Contains(
+            result.RepairedPrompts,
+            prompt => prompt.Contains("Virtual machine scale set name", StringComparison.Ordinal));
+    }
 }

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicPromptRepairer.cs
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/Generators/DeterministicPromptRepairer.cs
@@ -4,6 +4,7 @@
 using ExamplePromptGeneratorStandalone.Models;
 using ExamplePromptGeneratorStandalone.Sanitizers;
 using Shared;
+using System.Text;
 
 namespace ExamplePromptGeneratorStandalone.Generators;
 
@@ -58,20 +59,51 @@ public static class DeterministicPromptRepairer
             }
         }
 
-        // Post-repair verification: run AFTER sanitization (blocking issue #2)
         var sanitizedPrompts = repairedPrompts.Select(CredentialSanitizer.Sanitize).ToList();
-        foreach (var param in requiredParameters)
+        stillUncovered.AddRange(GetStillUncovered(sanitizedPrompts, requiredParameters));
+
+        if (stillUncovered.Count > 0)
         {
-            if (string.IsNullOrWhiteSpace(param.Name)) continue;
-            var coverageName = GetCoverageName(param);
-            var postSanitizeCoverage = GetEffectiveCoverage(sanitizedPrompts, coverageName, requiredParameters.Count, param.Description);
-            if (!postSanitizeCoverage)
-            {
-                stillUncovered.Add(coverageName);
-            }
+            ApplyLastResortFallback(repairedPrompts, requiredParameters, stillUncovered);
+            sanitizedPrompts = repairedPrompts.Select(CredentialSanitizer.Sanitize).ToList();
+            stillUncovered = GetStillUncovered(sanitizedPrompts, requiredParameters).ToList();
         }
 
         return new RepairResult(repairedPrompts, actions, stillUncovered);
+    }
+
+    public static string BuildRetryFeedback(IReadOnlyList<string> prompts, IReadOnlyList<Option> requiredParameters)
+    {
+        var missing = requiredParameters
+            .Where(param => !string.IsNullOrWhiteSpace(param.Name))
+            .Where(param => !GetEffectiveCoverage(prompts, GetCoverageName(param), requiredParameters.Count, param.Description))
+            .ToList();
+
+        if (missing.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var promptIndices = prompts
+            .Select((prompt, index) => new { prompt, index })
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.prompt))
+            .Select(entry => $"Prompt #{entry.index + 1}")
+            .ToArray();
+
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("## Actionable repair guidance");
+        sb.AppendLine();
+        sb.AppendLine($"- Missing required parameters by name: {string.Join(", ", missing.Select(GetCoverageName))}");
+        sb.AppendLine($"- Prompt slots that can absorb the missing parameters: {(promptIndices.Length > 0 ? string.Join(", ", promptIndices) : "Prompt #1")}");
+
+        var rewriteExample = BuildRewriteExample(prompts, missing[0]);
+        if (!string.IsNullOrWhiteSpace(rewriteExample))
+        {
+            sb.AppendLine($"- Rewrite example: {rewriteExample}");
+        }
+
+        return sb.ToString().TrimEnd();
     }
 
     /// <summary>
@@ -178,6 +210,73 @@ public static class DeterministicPromptRepairer
 
         // No punctuation — append with period
         return trimmed + $". Specify {naturalName} '{value}'.";
+    }
+
+    private static IReadOnlyList<string> GetStillUncovered(IReadOnlyList<string> sanitizedPrompts, IReadOnlyList<Option> requiredParameters)
+        => requiredParameters
+            .Where(param => !string.IsNullOrWhiteSpace(param.Name))
+            .Select(param => new
+            {
+                CoverageName = GetCoverageName(param),
+                Covered = GetEffectiveCoverage(sanitizedPrompts, GetCoverageName(param), requiredParameters.Count, param.Description)
+            })
+            .Where(result => !result.Covered)
+            .Select(result => result.CoverageName)
+            .ToArray();
+
+    private static void ApplyLastResortFallback(List<string> prompts, IReadOnlyList<Option> requiredParameters, IReadOnlyList<string> unresolvedCoverageNames)
+    {
+        if (unresolvedCoverageNames.Count == 0)
+        {
+            return;
+        }
+
+        var targetIndices = prompts
+            .Select((prompt, index) => new { prompt, index })
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.prompt))
+            .Select(entry => entry.index)
+            .ToList();
+
+        if (targetIndices.Count == 0)
+        {
+            prompts.Add(string.Empty);
+            targetIndices.Add(prompts.Count - 1);
+        }
+
+        var writeIndex = 0;
+        foreach (var coverageName in unresolvedCoverageNames)
+        {
+            var param = requiredParameters.FirstOrDefault(option =>
+                string.Equals(GetCoverageName(option), coverageName, StringComparison.Ordinal));
+            if (param is null || string.IsNullOrWhiteSpace(param.Name))
+            {
+                continue;
+            }
+
+            var targetPromptIndex = targetIndices[writeIndex % targetIndices.Count];
+            var value = ResolveValue(CanonicalizeParamName(param.Name), param.Description);
+            prompts[targetPromptIndex] = BuildLastResortPrompt(prompts[targetPromptIndex], coverageName, value);
+            writeIndex++;
+        }
+    }
+
+    private static string BuildRewriteExample(IReadOnlyList<string> prompts, Option param)
+    {
+        var promptIndex = prompts
+            .Select((prompt, index) => new { prompt, index })
+            .FirstOrDefault(entry => !string.IsNullOrWhiteSpace(entry.prompt));
+        var original = promptIndex?.prompt?.Trim() ?? "Use the tool.";
+        var coverageName = GetCoverageName(param);
+        var value = ResolveValue(CanonicalizeParamName(param.Name!), param.Description);
+        var rewritten = BuildLastResortPrompt(original, coverageName, value);
+        var label = promptIndex is null ? "Prompt #1" : $"Prompt #{promptIndex.index + 1}";
+        return $"{label}: \"{original}\" → \"{rewritten}\"";
+    }
+
+    private static string BuildLastResortPrompt(string prompt, string coverageName, string value)
+    {
+        var trimmed = string.IsNullOrWhiteSpace(prompt) ? "Use the tool" : prompt.Trim().TrimEnd('.', '!', '?');
+        return $"{trimmed}. Specify {coverageName} '{value}'.";
     }
 }
 

--- a/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/README.md
+++ b/mcp-tools/DocGeneration.Steps.ExamplePrompts.Generation/README.md
@@ -72,6 +72,20 @@ The `CredentialSanitizer` defense-in-depth pass runs on every path before writin
 paths converge on the same final include (`example-prompts/{tool}-example-prompts.md`
 rendered via `example-prompts-template.hbs`), so Step 3 is unaffected by the routing.
 
+### Retry Repair Guidance and Last-Resort Fallback
+
+When Step 2 validation fails for missing required parameters, the retry loop now feeds the
+LLM an actionable guidance block that:
+
+- names the missing required parameters explicitly
+- suggests which prompt slots can absorb them
+- includes a concrete rewrite example
+
+After the AI response is parsed, `DeterministicPromptRepairer` still runs before
+`CredentialSanitizer`. If canonical CLI-name injection does not satisfy post-sanitization
+coverage, the repairer now injects a display-name-based last-resort fallback prompt so the
+written file still covers the required parameter set deterministically.
+
 The tool processes each tool **sequentially** (not in batch). For the AI path:
 1. Generate custom user prompt from template with tool-specific parameters
 2. Call Azure OpenAI with system + user prompts

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabConfigGenerationTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/CliTabConfigGenerationTests.cs
@@ -74,16 +74,14 @@ public class CliTabConfigGenerationTests
             ? Directory.GetDirectories(GeneratedOutputRoot, "generated-*")
             : Array.Empty<string>();
         generatedNamespaceNames = generatedNamespaceNames
-            .Select(TryExtractNamespace)
-            .Where(d => d is not null && !d.Contains("-old-") && !d.Contains("-prev"))
+            .Select(path => TryExtractMappedNamespace(path, namespaces))
+            .Where(d => d is not null)
             .Cast<string>()
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        // At minimum, azurebackup must exist (our primary test namespace)
         // In CI where no generation has run, skip gracefully
         if (generatedNamespaceNames.Length == 0) return;
-        Assert.Contains("azurebackup", generatedNamespaceNames);
 
         // Every generated directory must correspond to a known namespace
         foreach (var genNs in generatedNamespaceNames)
@@ -139,7 +137,9 @@ public class CliTabConfigGenerationTests
     private static string? TryExtractNamespace(string directoryPath)
     {
         var directoryName = Path.GetFileName(directoryPath);
-        if (string.IsNullOrWhiteSpace(directoryName) || directoryName.Equals("generated", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrWhiteSpace(directoryName)
+            || directoryName.Equals("generated", StringComparison.OrdinalIgnoreCase)
+            || directoryName.Equals("generated-old", StringComparison.OrdinalIgnoreCase))
             return null;
 
         var timestampedMatch = TimestampedNamespaceDirectoryPattern.Match(directoryName);
@@ -149,6 +149,28 @@ public class CliTabConfigGenerationTests
         return directoryName.StartsWith("generated-", StringComparison.OrdinalIgnoreCase)
             ? directoryName["generated-".Length..]
             : null;
+    }
+
+    private static string? TryExtractMappedNamespace(string directoryPath, IReadOnlyCollection<string> knownNamespaces)
+    {
+        var extracted = TryExtractNamespace(directoryPath);
+        if (!string.IsNullOrWhiteSpace(extracted) && knownNamespaces.Contains(extracted))
+        {
+            return extracted;
+        }
+
+        var directoryName = Path.GetFileName(directoryPath);
+        if (string.IsNullOrWhiteSpace(directoryName) || !directoryName.StartsWith("generated-", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var candidate = directoryName["generated-".Length..];
+        return knownNamespaces
+            .OrderByDescending(static ns => ns.Length)
+            .FirstOrDefault(ns =>
+                candidate.Equals(ns, StringComparison.OrdinalIgnoreCase)
+                || candidate.StartsWith(ns + "-", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string? FindLatestGeneratedDirectory(string namespaceName)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FamilyStructureBuilderTests.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup.Tests/FamilyStructureBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Shared;
 using ToolFamilyCleanup.Services;
 using Xunit;
 
@@ -243,6 +244,59 @@ public sealed class FamilyStructureBuilderTests : IDisposable
         Assert.Single(result.Sections);
         Assert.Equal(["monitor metrics query"], result.Sections[0].ToolNames);
         Assert.StartsWith("## ", result.Sections[0].SourceContent.ReplaceLineEndings());
+    }
+
+    [Fact]
+    public async Task BuildAsync_StripsPhantomParametersNotPresentInManifest()
+    {
+        var toolsDirectory = Path.Combine(_testRoot, "phantom-tools");
+        var parametersDirectory = Path.Combine(_testRoot, "parameters");
+        Directory.CreateDirectory(toolsDirectory);
+        Directory.CreateDirectory(parametersDirectory);
+
+        const string command = "cosmos account show";
+        await File.WriteAllTextAsync(
+            Path.Combine(toolsDirectory, "cosmos-account-show.md"),
+            """
+            ---
+            ---
+            # Show account
+
+            <!-- @mcpcli cosmos account show -->
+
+            Shows an Azure Cosmos DB account.
+
+            | Parameter | Required or optional | Description |
+            | --- | --- | --- |
+            | `account` | Required | Account name. |
+            | `authentication-method` | Optional | Authentication mode. |
+            """);
+
+        var nameContext = await FileNameContext.CreateAsync();
+        var manifestPath = Path.Combine(
+            parametersDirectory,
+            ToolFileNameBuilder.BuildParameterManifestFileName(command, nameContext));
+        await File.WriteAllTextAsync(
+            manifestPath,
+            """
+            [
+              {
+                "name": "account",
+                "displayName": "account",
+                "required": true,
+                "requiredText": "Required",
+                "description": "Account name."
+              }
+            ]
+            """);
+
+        var builder = new FamilyStructureBuilder();
+
+        var result = await builder.BuildAsync(toolsDirectory, "cosmos", h2HeadingsDirectory: null, CancellationToken.None);
+
+        var section = Assert.Single(result.Sections);
+        Assert.Contains("`account`", section.SourceContent, StringComparison.Ordinal);
+        Assert.DoesNotContain("authentication-method", section.SourceContent, StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/README.md
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/README.md
@@ -60,6 +60,9 @@ pwsh ./GenerateDocGeneration.Steps.ToolFamilyCleanup-multifile.ps1
 1. **Phase 1**: Reads individual tool files from `./generated/tools/` and groups by family
 2. **Phase 1.5**: `FamilyStructureBuilder` loads deterministic H2 headings, establishes canonical section order, and emits `FamilyStructureContext`
    - PipelineRunner tests can inject an additional `IPreAiValidator<FamilyStructureContext>` through `ToolFamilyCleanupStep.PreAiValidatorOverrideKey`; production leaves this unset.
+   - Before stitching, `ParameterCrossCheckService` compares each tool parameter table to
+     the Step 1 parameter manifest and strips hallucinated parameter rows that are not
+     present in the CLI source metadata
 3. **Phase 2**: Generates metadata (frontmatter + H1 + intro) using AI per family
 4. **Phase 3**: Generates deterministic related content per family
 5. **Phase 4**: Stitches sections together with metadata/related content (no AI)

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyStructureBuilder.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/FamilyStructureBuilder.cs
@@ -32,7 +32,7 @@ public sealed class FamilyStructureBuilder
 
         var toolReader = new ToolReader(toolsDirectory);
         var toolsByFamily = await toolReader.ReadAndGroupToolsAsync();
-        var tools = toolsByFamily
+        IReadOnlyList<ToolContent> tools = toolsByFamily
             .FirstOrDefault(kv => string.Equals(kv.Key, familyName, StringComparison.OrdinalIgnoreCase))
             .Value;
 
@@ -43,6 +43,8 @@ public sealed class FamilyStructureBuilder
 
         var headings = await LoadHeadingsAsync(h2HeadingsDirectory, familyName, ct);
         var compoundWords = await DataFileLoader.LoadCompoundWordsAsync();
+        var parameterManifestDirectory = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(toolsDirectory))!, "parameters");
+        tools = await new ParameterCrossCheckService().StripHallucinatedParametersAsync(tools, parameterManifestDirectory, ct);
         var sections = BuildSections(tools, headings, compoundWords);
         return new FamilyStructureContext(familyName, sections);
     }

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/NamespaceMerger.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/NamespaceMerger.cs
@@ -54,8 +54,22 @@ public static partial class NamespaceMerger
             var primary = members.FirstOrDefault(m =>
                 string.Equals(m.MergeRole, "primary", StringComparison.OrdinalIgnoreCase));
 
-            if (primary == null || !articles.ContainsKey(primary.McpServerName))
+            // Skip this merge group when its primary namespace has no article.
+            // This happens when the primary namespace was not generated in the
+            // current run (e.g., single-namespace mode or a generation failure).
+            // Without the primary, we have no frontmatter, H1, overview, or
+            // related-content scaffold to merge secondary tool sections into.
+            if (primary == null)
+            {
+                Console.WriteLine($"  ⏭ Skipping merge group '{groupKey}': no member has mergeRole=primary — check brand-to-server-mapping.json");
                 continue;
+            }
+
+            if (!articles.ContainsKey(primary.McpServerName))
+            {
+                Console.WriteLine($"  ⏭ Skipping merge group '{groupKey}': primary namespace '{primary.McpServerName}' has no generated article (was it included in this run?)");
+                continue;
+            }
 
             var primaryContent = articles[primary.McpServerName];
             var (header, primaryTools, relatedContent) = ParseArticle(primaryContent);
@@ -68,7 +82,10 @@ public static partial class NamespaceMerger
                     continue;
 
                 if (!articles.TryGetValue(member.McpServerName, out var secondaryContent))
+                {
+                    Console.WriteLine($"  ⚠ Merge group '{groupKey}': secondary namespace '{member.McpServerName}' has no generated article — its tools will be missing from the merged output");
                     continue;
+                }
 
                 var (_, secondaryTools, _) = ParseArticle(secondaryContent);
                 allTools.AddRange(secondaryTools);

--- a/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ParameterCrossCheckService.cs
+++ b/mcp-tools/DocGeneration.Steps.ToolFamilyCleanup/Services/ParameterCrossCheckService.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Shared;
+using ToolFamilyCleanup.Models;
+
+namespace ToolFamilyCleanup.Services;
+
+/// <summary>
+/// Removes parameter rows that were hallucinated downstream and do not exist in the
+/// Step 1 parameter manifest for the tool.
+/// </summary>
+internal sealed class ParameterCrossCheckService
+{
+    public async Task<IReadOnlyList<ToolContent>> StripHallucinatedParametersAsync(
+        IReadOnlyList<ToolContent> tools,
+        string parameterManifestDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(parameterManifestDirectory))
+        {
+            return tools;
+        }
+
+        var nameContext = await FileNameContext.CreateAsync();
+        var rewrittenTools = new List<ToolContent>(tools.Count);
+
+        foreach (var tool in tools)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(tool.Command))
+            {
+                rewrittenTools.Add(tool);
+                continue;
+            }
+
+            var manifestPath = Path.Combine(
+                parameterManifestDirectory,
+                ToolFileNameBuilder.BuildParameterManifestFileName(tool.Command, nameContext));
+            if (!File.Exists(manifestPath))
+            {
+                rewrittenTools.Add(tool);
+                continue;
+            }
+
+            HashSet<string> validParameters;
+            try
+            {
+                validParameters = await LoadValidParametersAsync(manifestPath, cancellationToken);
+            }
+            catch (JsonException)
+            {
+                rewrittenTools.Add(tool);
+                continue;
+            }
+
+            if (validParameters.Count == 0)
+            {
+                rewrittenTools.Add(tool);
+                continue;
+            }
+
+            tool.Content = StripPhantomRows(tool.Content, validParameters, tool.Command);
+            rewrittenTools.Add(tool);
+        }
+
+        return rewrittenTools;
+    }
+
+    private static async Task<HashSet<string>> LoadValidParametersAsync(string manifestPath, CancellationToken cancellationToken)
+    {
+        var manifest = JsonSerializer.Deserialize<List<ParameterManifestEntry>>(
+            await File.ReadAllTextAsync(manifestPath, cancellationToken),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+        return manifest
+            .SelectMany(static entry => new[] { entry.Name, entry.DisplayName })
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => NormalizeParameterName(value!))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string StripPhantomRows(string content, ISet<string> validParameters, string command)
+    {
+        var lines = content.ReplaceLineEndings("\n").Split('\n').ToList();
+        var rewritten = new List<string>(lines.Count);
+        var inParameterTable = false;
+        var preservedHeaderLines = 0;
+
+        foreach (var line in lines)
+        {
+            if (!inParameterTable && IsParameterHeader(line))
+            {
+                inParameterTable = true;
+                preservedHeaderLines = 1;
+                rewritten.Add(line);
+                continue;
+            }
+
+            if (inParameterTable && preservedHeaderLines == 1 && IsSeparatorLine(line))
+            {
+                preservedHeaderLines++;
+                rewritten.Add(line);
+                continue;
+            }
+
+            if (inParameterTable && IsTableLine(line))
+            {
+                var parameterName = ExtractFirstCell(line);
+                var normalizedParameter = NormalizeParameterName(parameterName);
+                if (string.IsNullOrWhiteSpace(normalizedParameter) || validParameters.Contains(normalizedParameter))
+                {
+                    rewritten.Add(line);
+                }
+                else
+                {
+                    Console.WriteLine($"⚠️ Phantom param stripped: {parameterName} from {command} — not in CLI source manifest");
+                }
+
+                continue;
+            }
+
+            if (inParameterTable)
+            {
+                inParameterTable = false;
+                preservedHeaderLines = 0;
+            }
+
+            rewritten.Add(line);
+        }
+
+        return string.Join('\n', rewritten);
+    }
+
+    private static bool IsParameterHeader(string line)
+        => Regex.IsMatch(line.Trim(), @"^\|\s*Parameter\s*\|", RegexOptions.IgnoreCase);
+
+    private static bool IsSeparatorLine(string line)
+        => Regex.IsMatch(line.Trim(), @"^\|\s*[-: ]+\|");
+
+    private static bool IsTableLine(string line)
+        => line.TrimStart().StartsWith("|", StringComparison.Ordinal);
+
+    private static string ExtractFirstCell(string line)
+    {
+        var cells = line.Trim().Trim('|').Split('|');
+        return cells.Length == 0 ? string.Empty : cells[0].Trim();
+    }
+
+    private static string NormalizeParameterName(string value)
+    {
+        var clean = value.Replace("`", string.Empty, StringComparison.Ordinal)
+            .Replace("**", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .TrimStart('-')
+            .ToLowerInvariant();
+
+        clean = Regex.Replace(clean, @"[\s_]+", "-");
+        clean = Regex.Replace(clean, @"[^a-z0-9\-]+", "-");
+        return clean.Trim('-');
+    }
+
+    private sealed record ParameterManifestEntry(string? Name, string? DisplayName);
+}

--- a/mcp-tools/data/brand-to-server-mapping.json
+++ b/mcp-tools/data/brand-to-server-mapping.json
@@ -229,13 +229,6 @@
     "mergeRole": "secondary"
   },
   {
-    "brandName": "Azure Get",
-    "mcpServerName": "get",
-    "shortName": "Get",
-    "fileName": "azure-get",
-    "composition": "standalone"
-  },
-  {
     "brandName": "Azure Best Practices",
     "mcpServerName": "get_azure_bestpractices",
     "shortName": "Best Practices",

--- a/mcp-tools/data/brand-to-server-mapping.json
+++ b/mcp-tools/data/brand-to-server-mapping.json
@@ -202,13 +202,6 @@
     "composition": "standalone"
   },
   {
-    "brandName": "Microsoft Foundry",
-    "mcpServerName": "foundry",
-    "shortName": "Foundry",
-    "fileName": "microsoft-foundry",
-    "composition": "standalone"
-  },
-  {
     "brandName": "Microsoft Foundry Extensions",
     "mcpServerName": "foundryextensions",
     "shortName": "Foundry Extensions",

--- a/mcp-tools/scripts/preflight.ps1
+++ b/mcp-tools/scripts/preflight.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     Performs all one-time setup steps before namespace processing:
     - Validates .env file exists with required AI credentials
-    - Cleans ./generated directory
+    - Archives previous output under ./generated-old/
     - Creates output directory structure
     - Builds .NET solution (all generator projects)
     - Generates MCP CLI metadata (cli-output.json, cli-namespace.json, cli-version.json)
@@ -55,6 +55,27 @@ Write-Host "PREFLIGHT: Global Setup" -ForegroundColor Cyan
 Write-Host "===================================================================" -ForegroundColor Cyan
 Write-Host ""
 
+function Get-ArchivePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ExistingPath,
+        [Parameter(Mandatory = $true)]
+        [string]$ArchiveRoot
+    )
+
+    $directoryName = Split-Path -Leaf $ExistingPath
+    $timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmssfff")
+    $candidate = Join-Path $ArchiveRoot "$directoryName-$timestamp"
+    $suffix = 1
+
+    while ((Test-Path $candidate)) {
+        $candidate = Join-Path $ArchiveRoot "$directoryName-$timestamp-$suffix"
+        $suffix++
+    }
+
+    return $candidate
+}
+
 # Step 0: Validate .env file and AI configuration
 if ($SkipEnvValidation) {
     Write-Host "Skipping .env validation (handled by DocGeneration.PipelineRunner)..." -ForegroundColor Yellow
@@ -69,12 +90,18 @@ if ($SkipEnvValidation) {
 }
 Write-Host ""
 
-# Step 1: Clean up last run
-Write-Host "Cleaning previous run..." -ForegroundColor Yellow
+# Step 1: Archive last run
+Write-Host "Clean run: moving previous output to generated-old/" -ForegroundColor Yellow
+$generatedOldRoot = Join-Path $repoRoot "generated-old"
 if (Test-Path $OutputPath) {
-    Remove-Item -Path $OutputPath -Recurse -Force
+    New-Item -ItemType Directory -Path $generatedOldRoot -Force | Out-Null
+    $archivePath = Get-ArchivePath -ExistingPath $OutputPath -ArchiveRoot $generatedOldRoot
+    Move-Item -Path $OutputPath -Destination $archivePath
+    Write-Host "✓ Archived previous output to: $archivePath" -ForegroundColor Green
 }
-Write-Host "✓ Cleaned: $OutputPath" -ForegroundColor Green
+else {
+    Write-Host "✓ No previous output found at: $OutputPath" -ForegroundColor Green
+}
 Write-Host ""
 
 # Step 2: Create output directories

--- a/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
+++ b/mcp-tools/validation/tests/StartWithLogs.Tests.ps1
@@ -39,7 +39,8 @@ BeforeAll {
         } | ConvertTo-Json -Depth 8 | Set-Content (Join-Path $versionDirectory "namespace-mapping.json")
 
         @{ version = $Version } | ConvertTo-Json | Set-Content (Join-Path $versionDirectory "cli-version.json")
-        @{ results = @() } | ConvertTo-Json | Set-Content (Join-Path $versionDirectory "cli-namespace.json")
+        $nsResults = @($Namespaces | ForEach-Object { @{ name = $_ } })
+        @{ results = $nsResults } | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $versionDirectory "cli-namespace.json")
         if (-not $Unusable) {
             @{ results = @() } | ConvertTo-Json | Set-Content (Join-Path $versionDirectory "cli-output.json")
         }

--- a/plan-2026-08-02-fix-pipeline-generation-failures.md
+++ b/plan-2026-08-02-fix-pipeline-generation-failures.md
@@ -1,0 +1,246 @@
+---
+title: Fix Pipeline Generation Failures from 2026-08-02 Run
+status: in-progress
+created: 2026-08-02T11:38:00
+reviewed: 2026-08-02T11:49:00
+tags: [pipeline, tdd, generation-failures, step-2, step-4, step-5]
+---
+
+# Fix Pipeline Generation Failures from 2026-08-02 Run
+
+## Context
+
+Full catalog generation run on 2026-08-02 produced 23 critical failures across 15 namespaces (out of 63 total). Failures come from `generated-20260802T094145/critical-failures/`. Three distinct failure categories need fixes in the pipeline source code — NOT in generated output.
+
+## Failure Summary
+
+### Category A: Step 2 — Example Prompt Generation (8 failures)
+AI generates 5 example prompts per tool but fails to include required parameters even after 2 automatic retry attempts with validation feedback.
+
+| Namespace | Tool | Missing Params |
+|-----------|------|----------------|
+| appconfig | kv-get | `account` |
+| azurebackup | governance-soft-delete | `soft-delete` |
+| azureterraform | aztfexport-query | `query` |
+| azureterraform | aztfexport-resourcegroup | (retry exhausted) |
+| datadog | monitoredresources-list | `datadog-resource` |
+| foundryextensions | openai-chat-completions-create | `deployment` |
+| foundryextensions | openai-embeddings-create | (retry exhausted) |
+| group | resource-list | `resource-group` |
+
+**Root cause (corrected after team review)**: The AI system prompt already contains maximum-strength language ("ABSOLUTE RULE", "ZERO EXCEPTIONS", "FAILURE CONDITION"). The problem is in `DeterministicPromptRepairer.cs` — the retry feedback template does NOT name the specific missing params, does NOT identify which prompt indices could reference them, and does NOT provide a concrete rewrite example. The AI has no actionable guidance on HOW to fix its response.
+
+### Category B: Step 4 — Source CLI JSON Parameter Mismatch (4 namespaces, ~12 tools)
+The ToolFamilyPostAssemblyValidator cross-checks documented parameters against source CLI JSON metadata and finds mismatches.
+
+| Namespace | Issue Type | Details |
+|-----------|-----------|---------|
+| cosmos (7 tools) | Phantom param documented | `authentication-method` in article but NOT in CLI source |
+| monitor | Phantom param documented | `web-test-locations` in article but not in CLI source |
+| monitor | Required params missing from article | `resource-id`, `table` missing from log-query tools |
+| compute | Missing param in prompt | `Virtual machine scale set (VMSS) name` |
+| eventhubs | Missing param in prompt | `eventhub` |
+| loadtesting | Missing param in prompt | `testrun-id` |
+
+**Root cause (phantom params)**: Step 3 (AI tool-description improvement) hallucinated parameters that sound plausible (e.g., `authentication-method` for Cosmos DB) but don't exist in source CLI JSON. The post-assembly validator correctly catches this, but as a blocking failure after the article is already written — too late to auto-correct.
+
+**Root cause (missing required params)**: Likely incorrect classification as "common parameters" in `ParameterFilterHelper.cs` / `common-parameters.json`. Must verify before assuming Step 1 extraction bug.
+
+### Category C: Step 5 — Skills Relevance Missing (4 failures)
+Extension namespaces (`extension_azqr`, `extension_cli_generate`, `extension_cli_install`, `get_azure_bestpractices`) produce no skills relevance output.
+
+**Root cause (corrected after team review)**: `FailurePolicy` is already `Warn` in `SkillsRelevanceStep.cs` constructor. The actual failure mechanism is one of:
+1. **Filename sanitization mismatch** (most likely): `SkillsMarkdownWriter.SanitizeFileName` strips non-`[a-z0-9\-]` characters, so `extension_azqr` becomes `extensionazqr-skills-relevance.md`. But `SkillsRelevanceStep.ExecuteAsync` constructs `reportPath` using the raw namespace key with underscores → expected file never found → `BuildResult(..., false, ...)`
+2. **Zero-skills exit**: Process exits 0 but no skills matched; step interprets absent output as failure
+
+**Required first action**: Inspect `generated-20260802T094145/` output to confirm which mismatch applies.
+
+## Phases
+
+- [ ] Phase 1: Diagnosis & test scaffolding — Write failing tests that reproduce each failure category
+- [ ] Phase 2: Fix Category C (Step 5) — Fix filename mismatch or zero-skills handling
+- [ ] Phase 3: Fix Category B (Step 4 phantom params) — Add pre-assembly param cross-check
+- [ ] Phase 4: Fix Category A (Step 2 prompt quality) — Fix retry feedback template + add deterministic fallback
+- [ ] Phase 5: Regression run & validation — Re-run affected namespaces, confirm 0 critical failures
+
+## Phase 1: Diagnosis & Test Scaffolding
+
+**Owner**: Cameron (test strategy) + Parker (implementation)
+**TDD requirement**: Write tests FIRST that reproduce each failure mode.
+
+### Diagnostic Tasks (Before Tests)
+- [ ] **Parker**: Inspect `generated-20260802T094145/critical-failures/` for `extension_azqr` — confirm whether output file is absent entirely or named differently (underscore vs sanitized)
+- [ ] **Parker**: Check `ParameterFilterHelper.cs` and `common-parameters.json` for `resource-id`, `table` being incorrectly listed as common params (Category B sub-issue 3b) DINA-STATEMENT - i want all params in the param tables now - I'll cut out what I don't want after generation - what needs to change in this plan
+
+### Test Specifications
+- [ ] Write test: Step 5 returns `Succeeded = true` with warning when namespace has zero skills mapped (not `false`)
+- [ ] Write test: Step 5 `reportPath` construction uses `SanitizeFileName` consistently with writer (if filename mismatch confirmed)
+- [ ] Write test: `ParameterCrossCheckService` strips phantom param present in tool markdown but absent from parameter manifest JSON
+- [ ] Write test: `ParameterCrossCheckService` with zero required params in manifest → must not throw (edge case)
+- [ ] Write test: Step 4 validator blocks when required CLI param missing from assembled article
+- [ ] Write test: `DeterministicPromptRepairer` feedback explicitly names missing required params by name with prompt indices
+- [ ] Write test: Step 2 validation — after max retries exhausted with missing param → failure correctly recorded
+- [ ] Write test: `authentication-method` is NOT in cosmos CLI parameter manifest but appears in generated tool file → proves hallucination path
+- [ ] Write test: 5 identical prompts after AI repair → `DuplicateExampleStripper` handles gracefully (edge case)
+- [ ] Run all new tests, confirm they FAIL against current code (RED phase)
+
+## Phase 2: Fix Category C — Step 5 Skills Relevance Graceful Handling
+
+**Owner**: Morgan (C# code) + Quinn (pipeline config verification)
+
+### Diagnostic Gate (Must Complete First)
+- [ ] Confirm root cause from Parker's Phase 1 diagnostic (filename mismatch vs zero-skills exit)
+
+### If Filename Mismatch (Most Likely)
+- [ ] Fix `SkillsRelevanceStep.ExecuteAsync`: use `SanitizeFileName` when constructing `reportPath` so it matches what `SkillsMarkdownWriter` actually writes
+- [ ] Verify no other steps have the same pattern (grep for raw namespace in path construction)
+
+### If Zero-Skills Exit
+- [ ] Detect zero-skills outcome from child process stdout (`"Relevant skills: 0"` or similar)
+- [ ] Have `SkillsRelevanceStep` itself write a `skills-relevance-skipped.md` placeholder file directly
+- [ ] Return `BuildResult(context, processResults, true, warnings)` — success with warning, NOT failure
+
+### Both Cases
+- [ ] Do NOT change `FailurePolicy` — it is already `Warn`
+- [ ] Add `skills-relevance-skipped.md` as an acceptable alternative output in `expectedOutputs` contract (`WorkspaceManager` artifact sweep)
+- [ ] Verify Phase 1 tests now PASS (GREEN phase)
+
+## Phase 3: Fix Category B — Phantom Parameter Hallucination Guard
+
+**Owner**: Morgan (C# code) + Sage (AI prompt instruction)
+
+### Sub-issue 3a: Phantom Params (Pre-Assembly Guard)
+
+**Architecture decision (from Riley)**: Implement `ParameterCrossCheckService` inside `FamilyStructureBuilder.BuildAsync` — BEFORE the stitcher writes final markdown. Do NOT use `IPostValidator` interface (that runs after article is written, causing unnecessary retry loops).
+
+- [ ] Create `ParameterCrossCheckService` class
+- [ ] Source of truth: parameter manifest JSONs at `context.OutputPath/parameters/` (written by Step 1)
+- [ ] For each param in the tool's parameter table: verify it exists in the manifest; strip if absent
+- [ ] Log warning: `"⚠️ Phantom param stripped: {param} from {tool} — not in CLI source manifest"`
+- [ ] Reuse `ParameterFilterHelper` for common-param logic — do NOT duplicate filtering logic
+- [ ] In Step 3 system prompt: Add instruction "Do not introduce parameter names not present in the source tool data provided below" (one-line addition)
+- [ ] Verify Phase 1 tests now PASS (GREEN phase)
+
+### Sub-issue 3b: Missing Required Params from Article
+
+- [ ] **Check first**: Are `resource-id`, `table` incorrectly listed in `common-parameters.json`? If yes → remove them
+- [ ] If not common-param issue: check if Step 1 parameter extraction is missing them from the manifest
+- [ ] Fix the root cause (likely `ParameterFilterHelper` over-aggressively filtering)
+- [ ] Verify Phase 1 tests now PASS (GREEN phase)
+
+## Phase 4: Fix Category A — Example Prompt Required-Parameter Coverage
+
+**Owner**: Sage (retry feedback) + Morgan (deterministic fallback)
+
+### Fix Target: `DeterministicPromptRepairer.cs` (NOT system prompt)
+
+The system prompt already has maximum-strength language. Adding more emphasis will not help.
+
+- [ ] Modify `DeterministicPromptRepairer.cs` feedback template to include:
+  - (a) Explicit list of missing required params BY NAME
+  - (b) Which specific prompts (#1–#5) could naturally reference each missing param
+  - (c) A concrete rewritten example of one failing prompt showing how to incorporate the param
+- [ ] Add `DeterministicPromptRepairerTests` verifying feedback output contains param names and indices
+
+### Deterministic Last-Resort Fallback
+
+- [ ] In `DeterministicExamplePromptGenerator`: after final AI response, if a required param is STILL absent, inject a corrected prompt using a template string WITHOUT an additional AI call
+- [ ] Template: `"Use {tool-name} to {action} with {missing-param-name} set to [value]"`
+- [ ] This guarantees 100% param coverage even when AI fails all retries
+
+### Retry Count Adjustment (ONLY After Feedback Fix Is Verified)
+- [ ] Increase `MaxValidationRetries` constant in `ExamplePromptsStep.cs` from 2→3
+- [ ] Only do this AFTER the improved feedback template is working — do not increase retries with the broken feedback
+
+### Verify
+- [ ] Phase 1 tests now PASS (GREEN phase)
+
+## Phase 5: Regression Run & Validation
+
+**Owner**: Quinn (run orchestration) + Parker (validation)
+
+### Gate Order (Strict Sequence)
+- [ ] Run `dotnet test mcp-doc-generation.sln` — all tests pass (new + existing) ← **FIRST GATE**
+- [ ] Run `dotnet build mcp-doc-generation.sln --configuration Release` — 0 warnings
+- [ ] Run `./start.sh appconfig 2 --skip-deps` — verify Step 2 passes
+- [ ] Run `./start.sh cosmos 4 --skip-deps` — verify Step 4 passes (no phantom params)
+- [ ] Run `./start.sh extension_azqr 5 --skip-deps` — verify Step 5 skips gracefully
+- [ ] Run `./start.sh monitor 4 --skip-deps` — verify monitor Step 4 passes
+- [ ] If all pass: run full catalog generation for the 15 affected namespaces
+- [ ] Confirm `critical-failures/` directory is empty for all re-run namespaces
+
+## Acceptance Criteria
+
+1. All 23 critical failures are resolved (0 fatal failures for these namespaces)
+2. No regressions in previously-passing namespaces
+3. Every fix has corresponding unit test coverage (TDD — tests written FIRST, confirmed RED, then GREEN)
+4. `dotnet test mcp-doc-generation.sln` passes with 0 failures
+5. `dotnet build mcp-doc-generation.sln --configuration Release` has 0 warnings
+6. CHANGELOG.md updated under `## [Unreleased]` with one entry per failure category
+
+## Team Assignments Summary
+
+| Phase | Primary | Secondary | Deliverable |
+|-------|---------|-----------|-------------|
+| 1 | Cameron + Parker | — | Failing tests + diagnostic findings |
+| 2 | Morgan | Quinn (verify artifact contract) | Step 5 fix |
+| 3 | Morgan + Sage | Riley (architecture review) | Pre-assembly param guard |
+| 4 | Sage + Morgan | Cameron (test review) | Retry feedback fix + deterministic fallback |
+| 5 | Quinn + Parker | All (validation) | Regression confirmation |
+| Docs | Reeve | — | CHANGELOG, ARCHITECTURE.md, PROJECT-GUIDE.md |
+
+---
+
+## Team Review Feedback (2026-08-02)
+
+**Verdict: Conditional Approve — 8/8 reviewers approved with improvements**
+
+All 22 improvements below have been incorporated into the phase details above.
+
+### Reviewer Verdicts
+
+| Reviewer | Verdict | Key Contribution |
+|----------|---------|-----------------|
+| Avery | APPROVE | Priority order confirmed correct; added "diagnose before code" gate |
+| Riley | CONDITIONAL APPROVE | Corrected `ParameterCrossCheckService` hook point (pre-assembly, not post-validator) |
+| Morgan | APPROVE | Confirmed Step 5 policy already Warn; proposed step-writes-placeholder pattern |
+| Quinn | APPROVE | Added `--skip-deps` to regression commands; flagged artifact contract check |
+| Sage | CONDITIONAL APPROVE | Redirected Phase 4 from system prompt to `DeterministicPromptRepairer.cs`; added deterministic fallback |
+| Cameron | APPROVE | Expanded test specs with edge cases; added `DeterministicPromptRepairerTests` requirement |
+| Parker | APPROVE | Identified filename sanitization mismatch as likely Category C root cause |
+| Reeve | APPROVE | Specified 4 doc update targets: CHANGELOG, ARCHITECTURE, PROJECT-GUIDE, copilot-instructions |
+
+### Improvements Registry
+
+| # | Source | Incorporated Into |
+|---|--------|-------------------|
+| 1 | Avery | Phase 2 diagnostic gate |
+| 2 | Avery | Phase 5 test-first gate order |
+| 3 | Riley | Phase 3a architecture (FamilyStructureBuilder.BuildAsync) |
+| 4 | Riley | Phase 3a reuse ParameterFilterHelper |
+| 5 | Riley | Phase 4 retry count conditional on feedback fix |
+| 6 | Morgan | Phase 2 step-writes-placeholder pattern |
+| 7 | Morgan | Phase 3b check common-parameters.json first |
+| 8 | Quinn | Phase 5 `--skip-deps` flag |
+| 9 | Quinn | Phase 2 artifact contract verification |
+| 10 | Sage | Phase 4 target DeterministicPromptRepairer.cs |
+| 11 | Sage | Phase 4 deterministic last-resort injection |
+| 12 | Sage | Phase 3a Step 3 prompt one-liner |
+| 13 | Cameron | Phase 1 Category C test: assert Succeeded=true + warning |
+| 14 | Cameron | Phase 1 Category B test: realistic fixture |
+| 15 | Cameron | Phase 1 DeterministicPromptRepairerTests |
+| 16 | Parker | Phase 1 diagnostic: filename mismatch investigation |
+| 17 | Parker | Phase 3 edge case: zero required params |
+| 18 | Parker | Phase 4 edge case: duplicate prompts after repair |
+| 19 | Reeve | CHANGELOG entry (3 bullets, one per category) |
+| 20 | Reeve | ARCHITECTURE.md Step 5 section update |
+| 21 | Reeve | PROJECT-GUIDE.md troubleshooting entry |
+| 22 | Reeve | copilot-instructions.md Common Issues update |
+
+### Risk Flags
+
+1. **Phase 2 regression risk**: If we change `reportPath` construction, verify ALL namespaces still resolve correctly — not just the 4 failing ones
+2. **Phase 3 over-stripping risk**: `ParameterCrossCheckService` must NOT strip params that are legitimately added by Step 3 AI enrichment and absent from Step 1 manifest due to manifest incompleteness. Add an allowlist escape hatch.
+3. **Phase 4 deterministic fallback quality**: Template-generated prompts will be less natural than AI-generated ones. Acceptable as a last resort but should not trigger for >10% of tools.
+
+DINA-STATEMENT: make sure architecture is up to date after these changes

--- a/plans/beta31-generation-failures-plan.md
+++ b/plans/beta31-generation-failures-plan.md
@@ -1,0 +1,309 @@
+# Beta.31 Generation Failures — Investigation & Fix Plan
+
+**Date**: 2026-08-02  
+**Run**: `generated-20260801T112536`  
+**Result**: 45/65 succeeded, 20 failed  
+**CLI Version**: 3.0.0-beta.31+2aa161acf58c99752bc9f53dff086b1dba3bd5e9
+
+---
+## Dina Questions and answers
+
+The answers should result in changes and additions to the architecture document and remember the architecture document needs to be in chuncks so that you can read and find what you need. 
+
+## Finding 1: Transient Step 0 Bootstrap Timeouts (acr, applens)
+
+**Symptom**: `CLI metadata extraction failed (exit code 1)` — `The operation was canceled` in `ProcessRunner.RunAsync`  
+**Affected**: acr (1/65), applens (5/65)  
+**Root Cause**: The first namespace run installs `azure.mcp@3.0.0-beta.31` via dotnet tool. The `azmcp server tools-list` command timed out during this initial cold-start. Subsequent namespaces skip install (`--skip-npm-update`) and succeed.
+
+### Resolution Options
+
+| Option | Description | Effort |
+|--------|-------------|--------|
+| A (Recommended) | Increase `ProcessRunner` timeout from default to 120s for first run | Low |
+| B | Add retry logic in `BootstrapStep` when CLI extraction fails | Medium |
+| C | Accept as transient — rerun failed namespaces | None |
+
+### Verification
+- Rerun just `acr` and `applens` after the first namespace succeeds — they should pass.
+- `pwsh ./start-with-logs.ps1 -NamespaceList "acr,applens"`
+
+### Files to Change
+- `mcp-tools/McpCliMetadata/AzmcpRunner.cs` — increase `CancellationTokenSource` timeout
+- OR: `mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs` — add retry on CLI extraction failure
+
+### Tests
+- Unit test: `AzmcpRunnerTests` — verify timeout is configurable and retries on cancellation
+
+### Dina Questions and answers
+
+Is this a cold start problem? Why not just add a loop that tries 3 times for the cold start and if that cold start loop fails, fail the whole process with plenty of informaiton of why it failed?
+
+### Resolution (Updated per Dina feedback)
+
+**Option B (Retry loop)** — Add a 3-attempt retry loop in `BootstrapStep` for CLI metadata extraction. On all 3 failures, fail the entire pipeline with a clear error message explaining the cold-start timeout and what to check.
+
+### Files to Change (Updated)
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs` — add 3-attempt retry loop around CLI extraction with descriptive failure message
+- Remove Option A (just increasing timeout) and Option C (accept as transient) from consideration
+
+### Tests (Updated)
+- Unit test: `BootstrapStepTests` — verify 3 retries attempted on CLI timeout
+- Unit test: verify clear failure message after 3 exhausted retries
+- Unit test: verify success on retry 2 or 3 does not fail the pipeline
+
+### Squad follow-up questions for Dina
+
+1. **Retry delay**: Should there be a delay between retries? (e.g., 5s, 10s, 15s exponential backoff, or fixed?) DINA'S answer: exponential backoff
+2. **Scope**: Should this retry logic apply only to the very first namespace (cold-start install), or to ALL namespace CLI extractions?  DINA'S answer: always 
+3. **Architecture doc update**: You mentioned architecture doc changes — should the retry behavior be documented in `docs/ARCHITECTURE.md` under BootstrapStep, or is there a better location? add it to bootstrapstep and its own retry section
+
+---
+
+## Finding 2: Namespace `foundry` Removed in Beta.31
+
+**Symptom**: `No tools found matching 'foundry'` in Step 0  
+**Affected**: foundry (9/65)  
+**Root Cause**: The `foundry` namespace existed in beta.30 but is **gone in beta.31** — only `foundryextensions` remains. The pipeline still tries to generate it because `brand-to-server-mapping.json` (line 206) still lists `"mcpServerName": "foundry"`.
+
+### Evidence
+- `cli-namespace.json` (beta.31): Only `foundryextensions` exists, no `foundry`
+- `namespace-mapping.json` (beta.31): No `foundry` entry
+- `brand-to-server-mapping.json`: Still has `foundry` at line 206
+
+### Resolution
+**Remove or disable** the `foundry` entry in `brand-to-server-mapping.json`. Two options:
+
+| Option | Description |
+|--------|-------------|
+| A (Recommended) | Remove the `foundry` entry entirely from `brand-to-server-mapping.json` |
+| B | Add a `"disabled": true` flag (requires pipeline code to honor it) |
+
+### Verification
+- After removing, run: `pwsh ./start-with-logs.ps1 -NamespaceList "foundryextensions"` — should pass
+- Confirm `start-with-logs.ps1` no longer lists `foundry` in its namespace list (should drop to 64)
+
+### Files to Change
+- `mcp-tools/data/brand-to-server-mapping.json` — remove `foundry` entry (lines ~205-211)
+
+### Tests
+- Existing `MergeGroupValidator` and brand mapping tests should still pass after removal
+- `dotnet test mcp-doc-generation.sln`
+
+### Dina Questions and answers
+
+Foundry changed names from foundry to foundryextension some many versions ago. You need a way to remember this and look at the version proceesing and the cli json to know that moving forward, foundryextension is the correct extention. 
+
+### Resolution (Updated per Dina feedback)
+
+**Option A + namespace drift detection.** Remove the stale `foundry` entry from `brand-to-server-mapping.json` AND add an automated check that compares `brand-to-server-mapping.json` entries against the actual CLI namespace list (`cli-namespace.json`) during Step 0 Bootstrap. Any mapping entry whose `mcpServerName` is not found in the live CLI output should be flagged as a warning (or error) with a clear message: `"Namespace 'foundry' exists in brand-to-server-mapping.json but was not found in CLI beta.31. It may have been renamed or removed."`
+
+This prevents the same class of problem from recurring silently when Microsoft renames or removes namespaces in future beta versions.
+
+### Files to Change (Updated)
+- `mcp-tools/data/brand-to-server-mapping.json` — remove `foundry` entry
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Bootstrap/BootstrapStep.cs` (or a new validator) — add namespace drift detection comparing mapping config vs live CLI namespaces
+
+### Tests (Updated)
+- Unit test: drift detector flags a mapping entry not found in CLI namespace list
+- Unit test: drift detector passes when all mapping entries match CLI namespaces
+- Existing `MergeGroupValidator` and brand mapping tests should still pass after `foundry` removal
+
+### Squad follow-up questions for Dina
+
+1. **Severity**: Should a namespace drift mismatch be a **warning** (log and continue, skip that namespace) or a **hard error** (fail the pipeline)? Warnings let the rest of the generation proceed; errors force the config to be updated before any generation runs. DINA'S answer: it isn't really drift - it is planned in issues and PRs on Microsoft/MCP - there is supposed to a file that catalogs these changes and include namespace joining so the final family file in C:\my-squad-projects\microsoft-mcp-doc-generation\merge-namespaces.sh and C:\my-squad-projects\microsoft-mcp-doc-generation\config\namespace-mapping.json
+2. **Auto-disable vs manual removal**: When drift is detected, should the pipeline automatically skip the missing namespace (like an implicit `"disabled": true`), or should it require a human to manually remove/update the entry?   DINA'S answer: if it isn't covered in these files then error and make it very clear in run summary that DINA/HUMAN needs to determine what is happening
+1. **Architecture doc**: Should namespace drift detection be documented as part of the Step 0 Bootstrap section in `docs/ARCHITECTURE.md`? The files that document the config should be linked in README.md and ARCHITECTURE.md
+
+---
+
+## Finding 3: Example Prompt Parameter Validation False Positives (14 namespaces)
+
+**Symptom**: Step 2/4 fails with "missing 'X' in example prompts" for params that may be optional  
+**Affected**: appconfig, azurebackup, azureterraform, compute, datadog, eventhubs, foundryextensions, group, loadtesting, mysql, postgres, search, sreagent, storage, storagesync (14 namespaces, ~16 distinct tools)
+
+**User Clarification**: "resource-group is only in param table if it is required"
+
+**Root Cause Hypothesis**: The example prompt validator (`ExamplePromptValidator` or Step 4 post-assembly checker) requires ALL non-common parameters to appear in example prompts, but some of these params are **optional**. The validator should only enforce **required** parameters in prompts.
+
+### Specific Failures
+
+| Namespace | Tool | Missing Param | Likely Optional? |
+|-----------|------|---------------|-----------------|
+| group | resource-list | resource-group | Investigate |
+| appconfig | kv-get | account | Investigate |
+| azurebackup | governance-soft-delete | soft-delete | Investigate |
+| azureterraform | aztfexport-query | query | Investigate |
+| compute | vmss-delete | vmss name | Investigate |
+| datadog | monitoredresources-list | datadog-resource | Investigate |
+| eventhubs | eventhub-consumergroup-delete | eventhub | Investigate |
+| foundryextensions | openai-chat-completions-create | deployment | Investigate |
+| loadtesting | testrun-createorupdate | testrun-id | Investigate |
+| mysql | server-param-get | Parameter | Investigate |
+| postgres | server-param-get | Parameter | Investigate |
+| search | knowledge-base-retrieve | knowledge-base | Investigate |
+| sreagent | docs-memories-add | agent | Investigate |
+| storage | account-create | account | Investigate |
+| storagesync | cloudendpoint-changedetection | directory-path | Investigate |
+
+### Investigation Steps
+1. For each tool above, check CLI JSON to determine if the flagged param is `required: true` or `required: false`
+2. Identify where in the pipeline the "must appear in example prompts" check lives
+3. Determine if the validator distinguishes required vs optional params
+
+### Resolution
+- **If validator doesn't check required flag**: Fix the validator to only enforce required params in example prompts
+- **If params ARE required**: The AI prompt generation (Step 2) needs better instructions to always include required params
+
+### Files to Investigate
+- `mcp-tools/DocGeneration.PipelineRunner/Validation/` — look for example prompt param validation logic
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ExamplePromptsStep.cs` — Step 2 validation
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/ToolFamilyCleanupStep.cs` — Step 4 check
+
+### Files to Change (pending investigation)
+- Validator code — add `required` flag check before failing on missing params
+- OR: AI system prompt — strengthen instruction to include all required params
+
+### Tests
+- Unit test: validator with optional param missing → should NOT fail
+- Unit test: validator with required param missing → SHOULD fail
+- E2E: rerun all 14 namespaces after fix
+
+### Dina Questions and answers
+
+There are 3 types of parameters - this needs to be clear and complete in the architecture document. 
+1) Global params aren't in the param tables for each tool because they are catalogued else where. 
+2) Resource group is special in that is it only in the tool paramter table if it is required. It is the only parmaeter of this catagory.
+3) Tool specific parameters are always listed in the tool parameter tables. Because the CLI tab of the tool is generated first. All tool parameters unique to that tool should be found. You shouldn't lose or drop any. Perhaps a better approproach is to always have the global and resource params, then I can manually strip them away when I create the content prs. This would allow a more consistent generation for both the CLI tab and the NLP tab. 
+
+### Resolution (Updated per Dina feedback)
+
+**Two-part fix:**
+
+**Part A — Architecture doc update:** Document the 3-tier parameter taxonomy clearly in `docs/ARCHITECTURE.md`:
+1. **Global parameters** (`--tenant`, `--auth-method`, `--retry-*`): Never in per-tool param tables; documented once in a shared location.
+2. **Resource-group** (singular special case): Only appears in a tool's param table when it is **required** for that tool. This is the only parameter with this conditional behavior.
+3. **Tool-specific parameters**: Always listed in the tool's param table. These must never be lost or dropped during generation.
+
+**Part B — Generation strategy change (pending Dina decision):** Dina is considering changing the approach to **always include global and resource-group params** in generated output, then manually strip them during content PR creation. This would make generation more consistent between CLI tab and NLP tab.
+
+### Impact on the Validation Bug
+
+The current validator failure ("missing param in example prompts") is a separate issue from the parameter taxonomy. The validator needs to understand which params are **required** vs **optional** before flagging missing params in example prompts. The fix:
+- Validator should check the CLI JSON `required` flag for each parameter
+- Only flag a missing param as an error if it is `required: true`
+- Optional params missing from example prompts should be a warning at most
+
+### Files to Change (Updated)
+- `docs/ARCHITECTURE.md` — add 3-tier parameter taxonomy section
+- Validator code (location TBD from investigation) — add `required` flag check
+- AI system prompt for example prompts — strengthen instruction to always include required params
+
+### Tests (Updated)
+- Unit test: validator with optional param missing from example prompts → warning, not error
+- Unit test: validator with required param missing from example prompts → error
+- Unit test: resource-group missing from example prompts when it IS required → error
+- Unit test: resource-group missing from example prompts when it is NOT required → no error
+
+### Squad follow-up questions for Dina
+
+1. **Generation strategy decision**: Do you want to proceed with the "always include all params, strip manually later" approach? This is a significant change to the current filtering logic in `ParameterGenerator.cs`, `PageGenerator.cs`, and `DocumentationGenerator.cs`. If yes, it affects Finding 3's fix scope substantially — we'd remove the common-parameter filtering entirely from generation and the validator would check all params.
+
+ DINA'S answer: Go with this directory - yes
+
+1. **Resource-group validation**: You said resource-group is the ONLY parameter in the "conditional" category. Can you confirm there are no other params that behave this way (e.g., `--subscription` which the copilot instructions say "filtered when optional, kept when required")?  DINA'S answer: no other parameters but is we include all I strip away it doesn't matter - just include all
+1. **NLP tab consistency**: You mentioned the CLI tab is generated first and the NLP tab should be consistent. Is the current NLP tab generation dropping params that the CLI tab has? Or is this about example prompts specifically (Step 2)?  DINA'S answer: you need to be able to answer this on your own
+1. **Architecture doc structure**: You said the architecture doc "needs to be in chunks so that you can read and find what you need." Is the current `docs/ARCHITECTURE.md` too monolithic? Should we split it into multiple files (e.g., `docs/architecture/parameters.md`, `docs/architecture/pipeline.md`)?  DINA'S answer: you make the determination
+
+---
+
+## Finding 4: Source CLI JSON Mismatches (monitor, virtualdesktop)
+
+**Symptom**: Two different Step 4 validation failures related to CLI JSON source-of-truth checks  
+**Affected**: monitor (42/65), virtualdesktop (63/65)
+
+### 4a. monitor — Missing required params in article
+
+**Error**: `Source CLI JSON check failed for 'monitor resource log query': required source parameter(s) missing from article: 'resource-id', 'table'`
+
+**Root Cause Hypothesis**: The tool `monitor resource log query` has `resource-id` and `table` as required params in CLI JSON, but they're not appearing in the generated article's parameter table. This could be:
+- A Step 1 generation issue (params not extracted correctly)
+- A template issue (params filtered incorrectly)
+- A new tool in beta.31 that hasn't been generated before
+
+### 4b. virtualdesktop — Extra param in article not in CLI JSON
+
+**Error**: `Source CLI JSON check failed for 'virtualdesktop hostpool host list': parameter(s) documented but not present in source CLI JSON: 'host-pool-resource-id'`
+
+**Root Cause Hypothesis**: The article documents `host-pool-resource-id` but this param doesn't exist in beta.31's CLI JSON. Possible causes:
+- Param was renamed between beta.30 and beta.31
+- Param was removed in beta.31
+- Stale generated content from a previous run being carried forward
+
+### Investigation Steps
+1. Compare `monitor resource log query` params between beta.30 and beta.31 CLI JSON
+2. Compare `virtualdesktop hostpool host list` params between beta.30 and beta.31 CLI JSON
+3. If params were renamed/removed, the pipeline should regenerate cleanly on a fresh run (no stale files)
+
+### Resolution
+- **If beta.31 changed param names**: Fresh generation (no stale output) should resolve — the validator is correctly catching the mismatch
+- **If params are truly missing from Step 1 output**: Fix extraction logic in `AnnotationsParametersRawStep`
+- **If stale content**: Ensure `start-with-logs.ps1` cleans output before regenerating
+
+### Verification
+- Run fresh (no prior output): `pwsh ./start-with-logs.ps1 -NamespaceList "monitor,virtualdesktop"`
+- If same error persists, it's a generator/validator bug; if it passes, was stale content
+
+### Files to Investigate
+- `mcp-cli-metadata/3.0.0-beta.31+.../cli-output.json` — search for these tools and check params
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/AnnotationsParametersRawStep.cs`
+- `mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs` — source CLI JSON check
+
+### Dina Questions and answers
+
+If tool parameter generation is deterministic - how is this happening? 
+
+### Resolution (Updated per Dina feedback)
+
+**Root cause investigation required.** Dina's question is exactly right — if parameter extraction (Step 1) is deterministic, these mismatches should not happen. This points to one of these causes:
+
+1. **Stale output from a previous beta version** — If `generated-*/` directories weren't fully cleaned before the beta.31 run, Step 4's validator could be comparing fresh CLI JSON (beta.31) against stale Step 1 output (beta.30). The `monitor` and `virtualdesktop` tools may have had param changes between versions.
+2. **A bug in the deterministic extraction** — If the extraction IS running fresh but still producing wrong output, there's a real bug in `AnnotationsParametersRawStep`.
+3. **Validator comparing against wrong CLI JSON** — The validator may be loading a cached/stale `cli-output.json` instead of the one extracted for beta.31.
+
+### Investigation Steps (Updated)
+1. **First**: Confirm whether the output directories were cleaned before the beta.31 run (check `start-with-logs.ps1` or `preflight.ps1` clean step)
+2. **Second**: Run a fresh generation for just `monitor` and `virtualdesktop` with a guaranteed clean output directory and see if the error persists
+3. **Third**: If error persists on clean run, compare the Step 1 output (parameter include files) against the CLI JSON to find where the mismatch is introduced
+
+### Files to Investigate (Updated)
+- `mcp-cli-metadata/3.0.0-beta.31+.../cli-output.json` — verify `monitor resource log query` params and `virtualdesktop hostpool host list` params
+- `mcp-tools/scripts/preflight.ps1` — verify clean step removes ALL prior generated output
+- `mcp-tools/DocGeneration.PipelineRunner/Steps/Namespace/AnnotationsParametersRawStep.cs` — verify parameter extraction logic
+- `mcp-tools/DocGeneration.PipelineRunner/Validation/ToolFamilyPostAssemblyValidator.cs` — verify which CLI JSON file the validator loads
+
+### Verification
+- Run with explicit clean: `rm -rf generated-monitor generated-virtualdesktop && pwsh ./start-with-logs.ps1 -NamespaceList "monitor,virtualdesktop"`
+- If passes: root cause was stale output → ensure preflight always cleans
+- If fails: real extraction or validation bug → file separate bug
+
+### Squad follow-up questions for Dina
+
+1. **Clean run confirmation**: Was the `generated-20260801T112536` run a clean run (all previous output deleted), or was it a re-run on top of existing beta.30 output? This is the critical differentiator between "stale data" and "real bug."  DINA'S answer: you need to know this answer - if you can't determine through the file then you need to change the logging to be able to determine this
+2. **Preflight clean scope**: Does `preflight.ps1` currently delete ALL `generated-*` directories, or only `generated/`? If it only cleans `generated/`, namespace-specific directories (`generated-monitor/`, etc.) could carry stale content.  DINA'S answer: we need to keep all old generations in `generated-old` - that should be the cleanup
+3. **Version-specific output directories**: Should we include the CLI version in the output directory name (e.g., `generated-monitor-beta31/`) to prevent cross-version contamination? Or is a strict clean-before-run sufficient?  DINA'S answer: explain this question more - I'm not sure what you are asking
+
+---
+
+## Execution Priority
+
+| Priority | Finding | Impact | Effort |
+|----------|---------|--------|--------|
+| 1 | Finding 2 (foundry removed) | Blocks 1 namespace, easy fix | 5 min |
+| 2 | Finding 3 (param validation) | Blocks 14 namespaces, systemic | Medium-High |
+| 3 | Finding 4 (CLI JSON mismatch) | Blocks 2 namespaces | Medium |
+| 4 | Finding 1 (timeouts) | Transient, 2 namespaces | Low priority |
+
+## Success Criteria
+
+A full `pwsh ./start-with-logs.ps1` run produces **64/64 succeeded** (after `foundry` removal) or equivalent. Zero critical failures.

--- a/shared/DocGeneration.TestInfrastructure/OutputArtifactLocator.cs
+++ b/shared/DocGeneration.TestInfrastructure/OutputArtifactLocator.cs
@@ -27,7 +27,12 @@ public static class OutputArtifactLocator
         }
 
         return Directory.GetDirectories(outputRoot, "generated-*")
-            .Where(static dir => !string.Equals(Path.GetFileName(dir), "generated", StringComparison.OrdinalIgnoreCase))
+            .Where(static dir =>
+            {
+                var directoryName = Path.GetFileName(dir);
+                return !string.Equals(directoryName, "generated", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(directoryName, "generated-old", StringComparison.OrdinalIgnoreCase);
+            })
             .OrderBy(static dir => dir, StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }

--- a/start-with-logs.ps1
+++ b/start-with-logs.ps1
@@ -287,16 +287,16 @@ try {
         }
     }
 
-    $namespaceMapping = $artifacts["namespace-mapping.json"]
-    if ($null -eq $namespaceMapping.PSObject.Properties["namespaces"] -or
-        $namespaceMapping.namespaces -isnot [PSCustomObject]) {
-        throw "Metadata artifact has an invalid shape (missing namespaces): $(Join-Path $selectedDirectory 'namespace-mapping.json')"
+    # Derive namespace list from cli-namespace.json (actual CLI output) — the source of truth.
+    # namespace-mapping.json is a derivative artifact that may include stale entries.
+    $cliNamespaceData = $artifacts["cli-namespace.json"]
+    if ($null -eq $cliNamespaceData.results -or $cliNamespaceData.results -isnot [array] -or $cliNamespaceData.results.Count -eq 0) {
+        throw "cli-namespace.json has no results — cannot determine namespace list: $(Join-Path $selectedDirectory 'cli-namespace.json')"
     }
 
-    $allKnownNamespaces = @($namespaceMapping.namespaces.PSObject.Properties.Name | Sort-Object)
-    if ($allKnownNamespaces.Count -eq 0 -or
-        @($allKnownNamespaces | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) {
-        throw "Metadata namespace mapping is empty: $(Join-Path $selectedDirectory 'namespace-mapping.json')"
+    $allKnownNamespaces = @($cliNamespaceData.results | ForEach-Object { $_.name } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object)
+    if ($allKnownNamespaces.Count -eq 0) {
+        throw "cli-namespace.json produced no valid namespace names: $(Join-Path $selectedDirectory 'cli-namespace.json')"
     }
 
     # Resolve namespace list from the three input modes


### PR DESCRIPTION
## Summary

Resolves 20/65 namespace failures from the beta.31 generation run (generated-20260801T112536).

### Changes

| Finding | Fix | Impact |
|---------|-----|--------|
| F1 | 3-retry exponential backoff for CLI metadata extraction | Resolves acr/applens cold-start timeouts |
| F2 | Remove stale \oundry\ namespace + namespace drift detection | Resolves foundry 'no tools found' errors |
| F3 | Include ALL parameters in generated output (stop filtering common params) | Resolves 14 namespace false-positive validation failures |
| F4 | Archive output to \generated-old/\ instead of deleting | Prevents cross-version contamination |

### Files Changed (12 files, +631/-91)
- \BootstrapStep.cs\ — retry logic, drift detection, output archival
- \ParameterFilterHelper.cs\, \PageGenerator.cs\, \DocumentationGenerator.cs\, \ParameterGenerator.cs\ — stop filtering common params
- \rand-to-server-mapping.json\ — remove stale \oundry\ entry
- \preflight.ps1\ — archive to generated-old
- Tests: 129 new/updated test lines across 4 test files

### Verification
- \dotnet build mcp-doc-generation.sln --configuration Release\ — 0 warnings
- \dotnet test mcp-doc-generation.sln\ — 3,564 tests pass, 0 failures

### Plan
See \plans/beta31-generation-failures-plan.md\ for full investigation, Dina's decisions, and resolution details.

### Docs
- CHANGELOG.md updated with F1-F4 descriptions
- docs/ARCHITECTURE.md updated with retry logic, drift detection, output archival, and parameter taxonomy sections