### PR TITLE
Fix: Remove stale inventory entries for #773 and #774

### DIFF
--- a/skills-generation/SkillsGen.Core.Tests/Unit/Orchestration/SkillInventoryLoaderTests.cs
+++ b/skills-generation/SkillsGen.Core.Tests/Unit/Orchestration/SkillInventoryLoaderTests.cs
@@ -92,4 +92,61 @@ public class SkillInventoryLoaderTests
 
         result.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Load_RealInventoryFile_DoesNotContainAzureRbac()
+    {
+        // Issue #773: azure-rbac does not exist in skills-source/skills/ and must be removed from inventory
+        var loader = new SkillInventoryLoader(_logger);
+        var inventoryPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "data", "skills-inventory.json"));
+
+        // Skip if file not found (CI environment without the data directory)
+        if (!File.Exists(inventoryPath)) return;
+
+        var result = loader.Load(inventoryPath);
+
+        result.Should().NotContain(
+            e => e.Name == "azure-rbac",
+            "issue #773 requires azure-rbac to be removed from inventory as it does not exist upstream in skills-source/skills/");
+    }
+
+    [Fact]
+    public void Load_RealInventoryFile_DoesNotContainAzureHostedCopilotSdk()
+    {
+        // Issue #774: azure-hosted-copilot-sdk does not exist in skills-source/skills/ and must be removed from inventory
+        var loader = new SkillInventoryLoader(_logger);
+        var inventoryPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "data", "skills-inventory.json"));
+
+        // Skip if file not found (CI environment without the data directory)
+        if (!File.Exists(inventoryPath)) return;
+
+        var result = loader.Load(inventoryPath);
+
+        result.Should().NotContain(
+            e => e.Name == "azure-hosted-copilot-sdk",
+            "issue #774 requires azure-hosted-copilot-sdk to be removed from inventory as it does not exist upstream in skills-source/skills/");
+    }
+
+    [Fact]
+    public void Load_RealInventoryFile_RetainsValidEntries()
+    {
+        // Guard: ensure we didn't accidentally remove valid entries when fixing #773 and #774
+        var loader = new SkillInventoryLoader(_logger);
+        var inventoryPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "data", "skills-inventory.json"));
+
+        // Skip if file not found (CI environment without the data directory)
+        if (!File.Exists(inventoryPath)) return;
+
+        var result = loader.Load(inventoryPath);
+
+        // Verify a representative sample of valid entries still exist
+        result.Should().Contain(e => e.Name == "azure-storage", "azure-storage is a valid upstream skill");
+        result.Should().Contain(e => e.Name == "azure-compute", "azure-compute is a valid upstream skill");
+        result.Should().Contain(e => e.Name == "azure-compliance", "azure-compliance is a valid upstream skill");
+        result.Should().Contain(e => e.Name == "azure-ai", "azure-ai is a valid upstream skill");
+        result.Should().Contain(e => e.Name == "microsoft-foundry", "microsoft-foundry is a valid upstream skill");
+    }
 }

--- a/skills-generation/data/skills-inventory.json
+++ b/skills-generation/data/skills-inventory.json
@@ -1,31 +1,133 @@
 {
   "skills": [
-    { "name": "azure-ai", "displayName": "Azure AI Services", "category": "AI and Machine Learning" },
-    { "name": "azure-aigateway", "slug": "azure-ai-gateway", "displayName": "Azure AI Gateway", "category": "AI and Machine Learning" },
-    { "name": "azure-hosted-copilot-sdk", "displayName": "Azure Hosted Copilot SDK", "category": "AI and Machine Learning" },
-    { "name": "microsoft-foundry", "displayName": "Microsoft Foundry", "category": "AI and Machine Learning" },
-    { "name": "azure-kusto", "displayName": "Azure Kusto (Data Explorer)", "category": "Data and Storage" },
-    { "name": "azure-messaging", "displayName": "Azure Messaging", "category": "Data and Storage" },
-    { "name": "azure-storage", "displayName": "Azure Storage", "category": "Data and Storage" },
-    { "name": "azure-deploy", "displayName": "Azure Deploy", "category": "Development Lifecycle" },
-    { "name": "azure-app-onboard", "displayName": "Azure App Onboard", "category": "Development Lifecycle" },
-    { "name": "azure-app-onboard-prereq", "displayName": "Azure App Onboard Prereq", "category": "Development Lifecycle" },
-    { "name": "azure-prepare", "displayName": "Azure Prepare", "category": "Development Lifecycle" },
-    { "name": "azure-upgrade", "displayName": "Azure Upgrade", "category": "Development Lifecycle", "skillVersion": "1.0.0" },
-    { "name": "azure-validate", "displayName": "Azure Validate", "category": "Development Lifecycle" },
-    { "name": "airunway-aks-setup", "displayName": "AIRunway AKS Setup", "category": "Infrastructure and Compute" },
-    { "name": "azure-compute", "displayName": "Azure Compute", "category": "Infrastructure and Compute" },
-    { "name": "azure-enterprise-infra-planner", "displayName": "Azure Enterprise Infrastructure Planner", "category": "Infrastructure and Compute" },
-    { "name": "azure-kubernetes", "displayName": "Azure Kubernetes", "category": "Infrastructure and Compute" },
-    { "name": "azure-cloud-migrate", "displayName": "Azure Cloud Migration", "category": "Migration", "skillVersion": "1.0.2" },
-    { "name": "appinsights-instrumentation", "slug": "app-insights-instrumentation", "displayName": "App Insights Instrumentation", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-cost", "displayName": "Azure Cost Optimization", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-diagnostics", "displayName": "Azure Diagnostics", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-quotas", "displayName": "Azure Quotas", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-resource-lookup", "displayName": "Azure Resource Lookup", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-resource-visualizer", "displayName": "Azure Resource Visualizer", "category": "Monitoring and Diagnostics" },
-    { "name": "azure-compliance", "displayName": "Azure Compliance", "category": "Security and Compliance" },
-    { "name": "azure-rbac", "displayName": "Azure RBAC", "category": "Security and Compliance" },
-    { "name": "entra-app-registration", "displayName": "Entra App Registration", "category": "Security and Compliance" }
+    {
+      "name": "azure-ai",
+      "displayName": "Azure AI Services",
+      "category": "AI and Machine Learning"
+    },
+    {
+      "name": "azure-aigateway",
+      "slug": "azure-ai-gateway",
+      "displayName": "Azure AI Gateway",
+      "category": "AI and Machine Learning"
+    },
+    {
+      "name": "microsoft-foundry",
+      "displayName": "Microsoft Foundry",
+      "category": "AI and Machine Learning"
+    },
+    {
+      "name": "azure-kusto",
+      "displayName": "Azure Kusto (Data Explorer)",
+      "category": "Data and Storage"
+    },
+    {
+      "name": "azure-messaging",
+      "displayName": "Azure Messaging",
+      "category": "Data and Storage"
+    },
+    {
+      "name": "azure-storage",
+      "displayName": "Azure Storage",
+      "category": "Data and Storage"
+    },
+    {
+      "name": "azure-deploy",
+      "displayName": "Azure Deploy",
+      "category": "Development Lifecycle"
+    },
+    {
+      "name": "azure-app-onboard",
+      "displayName": "Azure App Onboard",
+      "category": "Development Lifecycle"
+    },
+    {
+      "name": "azure-app-onboard-prereq",
+      "displayName": "Azure App Onboard Prereq",
+      "category": "Development Lifecycle"
+    },
+    {
+      "name": "azure-prepare",
+      "displayName": "Azure Prepare",
+      "category": "Development Lifecycle"
+    },
+    {
+      "name": "azure-upgrade",
+      "displayName": "Azure Upgrade",
+      "category": "Development Lifecycle",
+      "skillVersion": "1.0.0"
+    },
+    {
+      "name": "azure-validate",
+      "displayName": "Azure Validate",
+      "category": "Development Lifecycle"
+    },
+    {
+      "name": "airunway-aks-setup",
+      "displayName": "AIRunway AKS Setup",
+      "category": "Infrastructure and Compute"
+    },
+    {
+      "name": "azure-compute",
+      "displayName": "Azure Compute",
+      "category": "Infrastructure and Compute"
+    },
+    {
+      "name": "azure-enterprise-infra-planner",
+      "displayName": "Azure Enterprise Infrastructure Planner",
+      "category": "Infrastructure and Compute"
+    },
+    {
+      "name": "azure-kubernetes",
+      "displayName": "Azure Kubernetes",
+      "category": "Infrastructure and Compute"
+    },
+    {
+      "name": "azure-cloud-migrate",
+      "displayName": "Azure Cloud Migration",
+      "category": "Migration",
+      "skillVersion": "1.0.2"
+    },
+    {
+      "name": "appinsights-instrumentation",
+      "slug": "app-insights-instrumentation",
+      "displayName": "App Insights Instrumentation",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-cost",
+      "displayName": "Azure Cost Optimization",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-diagnostics",
+      "displayName": "Azure Diagnostics",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-quotas",
+      "displayName": "Azure Quotas",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-resource-lookup",
+      "displayName": "Azure Resource Lookup",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-resource-visualizer",
+      "displayName": "Azure Resource Visualizer",
+      "category": "Monitoring and Diagnostics"
+    },
+    {
+      "name": "azure-compliance",
+      "displayName": "Azure Compliance",
+      "category": "Security and Compliance"
+    },
+    {
+      "name": "entra-app-registration",
+      "displayName": "Entra App Registration",
+      "category": "Security and Compliance"
+    }
   ]
 }


### PR DESCRIPTION
## Problem

`skills-inventory.json` lists 2 skills that no longer exist upstream — every full run fails for them (issues #773, #774):
- `azure-rbac`
- `azure-hosted-copilot-sdk`

## Fix

1. Removed both stale entries from `skills-generation/data/skills-inventory.json` (27 → 25 entries)
2. Added 3 regression tests to prevent recurrence

## Files changed

| File | Change |
|------|--------|
| `skills-generation/data/skills-inventory.json` | Remove 2 stale entries |
| `skills-generation/.../SkillInventoryLoaderTests.cs` | 3 new regression tests |

## Tests

All 555 tests pass (552 existing + 3 new).

Fixes #773, Fixes #774